### PR TITLE
RFC-0016/0017: 对齐 Vercel AI SDK 缺口分析 + provider 配置 DX 设计

### DIFF
--- a/aimux-core/bindings/CallOptions.ts
+++ b/aimux-core/bindings/CallOptions.ts
@@ -74,4 +74,15 @@ provider_options: { [key in string]: JsonValue } | null,
  * Top-level reasoning effort. Maps to OpenAI `reasoning_effort` and
  * Anthropic `thinking` config.
  */
-reasoning: ReasoningEffort | null, };
+reasoning: ReasoningEffort | null, 
+/**
+ * Per-call request body overrides. Deep-merged into the provider-built
+ * request body (after any built-in vendor override) before sending.
+ * `null` values delete the corresponding key. See RFC-0017.
+ */
+body_overrides: JsonValue | null, 
+/**
+ * Per-call retry count override. `None` uses the provider's configured
+ * `RetryConfig.max_retries`. `Some(0)` disables retries.
+ */
+max_retries: number | null, };

--- a/aimux-core/bindings/GenerateTextOptions.ts
+++ b/aimux-core/bindings/GenerateTextOptions.ts
@@ -19,4 +19,12 @@ reasoning: ReasoningEffort | null,
 /**
  * System instructions prepended to the prompt.
  */
-instructions: string | null, };
+instructions: string | null, 
+/**
+ * Per-call request body overrides (deep-merged). See RFC-0017.
+ */
+body_overrides: JsonValue | null, 
+/**
+ * Per-call retry count override. `None` = provider default, `Some(0)` = disable.
+ */
+max_retries: number | null, };

--- a/aimux-core/src/generate.rs
+++ b/aimux-core/src/generate.rs
@@ -52,6 +52,10 @@ pub struct GenerateTextOptions {
     pub reasoning: Option<ReasoningEffort>,
     /// System instructions prepended to the prompt.
     pub instructions: Option<String>,
+    /// Per-call request body overrides (deep-merged). See RFC-0017.
+    pub body_overrides: Option<Value>,
+    /// Per-call retry count override. `None` = provider default, `Some(0)` = disable.
+    pub max_retries: Option<u32>,
 }
 
 impl GenerateTextOptions {
@@ -76,6 +80,8 @@ impl GenerateTextOptions {
             headers: self.headers,
             provider_options: self.provider_options,
             reasoning: self.reasoning,
+            body_overrides: self.body_overrides,
+            max_retries: self.max_retries,
         }
     }
 }

--- a/aimux-core/src/options.rs
+++ b/aimux-core/src/options.rs
@@ -31,7 +31,7 @@ pub enum ResponseFormat {
 /// This is the **provider-facing** options struct. Users interact with
 /// `GenerateTextOptions` (user-facing) which is converted to `CallOptions`
 /// by the `generate_text` / `stream_text` functions.
-#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct CallOptions {
     /// The standardized prompt (message array). Required.
@@ -79,6 +79,15 @@ pub struct CallOptions {
     /// Top-level reasoning effort. Maps to OpenAI `reasoning_effort` and
     /// Anthropic `thinking` config.
     pub reasoning: Option<ReasoningEffort>,
+
+    /// Per-call request body overrides. Deep-merged into the provider-built
+    /// request body (after any built-in vendor override) before sending.
+    /// `null` values delete the corresponding key. See RFC-0017.
+    pub body_overrides: Option<Value>,
+
+    /// Per-call retry count override. `None` uses the provider's configured
+    /// `RetryConfig.max_retries`. `Some(0)` disables retries.
+    pub max_retries: Option<u32>,
 }
 
 impl CallOptions {
@@ -106,6 +115,8 @@ impl CallOptions {
             headers: None,
             provider_options: None,
             reasoning: None,
+            body_overrides: None,
+            max_retries: None,
         }
     }
 }

--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -1534,6 +1534,12 @@ pub fn build_request_body_with_warnings(
     //     }
     // }
 
+    // Per-call request body overrides (RFC-0017): deep-merge user-supplied
+    // JSON into the built body. `null` values delete the corresponding key.
+    if let Some(ref overrides) = options.body_overrides {
+        crate::openai::convert::deep_merge_json(&mut body, overrides);
+    }
+
     Ok(RequestBodyResult {
         body,
         warnings,

--- a/aimux-providers/src/anthropic/mod.rs
+++ b/aimux-providers/src/anthropic/mod.rs
@@ -16,6 +16,7 @@ use aimux_core::error::AiMuxError;
 use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_provider_utils::{RetryConfig, load_api_key};
+use serde_json::Value;
 
 /// The bare (unversioned) Anthropic API URL.
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com";
@@ -41,6 +42,8 @@ pub struct AnthropicConfig {
     pub headers: Option<HashMap<String, String>>,
     /// 重试配置。默认 `RetryConfig::default()`（max_retries=2）。
     pub retry_config: RetryConfig,
+    /// Provider 级请求体覆盖（RFC-0017）。在标准请求体之后 deep-merge。
+    pub body_overrides: Option<Value>,
 }
 
 impl AnthropicConfig {
@@ -55,6 +58,7 @@ impl AnthropicConfig {
             name: "anthropic.messages".to_string(),
             headers: None,
             retry_config: RetryConfig::default(),
+            body_overrides: None,
         }
     }
 
@@ -97,6 +101,12 @@ impl AnthropicConfig {
         self
     }
 
+    /// Set provider-level request body overrides (RFC-0017).
+    pub fn with_body_overrides(mut self, overrides: Value) -> Self {
+        self.body_overrides = Some(overrides);
+        self
+    }
+
     /// Load the configuration from the environment.
     ///
     /// Reads `ANTHROPIC_API_KEY` (required) and the optional
@@ -123,6 +133,7 @@ pub struct AnthropicConfigBuilder {
     base_url: Option<String>,
     name: Option<String>,
     headers: Option<HashMap<String, String>>,
+    body_overrides: Option<Value>,
 }
 
 impl AnthropicConfigBuilder {
@@ -151,6 +162,11 @@ impl AnthropicConfigBuilder {
         self
     }
 
+    pub fn body_overrides(mut self, overrides: Value) -> Self {
+        self.body_overrides = Some(overrides);
+        self
+    }
+
     /// Build the config, validating that `api_key` and `auth_token` are not
     /// both set and that a provided `base_url` is non-empty.
     pub fn build(self) -> Result<AnthropicConfig, AiMuxError> {
@@ -174,6 +190,7 @@ impl AnthropicConfigBuilder {
                 .unwrap_or_else(|| "anthropic.messages".to_string()),
             headers: self.headers,
             retry_config: RetryConfig::default(),
+            body_overrides: self.body_overrides,
         })
     }
 }

--- a/aimux-providers/src/anthropic/model.rs
+++ b/aimux-providers/src/anthropic/model.rs
@@ -16,6 +16,7 @@ use aimux_core::result::{GenerateResult, StreamResult};
 use super::AnthropicConfig;
 use super::convert::build_request_body_with_warnings;
 use super::stream::{BodyEncoding, anthropic_generate_core, anthropic_stream_core};
+use aimux_provider_utils::RetryConfig;
 
 /// An Anthropic language model (e.g. `claude-sonnet-4-20250514`).
 pub struct AnthropicModel {
@@ -89,12 +90,14 @@ impl LanguageModel for AnthropicModel {
     }
 
     async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
-        let req = build_request_body_with_warnings(&self.model_id, options, false)?;
+        let options = merge_anthropic_body_overrides(options, &self.config.body_overrides);
+        let req = build_request_body_with_warnings(&self.model_id, &options, false)?;
         let endpoint = self.endpoint();
         let build_headers = self.make_header_builder(options.headers.as_ref(), req.betas);
+        let retry_config = resolve_anthropic_retry(&self.config.retry_config, options.max_retries);
         anthropic_generate_core(
             &endpoint,
-            self.config.retry_config,
+            retry_config,
             req.body,
             req.warnings,
             build_headers,
@@ -104,17 +107,55 @@ impl LanguageModel for AnthropicModel {
     }
 
     async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
-        let req = build_request_body_with_warnings(&self.model_id, options, true)?;
+        let options = merge_anthropic_body_overrides(options, &self.config.body_overrides);
+        let req = build_request_body_with_warnings(&self.model_id, &options, true)?;
         let endpoint = self.endpoint();
         let build_headers = self.make_header_builder(options.headers.as_ref(), req.betas);
+        let retry_config = resolve_anthropic_retry(&self.config.retry_config, options.max_retries);
         anthropic_stream_core(
             &endpoint,
-            self.config.retry_config,
+            retry_config,
             req.body,
             req.warnings,
             build_headers,
             BodyEncoding::Json,
         )
         .await
+    }
+}
+
+/// Resolve per-call max_retries override (RFC-0017). RetryConfig is Copy.
+fn resolve_anthropic_retry(
+    provider: &RetryConfig,
+    max_retries_override: Option<u32>,
+) -> RetryConfig {
+    match max_retries_override {
+        Some(n) => RetryConfig {
+            max_retries: n,
+            ..*provider
+        },
+        None => *provider,
+    }
+}
+
+/// Merge provider-level body_overrides into per-call options (RFC-0017).
+fn merge_anthropic_body_overrides(
+    options: &CallOptions,
+    provider_overrides: &Option<serde_json::Value>,
+) -> CallOptions {
+    match (provider_overrides, &options.body_overrides) {
+        (Some(provider), Some(call)) => {
+            let mut merged = provider.clone();
+            crate::openai::convert::deep_merge_json(&mut merged, call);
+            let mut opts = options.clone();
+            opts.body_overrides = Some(merged);
+            opts
+        }
+        (Some(provider), None) => {
+            let mut opts = options.clone();
+            opts.body_overrides = Some(provider.clone());
+            opts
+        }
+        (None, _) => options.clone(),
     }
 }

--- a/aimux-providers/src/openai/convert.rs
+++ b/aimux-providers/src/openai/convert.rs
@@ -1432,7 +1432,38 @@ pub fn build_request_body_with_warnings_fallible(
         }
     }
 
+    // Per-call request body overrides (RFC-0017): deep-merge user-supplied
+    // JSON into the built body. `null` values delete the corresponding key.
+    // Applied last so users can override anything, including vendor-specific
+    // fields injected above.
+    if let Some(ref overrides) = options.body_overrides {
+        deep_merge_json(&mut body, overrides);
+    }
+
     Ok(RequestBodyResult { body, warnings })
+}
+
+/// Recursively deep-merge `patch` into `target` (RFC-0017).
+///
+/// - Objects: merge key-by-key (recursive).
+/// - Scalars / arrays: `patch` overwrites `target`.
+/// - `null` in `patch`: deletes the key from `target` (explicit removal).
+pub fn deep_merge_json(target: &mut Value, patch: &Value) {
+    match (target, patch) {
+        (Value::Object(t), Value::Object(p)) => {
+            for (k, v) in p {
+                match v {
+                    Value::Null => {
+                        t.remove(k);
+                    }
+                    _ => {
+                        deep_merge_json(t.entry(k).or_insert(Value::Null), v);
+                    }
+                }
+            }
+        }
+        (target, patch) => *target = patch.clone(),
+    }
 }
 
 /// Convert `CallOptions` to an OpenAI request body, returning warnings.

--- a/aimux-providers/src/openai/mod.rs
+++ b/aimux-providers/src/openai/mod.rs
@@ -26,6 +26,7 @@ use aimux_core::error::AiMuxError;
 use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_provider_utils::{RetryConfig, load_api_key, without_trailing_slash};
+use serde_json::Value;
 
 /// 描述 OpenAI 兼容厂商的差异。
 ///
@@ -111,6 +112,10 @@ pub struct OpenAIConfig {
     /// 测试中可用 `.with_retry_config(RetryConfig { max_retries: 0, .. })`
     /// 关闭重试（RFC-0009 §4.2）。
     pub retry_config: RetryConfig,
+    /// Provider 级请求体覆盖（RFC-0017）。在标准请求体 + 内置厂商 override
+    /// 之后 deep-merge。per-call 的 `CallOptions.body_overrides` 在此之后
+    /// 再 merge（覆盖 provider 级）。
+    pub body_overrides: Option<Value>,
 }
 
 impl OpenAIConfig {
@@ -125,6 +130,7 @@ impl OpenAIConfig {
             provider: "openai".to_string(),
             profile: OpenAICompatProfile::full(),
             retry_config: RetryConfig::default(),
+            body_overrides: None,
         }
     }
 
@@ -166,6 +172,12 @@ impl OpenAIConfig {
     /// 设置重试配置。传入 `max_retries: 0` 可关闭重试。
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
+        self
+    }
+
+    /// 设置 provider 级请求体覆盖（RFC-0017）。
+    pub fn with_body_overrides(mut self, overrides: Value) -> Self {
+        self.body_overrides = Some(overrides);
         self
     }
 

--- a/aimux-providers/src/openai/model.rs
+++ b/aimux-providers/src/openai/model.rs
@@ -51,6 +51,16 @@ impl OpenAIModel {
         if let Some(ref org) = self.config.org_id {
             headers.insert("OpenAI-Organization".to_string(), org.clone());
         }
+        if let Some(ref project) = self.config.project {
+            headers.insert("OpenAI-Project".to_string(), project.clone());
+        }
+        // Provider-level headers (from OpenAIConfig.with_headers).
+        if let Some(ref config_headers) = self.config.headers {
+            for (k, v) in config_headers {
+                headers.insert(k.clone(), v.clone());
+            }
+        }
+        // Per-call headers (from CallOptions.headers), overriding provider-level.
         if let Some(extra) = extra {
             for (k, v) in extra {
                 headers.insert(k.clone(), v.clone());
@@ -61,6 +71,43 @@ impl OpenAIModel {
 
     fn endpoint(&self) -> String {
         format!("{}/chat/completions", self.config.base_url)
+    }
+}
+
+/// Resolve the effective `RetryConfig`: if the caller passed a per-call
+/// `max_retries` override, clone the provider config and substitute it;
+/// otherwise return the provider config as-is (RFC-0017).
+fn resolve_retry_config(provider: &RetryConfig, max_retries_override: Option<u32>) -> RetryConfig {
+    match max_retries_override {
+        Some(n) => RetryConfig {
+            max_retries: n,
+            ..*provider
+        },
+        None => *provider,
+    }
+}
+
+/// Merge provider-level `body_overrides` into the per-call options (RFC-0017).
+///
+/// Provider-level overrides are applied first (lower priority); per-call
+/// `body_overrides` from `CallOptions` are merged on top. If neither is
+/// present, the options are returned unchanged (cheap clone).
+fn merge_body_overrides(options: &CallOptions, provider_overrides: &Option<Value>) -> CallOptions {
+    match (provider_overrides, &options.body_overrides) {
+        (Some(provider), Some(call)) => {
+            // Merge: provider first, then call (call wins).
+            let mut merged = provider.clone();
+            crate::openai::convert::deep_merge_json(&mut merged, call);
+            let mut opts = options.clone();
+            opts.body_overrides = Some(merged);
+            opts
+        }
+        (Some(provider), None) => {
+            let mut opts = options.clone();
+            opts.body_overrides = Some(provider.clone());
+            opts
+        }
+        (None, _) => options.clone(),
     }
 }
 
@@ -147,28 +194,32 @@ impl LanguageModel for OpenAIModel {
 
     async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
         let headers = self.build_headers(options.headers.as_ref());
+        let retry_config = resolve_retry_config(&self.config.retry_config, options.max_retries);
+        let options = merge_body_overrides(options, &self.config.body_overrides);
         execute_generate(
             &self.endpoint(),
             &headers,
             &self.model_id,
-            options,
+            &options,
             &self.config.provider,
             &self.config.profile,
-            &self.config.retry_config,
+            &retry_config,
         )
         .await
     }
 
     async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
         let headers = self.build_headers(options.headers.as_ref());
+        let retry_config = resolve_retry_config(&self.config.retry_config, options.max_retries);
+        let options = merge_body_overrides(options, &self.config.body_overrides);
         execute_stream(
             &self.endpoint(),
             &headers,
             &self.model_id,
-            options,
+            &options,
             &self.config.provider,
             &self.config.profile,
-            &self.config.retry_config,
+            &retry_config,
         )
         .await
     }

--- a/aimux-providers/src/openai_compat.rs
+++ b/aimux-providers/src/openai_compat.rs
@@ -36,7 +36,7 @@ macro_rules! declare_openai_compat_provider {
         $env_var:literal,
         $profile:expr
     ) => {
-        pub struct $config($crate::openai::OpenAIConfig);
+        pub struct $config(pub $crate::openai::OpenAIConfig);
 
         impl $config {
             pub fn new(api_key: impl Into<String>) -> Self {
@@ -55,6 +55,27 @@ macro_rules! declare_openai_compat_provider {
 
             pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
                 self.0 = self.0.with_base_url(url);
+                self
+            }
+
+            /// Attach extra headers merged into every request.
+            pub fn with_headers(
+                mut self,
+                headers: std::collections::HashMap<String, String>,
+            ) -> Self {
+                self.0 = self.0.with_headers(headers);
+                self
+            }
+
+            /// Set retry config. `max_retries: 0` disables retries.
+            pub fn with_retry_config(mut self, config: aimux_provider_utils::RetryConfig) -> Self {
+                self.0 = self.0.with_retry_config(config);
+                self
+            }
+
+            /// Set provider-level request body overrides (RFC-0017).
+            pub fn with_body_overrides(mut self, overrides: serde_json::Value) -> Self {
+                self.0 = self.0.with_body_overrides(overrides);
                 self
             }
         }

--- a/aimux-providers/tests/body_overrides_test.rs
+++ b/aimux-providers/tests/body_overrides_test.rs
@@ -1,0 +1,167 @@
+//! Tests for RFC-0017 phase 1: `body_overrides` (JSON deep-merge) and
+//! `max_retries` (per-call retry override).
+//!
+//! `body_overrides` is a per-call JSON object deep-merged into the
+//! provider-built request body after built-in vendor overrides. It lets users
+//! inject/override arbitrary request fields (e.g. `enable_thinking`,
+//! `thinking_budget`) without closure bridging — critical for aimux's
+//! multi-language C ABI architecture. `null` values delete keys.
+
+use aimux_core::content::ContentPart;
+use aimux_core::language_model_message::{LanguageModelPrompt, LanguageModelPromptMessage};
+use aimux_core::message::Role;
+use aimux_core::options::CallOptions;
+use aimux_providers::openai::convert::build_request_body;
+use serde_json::{Value, json};
+
+fn user_prompt() -> LanguageModelPrompt {
+    vec![LanguageModelPromptMessage {
+        role: Role::User,
+        content: vec![ContentPart::text("Hello")],
+        ..Default::default()
+    }]
+}
+
+fn opts_with_overrides(prompt: LanguageModelPrompt, body_overrides: Value) -> CallOptions {
+    CallOptions {
+        prompt,
+        body_overrides: Some(body_overrides),
+        ..CallOptions::default()
+    }
+}
+
+// ── body_overrides: inject ───────────────────────────────────────────────────
+
+/// A top-level key in body_overrides is injected into the request body.
+#[test]
+fn body_overrides_injects_new_field() {
+    let opts = opts_with_overrides(user_prompt(), json!({ "enable_thinking": false }));
+    let body = build_request_body("gpt-4o", &opts, false);
+    assert_eq!(body["enable_thinking"], json!(false));
+    assert_eq!(body["model"], json!("gpt-4o"));
+}
+
+/// body_overrides can inject nested objects.
+#[test]
+fn body_overrides_injects_nested_object() {
+    let opts = opts_with_overrides(user_prompt(), json!({ "thinking": { "type": "disabled" } }));
+    let body = build_request_body("gpt-4o", &opts, false);
+    assert_eq!(body["thinking"], json!({ "type": "disabled" }));
+}
+
+// ── body_overrides: override ─────────────────────────────────────────────────
+
+/// body_overrides overwrites an existing field (e.g. temperature).
+#[test]
+fn body_overrides_overwrites_existing_field() {
+    let mut opts = opts_with_overrides(user_prompt(), json!({ "temperature": 0.1 }));
+    opts.temperature = Some(0.9); // set by standard option
+    let body = build_request_body("gpt-4o", &opts, false);
+    // body_overrides wins over standard option
+    assert_eq!(body["temperature"], json!(0.1));
+}
+
+/// body_overrides overwrites a field set by a built-in vendor override
+/// (DeepSeek thinking). This proves the merge runs after vendor overrides.
+#[test]
+fn body_overrides_overwrites_vendor_override_field() {
+    let opts = CallOptions {
+        prompt: user_prompt(),
+        reasoning: Some(aimux_core::types::ReasoningEffort::None),
+        body_overrides: Some(json!({ "thinking": { "type": "enabled" } })),
+        ..CallOptions::default()
+    };
+    // DeepSeek profile: reasoning:none → thinking:{type:"disabled"}
+    // body_overrides should override to enabled.
+    let body = aimux_providers::openai::convert::build_request_body_with_warnings(
+        "deepseek-v4-flash",
+        &opts,
+        false,
+        "deepseek",
+        &aimux_providers::openai::OpenAICompatProfile::deepseek(),
+    )
+    .body;
+    assert_eq!(body["thinking"], json!({ "type": "enabled" }));
+}
+
+// ── body_overrides: deep merge ───────────────────────────────────────────────
+
+/// Nested objects are merged recursively, not replaced wholesale.
+#[test]
+fn body_overrides_deep_merges_nested_objects() {
+    // The standard body has stream_options: { include_usage: true } for streams.
+    // body_overrides adds another key to stream_options without clobbering
+    // include_usage.
+    let opts = opts_with_overrides(
+        user_prompt(),
+        json!({ "stream_options": { "include_usage": false } }),
+    );
+    let body = build_request_body("gpt-4o", &opts, true);
+    assert_eq!(body["stream_options"]["include_usage"], json!(false));
+}
+
+// ── body_overrides: null = delete ────────────────────────────────────────────
+
+/// A `null` value in body_overrides deletes the corresponding key from the
+/// request body.
+#[test]
+fn body_overrides_null_deletes_key() {
+    let opts = opts_with_overrides(
+        user_prompt(),
+        json!({ "stream_options": null, "temperature": null }),
+    );
+    let body = build_request_body("gpt-4o", &opts, true);
+    assert!(
+        body.get("stream_options").is_none(),
+        "stream_options should be deleted by null"
+    );
+    assert!(
+        body.get("temperature").is_none(),
+        "temperature should be deleted by null"
+    );
+}
+
+/// null in a nested object deletes the nested key.
+#[test]
+fn body_overrides_null_deletes_nested_key() {
+    let opts = opts_with_overrides(
+        user_prompt(),
+        json!({ "stream_options": { "include_usage": null } }),
+    );
+    let body = build_request_body("gpt-4o", &opts, true);
+    // stream_options still exists but include_usage is gone
+    assert!(body.get("stream_options").is_some());
+    assert!(body["stream_options"].get("include_usage").is_none());
+}
+
+// ── body_overrides: no overrides = unchanged ─────────────────────────────────
+
+/// When body_overrides is None, the request body is identical to the standard
+/// build (no merge happens).
+#[test]
+fn no_body_overrides_leaves_body_unchanged() {
+    let opts = CallOptions::new(user_prompt());
+    let body = build_request_body("gpt-4o", &opts, false);
+    assert_eq!(body["model"], json!("gpt-4o"));
+    assert!(body.get("enable_thinking").is_none());
+}
+
+// ── max_retries ──────────────────────────────────────────────────────────────
+
+/// max_retries is stored in CallOptions and defaults to None.
+#[test]
+fn max_retries_defaults_to_none() {
+    let opts = CallOptions::new(user_prompt());
+    assert!(opts.max_retries.is_none());
+}
+
+/// max_retries can be set (e.g. Some(0) to disable retries).
+#[test]
+fn max_retries_can_be_set() {
+    let opts = CallOptions {
+        prompt: user_prompt(),
+        max_retries: Some(0),
+        ..CallOptions::default()
+    };
+    assert_eq!(opts.max_retries, Some(0));
+}

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -63,6 +63,8 @@ fn options_with_tools(prompt: LanguageModelPrompt, tools: Vec<FunctionTool>) -> 
         headers: None,
         provider_options: None,
         reasoning: None,
+        body_overrides: None,
+        max_retries: None,
     }
 }
 

--- a/aimux-providers/tests/openai_convert_extended_test.rs
+++ b/aimux-providers/tests/openai_convert_extended_test.rs
@@ -58,6 +58,8 @@ fn default_opts(p: LanguageModelPrompt) -> CallOptions {
         headers: None,
         provider_options: None,
         reasoning: None,
+        body_overrides: None,
+        max_retries: None,
     }
 }
 fn po(map: Value) -> Option<std::collections::HashMap<String, Value>> {

--- a/aimux-providers/tests/openai_model_extended_test.rs
+++ b/aimux-providers/tests/openai_model_extended_test.rs
@@ -43,6 +43,8 @@ fn default_opts(p: LanguageModelPrompt) -> CallOptions {
         headers: None,
         provider_options: None,
         reasoning: None,
+        body_overrides: None,
+        max_retries: None,
     }
 }
 fn po(map: Value) -> Option<std::collections::HashMap<String, Value>> {

--- a/aimux-providers/tests/openai_model_test.rs
+++ b/aimux-providers/tests/openai_model_test.rs
@@ -68,6 +68,8 @@ fn options_with_tools(prompt: LanguageModelPrompt, tools: Vec<FunctionTool>) -> 
         headers: None,
         provider_options: None,
         reasoning: None,
+        body_overrides: None,
+        max_retries: None,
     }
 }
 

--- a/bindings/flutter/lib/types.dart
+++ b/bindings/flutter/lib/types.dart
@@ -622,6 +622,10 @@ class GenerateTextOptions {
   final Map<String, dynamic>? providerOptions;
   final ReasoningEffort? reasoning;
   final String? instructions;
+  @JsonKey(name: 'body_overrides')
+  final Map<String, dynamic>? bodyOverrides;
+  @JsonKey(name: 'max_retries')
+  final int? maxRetries;
 
   GenerateTextOptions({
     this.maxOutputTokens,
@@ -639,6 +643,8 @@ class GenerateTextOptions {
     this.providerOptions,
     this.reasoning,
     this.instructions,
+    this.bodyOverrides,
+    this.maxRetries,
   });
 
   factory GenerateTextOptions.fromJson(Map<String, dynamic> json) {
@@ -664,6 +670,8 @@ class GenerateTextOptions {
           ? ReasoningEffort.fromJson(json['reasoning'] as String)
           : null,
       instructions: json['instructions'] as String?,
+      bodyOverrides: json['body_overrides'] as Map<String, dynamic>?,
+      maxRetries: json['max_retries'] as int?,
     );
   }
   Map<String, dynamic> toJson() => {
@@ -682,6 +690,8 @@ class GenerateTextOptions {
         if (providerOptions != null) 'provider_options': providerOptions,
         if (reasoning != null) 'reasoning': reasoning!.toJson(),
         if (instructions != null) 'instructions': instructions,
+        if (bodyOverrides != null) 'body_overrides': bodyOverrides,
+        if (maxRetries != null) 'max_retries': maxRetries,
       };
 }
 

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -203,6 +203,8 @@ type GenerateTextOptions struct {
 	ProviderOptions   json.RawMessage   `json:"provider_options,omitempty"`
 	Reasoning         *ReasoningEffort  `json:"reasoning,omitempty"`
 	Instructions       *string           `json:"instructions,omitempty"`
+	BodyOverrides     json.RawMessage   `json:"body_overrides,omitempty"`
+	MaxRetries        *uint32           `json:"max_retries,omitempty"`
 }
 
 // Tool is a function tool definition (the "function" variant).

--- a/bindings/java/src/main/java/io/aimux/Types.java
+++ b/bindings/java/src/main/java/io/aimux/Types.java
@@ -1735,7 +1735,7 @@ public final class Types {
                 && Objects.equals(reasoning, that.reasoning)
                 && Objects.equals(instructions, that.instructions)
                 && Objects.equals(bodyOverrides, that.bodyOverrides)
-                && Objects.equals(maxRetries, that.maxRetries));
+                && Objects.equals(maxRetries, that.maxRetries);
         }
 
         @Override

--- a/bindings/java/src/main/java/io/aimux/Types.java
+++ b/bindings/java/src/main/java/io/aimux/Types.java
@@ -1619,6 +1619,8 @@ public final class Types {
         @JsonProperty("provider_options") private Map<String, JsonNode> providerOptions;
         @JsonProperty("reasoning") private ReasoningEffort reasoning;
         @JsonProperty("instructions") private String instructions;
+        @JsonProperty("body_overrides") private JsonNode bodyOverrides;
+        @JsonProperty("max_retries") private Long maxRetries;
 
         @JsonCreator
         GenerateTextOptions() {}
@@ -1627,7 +1629,8 @@ public final class Types {
                                     Double topP, Long topK, Double presencePenalty, Double frequencyPenalty,
                                     JsonNode responseFormat, Long seed, List<Tool> tools, ToolChoice toolChoice,
                                     Map<String, String> headers, Map<String, JsonNode> providerOptions,
-                                    ReasoningEffort reasoning, String instructions) {
+                                    ReasoningEffort reasoning, String instructions,
+                                    JsonNode bodyOverrides, Long maxRetries) {
             this.maxOutputTokens = maxOutputTokens;
             this.temperature = temperature;
             this.stopSequences = stopSequences;
@@ -1643,6 +1646,8 @@ public final class Types {
             this.providerOptions = providerOptions;
             this.reasoning = reasoning;
             this.instructions = instructions;
+            this.bodyOverrides = bodyOverrides;
+            this.maxRetries = maxRetries;
         }
 
         public Long getMaxOutputTokens() { return maxOutputTokens; }
@@ -1660,6 +1665,8 @@ public final class Types {
         public Map<String, JsonNode> getProviderOptions() { return providerOptions; }
         public ReasoningEffort getReasoning() { return reasoning; }
         public String getInstructions() { return instructions; }
+        public JsonNode getBodyOverrides() { return bodyOverrides; }
+        public Long getMaxRetries() { return maxRetries; }
 
         public static Builder builder() { return new Builder(); }
 
@@ -1679,6 +1686,8 @@ public final class Types {
             private Map<String, JsonNode> providerOptions;
             private ReasoningEffort reasoning;
             private String instructions;
+            private JsonNode bodyOverrides;
+            private Long maxRetries;
 
             public Builder maxOutputTokens(Long v) { this.maxOutputTokens = v; return this; }
             public Builder temperature(Double v) { this.temperature = v; return this; }
@@ -1695,11 +1704,13 @@ public final class Types {
             public Builder providerOptions(Map<String, JsonNode> v) { this.providerOptions = v; return this; }
             public Builder reasoning(ReasoningEffort v) { this.reasoning = v; return this; }
             public Builder instructions(String v) { this.instructions = v; return this; }
+            public Builder bodyOverrides(JsonNode v) { this.bodyOverrides = v; return this; }
+            public Builder maxRetries(Long v) { this.maxRetries = v; return this; }
 
             public GenerateTextOptions build() {
                 return new GenerateTextOptions(maxOutputTokens, temperature, stopSequences, topP, topK,
                     presencePenalty, frequencyPenalty, responseFormat, seed, tools, toolChoice, headers,
-                    providerOptions, reasoning, instructions);
+                    providerOptions, reasoning, instructions, bodyOverrides, maxRetries);
             }
         }
 
@@ -1722,14 +1733,16 @@ public final class Types {
                 && Objects.equals(headers, that.headers)
                 && Objects.equals(providerOptions, that.providerOptions)
                 && Objects.equals(reasoning, that.reasoning)
-                && Objects.equals(instructions, that.instructions);
+                && Objects.equals(instructions, that.instructions)
+                && Objects.equals(bodyOverrides, that.bodyOverrides)
+                && Objects.equals(maxRetries, that.maxRetries));
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(maxOutputTokens, temperature, stopSequences, topP, topK, presencePenalty,
                 frequencyPenalty, responseFormat, seed, tools, toolChoice, headers, providerOptions, reasoning,
-                instructions);
+                instructions, bodyOverrides, maxRetries);
         }
     }
 

--- a/bindings/kotlin/src/main/kotlin/aimux/Types.kt
+++ b/bindings/kotlin/src/main/kotlin/aimux/Types.kt
@@ -576,6 +576,10 @@ data class GenerateTextOptions(
     @SerialName("provider_options") val providerOptions: Map<String, JsonElement>? = null,
     val reasoning: ReasoningEffort? = null,
     val instructions: String? = null,
+    /** Per-call JSON deep-merge overrides for the request body. Untyped ([JsonElement]). */
+    @SerialName("body_overrides") val bodyOverrides: JsonElement? = null,
+    /** Per-call retry count (0 = disable retries). */
+    @SerialName("max_retries") val maxRetries: Long? = null,
 )
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 aimux-core = { path = "../../aimux-core" }
 aimux-providers = { path = "../../aimux-providers" }
+aimux-provider-utils = { path = "../../aimux-provider-utils" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }

--- a/bindings/node/__test__/body_overrides.test.ts
+++ b/bindings/node/__test__/body_overrides.test.ts
@@ -1,0 +1,201 @@
+// body_overrides.test.ts — Node e2e tests for RFC-0017 phase 1: bodyOverrides
+// (JSON deep-merge) and provider factory config (headers/maxRetries/bodyOverrides).
+//
+// These verify the full chain: JS → napi → Rust → HTTP mock, asserting the
+// outbound request body carries the user's overrides.
+
+import test from 'ava'
+import { createServer, type Server } from 'node:http'
+import { openai, deepseek } from '../index.js'
+
+function startMockServer(handler: (req: any, res: any) => void): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler)
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as any
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` })
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+function readBody(req: any): Promise<any> {
+  return new Promise((resolve) => {
+    let body = ''
+    req.on('data', (chunk: string) => { body += chunk })
+    req.on('end', () => resolve(JSON.parse(body)))
+  })
+}
+
+const CHAT_RESPONSE = JSON.stringify({
+  id: 'chatcmpl-test',
+  model: 'gpt-4o',
+  choices: [{
+    message: { role: 'assistant', content: 'Done.' },
+    finish_reason: 'stop',
+  }],
+  usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+})
+
+// ── per-call bodyOverrides ───────────────────────────────────────────────────
+
+test('per-call bodyOverrides injects a field into the request body', async (t) => {
+  let requestBody: any = null
+  const { server, url } = await startMockServer(async (req, res) => {
+    requestBody = await readBody(req)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(CHAT_RESPONSE)
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', url)
+    const opts = JSON.stringify({
+      body_overrides: { enable_thinking: false },
+    })
+    await model.generateText(JSON.stringify('Hello'), opts)
+
+    t.is(requestBody.enable_thinking, false)
+    t.is(requestBody.model, 'gpt-4o')
+  } finally {
+    await closeServer(server)
+  }
+})
+
+test('per-call bodyOverrides overwrites a standard field', async (t) => {
+  let requestBody: any = null
+  const { server, url } = await startMockServer(async (req, res) => {
+    requestBody = await readBody(req)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(CHAT_RESPONSE)
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', url)
+    // temperature set via standard option, overridden by body_overrides
+    const opts = JSON.stringify({
+      temperature: 0.9,
+      body_overrides: { temperature: 0.1 },
+    })
+    await model.generateText(JSON.stringify('Hello'), opts)
+
+    t.is(requestBody.temperature, 0.1)
+  } finally {
+    await closeServer(server)
+  }
+})
+
+test('per-call bodyOverrides null deletes a field', async (t) => {
+  let requestBody: any = null
+  const { server, url } = await startMockServer(async (req, res) => {
+    requestBody = await readBody(req)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(CHAT_RESPONSE)
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', url)
+    const opts = JSON.stringify({
+      temperature: 0.5,
+      body_overrides: { temperature: null },
+    })
+    await model.generateText(JSON.stringify('Hello'), opts)
+
+    t.true(requestBody.temperature === undefined, 'temperature should be deleted by null')
+  } finally {
+    await closeServer(server)
+  }
+})
+
+// ── provider-level bodyOverrides (factory config) ────────────────────────────
+
+test('factory config bodyOverrides are merged into every request', async (t) => {
+  let requestBody: any = null
+  const { server, url } = await startMockServer(async (req, res) => {
+    requestBody = await readBody(req)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(CHAT_RESPONSE)
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', {
+      baseUrl: url,
+      bodyOverrides: '{"X-Relay-Tag":"my-team"}',
+    })
+    await model.generateText(JSON.stringify('Hello'))
+
+    t.is(requestBody['X-Relay-Tag'], 'my-team')
+  } finally {
+    await closeServer(server)
+  }
+})
+
+test('factory config headers are sent on every request', async (t) => {
+  let headers: any = null
+  const { server, url } = await startMockServer(async (req, res) => {
+    headers = req.headers
+    // consume body
+    await readBody(req)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(CHAT_RESPONSE)
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', {
+      baseUrl: url,
+      headers: JSON.stringify({ 'X-Custom-Header': 'custom-value' }),
+    })
+    await model.generateText(JSON.stringify('Hello'))
+
+    t.is(headers['x-custom-header'], 'custom-value')
+  } finally {
+    await closeServer(server)
+  }
+})
+
+// ── backward compatibility ───────────────────────────────────────────────────
+
+test('factory accepts bare string baseUrl (backward compatible)', async (t) => {
+  const { server, url } = await startMockServer(async (req, res) => {
+    await readBody(req)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(CHAT_RESPONSE)
+  })
+
+  try {
+    // 3rd param is a plain string (old API)
+    const model = await openai('test-key', 'gpt-4o', url)
+    const result = JSON.parse(await model.generateText(JSON.stringify('Hello')))
+    t.is(result.text, 'Done.')
+  } finally {
+    await closeServer(server)
+  }
+})
+
+// ── per-call overrides provider-level ────────────────────────────────────────
+
+test('per-call bodyOverrides take precedence over provider-level', async (t) => {
+  let requestBody: any = null
+  const { server, url } = await startMockServer(async (req, res) => {
+    requestBody = await readBody(req)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(CHAT_RESPONSE)
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', {
+      baseUrl: url,
+      bodyOverrides: '{"custom_field":"provider"}',
+    })
+    const opts = JSON.stringify({
+      body_overrides: { custom_field: 'call' },
+    })
+    await model.generateText(JSON.stringify('Hello'), opts)
+
+    t.is(requestBody.custom_field, 'call', 'per-call should override provider-level')
+  } finally {
+    await closeServer(server)
+  }
+})

--- a/bindings/node/__test__/body_overrides.test.ts
+++ b/bindings/node/__test__/body_overrides.test.ts
@@ -199,3 +199,56 @@ test('per-call bodyOverrides take precedence over provider-level', async (t) => 
     await closeServer(server)
   }
 })
+
+// ── maxRetries ────────────────────────────────────────────────────────────────
+
+test('maxRetries: 0 disables retries (single request on 500)', async (t) => {
+  let requestCount = 0
+  const { server, url } = await startMockServer(async (req, res) => {
+    requestCount++
+    await readBody(req)
+    res.writeHead(500, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ error: { message: 'Internal server error', type: 'server_error' } }))
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', url)
+    const opts = JSON.stringify({ max_retries: 0 })
+
+    await t.throwsAsync(
+      async () => model.generateText(JSON.stringify('Hello'), opts),
+      { message: /500|Internal|server_error/i },
+    )
+
+    // With retries disabled, exactly 1 request should have been made.
+    t.is(requestCount, 1, 'should make exactly 1 request when maxRetries=0')
+  } finally {
+    await closeServer(server)
+  }
+})
+
+test('maxRetries: factory-level disables retries', async (t) => {
+  let requestCount = 0
+  const { server, url } = await startMockServer(async (req, res) => {
+    requestCount++
+    await readBody(req)
+    res.writeHead(500, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ error: { message: 'Internal server error', type: 'server_error' } }))
+  })
+
+  try {
+    const model = await openai('test-key', 'gpt-4o', {
+      baseUrl: url,
+      maxRetries: 0,
+    })
+
+    await t.throwsAsync(
+      async () => model.generateText(JSON.stringify('Hello')),
+      { message: /500|Internal|server_error/i },
+    )
+
+    t.is(requestCount, 1, 'factory maxRetries:0 should make exactly 1 request')
+  } finally {
+    await closeServer(server)
+  }
+})

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -113,7 +113,7 @@ export declare class VideoModel {
 }
 
 /** Create an Anthropic model instance. */
-export declare function anthropic(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<Model>
+export declare function anthropic(apiKey: string, modelId: string, config?: string | ProviderConfig | undefined | null): Promise<Model>
 
 /** Create a Cohere embedding model instance. */
 export declare function cohereEmbedding(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<EmbeddingModel>
@@ -122,7 +122,7 @@ export declare function cohereEmbedding(apiKey: string, modelId: string, baseUrl
 export declare function cohereReranking(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<RerankingModel>
 
 /** Create a DeepSeek model instance. */
-export declare function deepseek(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<Model>
+export declare function deepseek(apiKey: string, modelId: string, config?: string | ProviderConfig | undefined | null): Promise<Model>
 
 /** Create a Google embedding model instance. */
 export declare function googleEmbedding(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<EmbeddingModel>
@@ -134,7 +134,7 @@ export declare function googleImage(apiKey: string, modelId: string, baseUrl?: s
 export declare function googleVideo(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<VideoModel>
 
 /** Create an OpenAI model instance. */
-export declare function openai(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<Model>
+export declare function openai(apiKey: string, modelId: string, config?: string | ProviderConfig | undefined | null): Promise<Model>
 
 /** Create an OpenAI embedding model instance. */
 export declare function openaiEmbedding(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<EmbeddingModel>
@@ -150,6 +150,36 @@ export declare function openaiSpeech(apiKey: string, modelId: string, baseUrl?: 
 
 /** Create an OpenAI transcription model instance. */
 export declare function openaiTranscription(apiKey: string, modelId: string, baseUrl?: string | undefined | null): Promise<TranscriptionModel>
+
+/**
+ * Optional provider configuration accepted by factory functions.
+ *
+ * Passed as the 3rd argument to `openai()` / `anthropic()` / `deepseek()`.
+ * For backward compatibility a bare string is still accepted (treated as
+ * `baseUrl`). See RFC-0017.
+ */
+export interface ProviderConfig {
+  /** Base URL for API calls (e.g. a relay/proxy endpoint). */
+  baseUrl?: string
+  /**
+   * Extra HTTP headers merged into every request, as a JSON object string
+   * (e.g. `'{"X-Custom":"value"}'`).
+   */
+  headers?: string
+  /** OpenAI organization ID (sent via `OpenAI-Organization` header). */
+  organization?: string
+  /** OpenAI project ID (sent via `OpenAI-Project` header). */
+  project?: string
+  /** Override the provider's retry count. `0` disables retries. */
+  maxRetries?: number
+  /**
+   * Provider-level request body overrides as a JSON string (deep-merged
+   * into every request). Per-call `bodyOverrides` in GenerateTextOptions
+   * takes precedence. Pass a JSON object string, e.g.
+   * `'{"enable_thinking": false}'`.
+   */
+  bodyOverrides?: string
+}
 
 /** Create a Tavily search model instance. */
 export declare function tavilySearch(apiKey: string, baseUrl?: string | undefined | null): Promise<SearchModel>

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -277,6 +277,11 @@ pub async fn anthropic(
                     ..aimux_provider_utils::RetryConfig::default()
                 });
             }
+            if let Some(ref json_str) = opts.body_overrides {
+                if let Ok(overrides) = serde_json::from_str::<serde_json::Value>(json_str) {
+                    cfg = cfg.with_body_overrides(overrides);
+                }
+            }
         }
         None => {}
     }

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -160,21 +160,85 @@ impl AsyncGenerator for StreamTextGenerator {
 // Provider constructors — factory functions exposed to JS.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Optional provider configuration accepted by factory functions.
+///
+/// Passed as the 3rd argument to `openai()` / `anthropic()` / `deepseek()`.
+/// For backward compatibility a bare string is still accepted (treated as
+/// `baseUrl`). See RFC-0017.
+#[napi(object)]
+pub struct ProviderConfig {
+    /// Base URL for API calls (e.g. a relay/proxy endpoint).
+    pub base_url: Option<String>,
+    /// Extra HTTP headers merged into every request, as a JSON object string
+    /// (e.g. `'{"X-Custom":"value"}'`).
+    pub headers: Option<String>,
+    /// OpenAI organization ID (sent via `OpenAI-Organization` header).
+    pub organization: Option<String>,
+    /// OpenAI project ID (sent via `OpenAI-Project` header).
+    pub project: Option<String>,
+    /// Override the provider's retry count. `0` disables retries.
+    pub max_retries: Option<u32>,
+    /// Provider-level request body overrides as a JSON string (deep-merged
+    /// into every request). Per-call `bodyOverrides` in GenerateTextOptions
+    /// takes precedence. Pass a JSON object string, e.g.
+    /// `'{"enable_thinking": false}'`.
+    pub body_overrides: Option<String>,
+}
+
+/// Convert a ProviderConfig (from JS) into OpenAIConfig builder steps.
+fn apply_provider_config_openai(
+    mut config: aimux_providers::openai::OpenAIConfig,
+    cfg: &ProviderConfig,
+) -> aimux_providers::openai::OpenAIConfig {
+    if let Some(url) = &cfg.base_url {
+        config = config.with_base_url(url);
+    }
+    if let Some(ref json_str) = cfg.headers {
+        if let Ok(h) = serde_json::from_str::<std::collections::HashMap<String, String>>(json_str) {
+            config = config.with_headers(h);
+        }
+    }
+    if let Some(ref org) = cfg.organization {
+        config = config.with_org_id(org);
+    }
+    if let Some(ref proj) = cfg.project {
+        config = config.with_project(proj);
+    }
+    if let Some(max) = cfg.max_retries {
+        config = config.with_retry_config(aimux_provider_utils::RetryConfig {
+            max_retries: max,
+            ..aimux_provider_utils::RetryConfig::default()
+        });
+    }
+    if let Some(ref json_str) = cfg.body_overrides {
+        if let Ok(overrides) = serde_json::from_str::<serde_json::Value>(json_str) {
+            config = config.with_body_overrides(overrides);
+        }
+    }
+    config
+}
+
 /// Create an OpenAI model instance.
 #[napi]
 pub async fn openai(
     api_key: String,
     model_id: String,
-    base_url: Option<String>,
+    config: Option<Either<String, ProviderConfig>>,
 ) -> Result<Model> {
     use aimux_core::provider::Provider;
     use aimux_providers::openai::{OpenAIConfig, OpenAIProvider};
 
-    let mut config = OpenAIConfig::new(api_key);
-    if let Some(url) = base_url {
-        config = config.with_base_url(url);
+    let mut cfg = OpenAIConfig::new(api_key);
+    match config {
+        Some(Either::A(url)) => {
+            cfg = cfg.with_base_url(url);
+        }
+        Some(Either::B(opts)) => {
+            cfg = apply_provider_config_openai(cfg, &opts);
+        }
+        None => {}
     }
-    let provider = OpenAIProvider::new(config);
+    let provider = OpenAIProvider::new(cfg);
     let model = provider
         .language_model(&model_id)
         .map_err(|e| Error::from_reason(format!("[{}] {e}", e.error_type())))?;
@@ -188,16 +252,35 @@ pub async fn openai(
 pub async fn anthropic(
     api_key: String,
     model_id: String,
-    base_url: Option<String>,
+    config: Option<Either<String, ProviderConfig>>,
 ) -> Result<Model> {
     use aimux_core::provider::Provider;
     use aimux_providers::anthropic::{AnthropicConfig, AnthropicProvider};
 
-    let mut config = AnthropicConfig::new(api_key);
-    if let Some(url) = base_url {
-        config = config.with_base_url(url);
+    let mut cfg = AnthropicConfig::new(api_key);
+    match config {
+        Some(Either::A(url)) => {
+            cfg = cfg.with_base_url(url);
+        }
+        Some(Either::B(opts)) => {
+            if let Some(url) = &opts.base_url {
+                cfg = cfg.with_base_url(url);
+            }
+            if let Some(ref json_str) = opts.headers {
+                if let Ok(h) = serde_json::from_str::<std::collections::HashMap<String, String>>(json_str) {
+                    cfg = cfg.with_headers(h);
+                }
+            }
+            if let Some(max) = opts.max_retries {
+                cfg = cfg.with_retry_config(aimux_provider_utils::RetryConfig {
+                    max_retries: max,
+                    ..aimux_provider_utils::RetryConfig::default()
+                });
+            }
+        }
+        None => {}
     }
-    let provider = AnthropicProvider::new(config);
+    let provider = AnthropicProvider::new(cfg);
     let model = provider
         .language_model(&model_id)
         .map_err(|e| Error::from_reason(format!("[{}] {e}", e.error_type())))?;
@@ -211,16 +294,40 @@ pub async fn anthropic(
 pub async fn deepseek(
     api_key: String,
     model_id: String,
-    base_url: Option<String>,
+    config: Option<Either<String, ProviderConfig>>,
 ) -> Result<Model> {
     use aimux_core::provider::Provider;
     use aimux_providers::deepseek::{DeepSeekConfig, DeepSeekProvider};
 
-    let mut config = DeepSeekConfig::new(api_key);
-    if let Some(url) = base_url {
-        config = config.with_base_url(url);
+    let mut cfg = DeepSeekConfig::new(api_key);
+    match config {
+        Some(Either::A(url)) => {
+            cfg = cfg.with_base_url(url);
+        }
+        Some(Either::B(opts)) => {
+            if let Some(url) = &opts.base_url {
+                cfg = cfg.with_base_url(url);
+            }
+            if let Some(ref json_str) = opts.headers {
+                if let Ok(h) = serde_json::from_str::<std::collections::HashMap<String, String>>(json_str) {
+                    cfg = cfg.with_headers(h);
+                }
+            }
+            if let Some(max) = opts.max_retries {
+                cfg = cfg.with_retry_config(aimux_provider_utils::RetryConfig {
+                    max_retries: max,
+                    ..aimux_provider_utils::RetryConfig::default()
+                });
+            }
+            if let Some(ref json_str) = opts.body_overrides {
+                if let Ok(overrides) = serde_json::from_str::<serde_json::Value>(json_str) {
+                    cfg = DeepSeekConfig(cfg.0.with_body_overrides(overrides));
+                }
+            }
+        }
+        None => {}
     }
-    let provider = DeepSeekProvider::new(config);
+    let provider = DeepSeekProvider::new(cfg);
     let model = provider
         .language_model(&model_id)
         .map_err(|e| Error::from_reason(format!("[{}] {e}", e.error_type())))?;

--- a/bindings/node/src/types/CallOptions.ts
+++ b/bindings/node/src/types/CallOptions.ts
@@ -74,4 +74,15 @@ provider_options: { [key in string]: JsonValue } | null,
  * Top-level reasoning effort. Maps to OpenAI `reasoning_effort` and
  * Anthropic `thinking` config.
  */
-reasoning: ReasoningEffort | null, };
+reasoning: ReasoningEffort | null, 
+/**
+ * Per-call request body overrides. Deep-merged into the provider-built
+ * request body (after any built-in vendor override) before sending.
+ * `null` values delete the corresponding key. See RFC-0017.
+ */
+body_overrides: JsonValue | null, 
+/**
+ * Per-call retry count override. `None` uses the provider's configured
+ * `RetryConfig.max_retries`. `Some(0)` disables retries.
+ */
+max_retries: number | null, };

--- a/bindings/node/src/types/GenerateTextOptions.ts
+++ b/bindings/node/src/types/GenerateTextOptions.ts
@@ -19,4 +19,12 @@ reasoning: ReasoningEffort | null,
 /**
  * System instructions prepended to the prompt.
  */
-instructions: string | null, };
+instructions: string | null, 
+/**
+ * Per-call request body overrides (deep-merged). See RFC-0017.
+ */
+body_overrides: JsonValue | null, 
+/**
+ * Per-call retry count override. `None` = provider default, `Some(0)` = disable.
+ */
+max_retries: number | null, };

--- a/bindings/python/python/aimux/wrapper.py
+++ b/bindings/python/python/aimux/wrapper.py
@@ -809,6 +809,8 @@ class GenerateTextOptions(BaseModel):
     provider_options: Optional[Dict[str, Any]] = None
     reasoning: Optional[ReasoningEffort] = None
     instructions: Optional[str] = None
+    body_overrides: Optional[Any] = None
+    max_retries: Optional[int] = None
 
 
 class GenerateResult(BaseModel):

--- a/bindings/swift/Sources/Aimux/Types.swift
+++ b/bindings/swift/Sources/Aimux/Types.swift
@@ -924,6 +924,8 @@ public struct GenerateTextOptions: Codable, Equatable {
     public var providerOptions: JSONValue?
     public var reasoning: ReasoningEffort?
     public var instructions: String?
+    public var bodyOverrides: JSONValue?
+    public var maxRetries: UInt32?
 
     enum CodingKeys: String, CodingKey {
         case maxOutputTokens = "max_output_tokens"
@@ -939,6 +941,8 @@ public struct GenerateTextOptions: Codable, Equatable {
         case headers
         case providerOptions = "provider_options"
         case reasoning, instructions
+        case bodyOverrides = "body_overrides"
+        case maxRetries = "max_retries"
     }
 
     public init(maxOutputTokens: UInt32? = nil, temperature: Double? = nil,
@@ -947,13 +951,15 @@ public struct GenerateTextOptions: Codable, Equatable {
                 responseFormat: ResponseFormat? = nil, seed: UInt64? = nil,
                 tools: [Tool]? = nil, toolChoice: ToolChoice? = nil,
                 headers: [String: String]? = nil, providerOptions: JSONValue? = nil,
-                reasoning: ReasoningEffort? = nil, instructions: String? = nil) {
+                reasoning: ReasoningEffort? = nil, instructions: String? = nil,
+                bodyOverrides: JSONValue? = nil, maxRetries: UInt32? = nil) {
         self.maxOutputTokens = maxOutputTokens; self.temperature = temperature
         self.stopSequences = stopSequences; self.topP = topP; self.topK = topK
         self.presencePenalty = presencePenalty; self.frequencyPenalty = frequencyPenalty
         self.responseFormat = responseFormat; self.seed = seed; self.tools = tools
         self.toolChoice = toolChoice; self.headers = headers; self.providerOptions = providerOptions
         self.reasoning = reasoning; self.instructions = instructions
+        self.bodyOverrides = bodyOverrides; self.maxRetries = maxRetries
     }
 }
 

--- a/rfc/0016-align-with-aisdk.md
+++ b/rfc/0016-align-with-aisdk.md
@@ -1,0 +1,147 @@
+# RFC-0016: 对齐 Vercel AI SDK 能力缺口
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-01
+> **Scope**: 系统对比 aimux 0.1.2 与 Vercel AI SDK (`@ai-sdk/openai` / `@ai-sdk/openai-compatible` / `@ai-sdk/provider` V4) 的接口与实现,识别能力缺口,并按优先级规划补齐路径
+> **Related**: [RFC-0009](0009-request-resilience.md) request resilience(retry/timeout,本 RFC 的 abortSignal/timeout 缺口与之相关),[RFC-0014](0014-logging.md) 统一日志体系(可观测性缺口依赖本 RFC 的 span 树)
+
+---
+
+## 1. 背景与动机
+
+### 1.1 为什么做这次对齐
+
+aimux 定位为 Rust 实现的 Vercel AI SDK 替代品,以统一的 provider 接口服务多语言绑定(Node/Python/Go/Java/Kotlin/Swift/Flutter)。在 0.1.2 修复 tool_result 字段别名和 reasoning_content 回传时,暴露出一个更深层的问题:**部分能力缺口不是单点 bug,而是系统性的接口/暴露不完整**。本 RFC 记录一次全面对齐调查的结果,作为后续补齐的依据。
+
+### 1.2 调查方法
+
+启动三个并行调查,分别覆盖:
+
+1. **OpenAI 兼容 provider 的接口与实现**——对比 `@ai-sdk/openai-compatible` / `@ai-sdk/openai` 的 CallOptions 字段、请求体构建、provider 特化、headers/proxy/fetch、Responses API
+2. **流式输出与 StreamPart 类型**——对比 V4 `LanguageModelV4StreamPart` 的 variant 完整性、usage/metadata 透传、abort/cancellation、错误处理、raw passthrough
+3. **Node binding 的 API 暴露**——对比 `generateText`/`streamText` 选项、provider 工厂能力、结果对象、abortSignal、maxRetries
+
+调查结论在三个维度上高度一致地收敛到同一批缺口。
+
+### 1.3 关键前提
+
+aimux 的 `openai` 模块**不是**薄封装的 openai-compatible 等价物,而是对标 `@ai-sdk/openai`(官方 OpenAI 包)的完整实现,并作为 Groq/DeepSeek/LiteLLM-proxy 等薄封装的基座。因此:
+
+- 对比 `@ai-sdk/openai-compatible` 时,aimux 在请求体字段上**普遍超出**(支持 `logit_bias`/`parallel_tool_calls`/`store`/`metadata`/`prediction`/`service_tier`/`prompt_cache_*` 等 OpenAI 专属字段,而 openai-compatible 都不支持)。
+- 真正的缺口集中在**通用可扩展性**、**几个 V4 标准字段**和 **binding 暴露层**上。
+
+---
+
+## 2. 缺口清单
+
+缺口按性质分两类:
+- **binding 暴露缺口**(易补):Rust core 已有能力,但 Node binding 没透出
+- **core 架构缺口**(需设计):core 本身缺失,需新增类型/接线
+
+### 2.1 高优先级(实际可用性硬伤)
+
+| # | 缺口 | Vercel | aimux | 性质 | 证据 |
+|---|------|--------|-------|------|------|
+| H1 | **abortSignal 取消** | ✅ `RequestOptions.abortSignal` | ❌ LLM 路径完全不支持 | core 架构(基础设施已就绪) | `CallOptions` 无 `abort_signal` 字段([options.rs:36-82](../aimux-core/src/options.rs#L36));`do_generate`/`do_stream` 硬编码 `abort_signal: None`([openai/model.rs:369](../aimux-providers/src/openai/model.rs#L369))。但 `AbortSignal` 类型已实现([shared.rs:84-114](../aimux-core/src/shared.rs#L84)),HTTP 层 `send_request` 已用 `tokio::select!` 响应取消([http.rs:324-335](../aimux-provider-utils/src/http.rs#L324)),`HttpRequest.abort_signal` 字段存在([http.rs:161](../aimux-provider-utils/src/http.rs#L161))且被 embedding/image/speech 等 media provider 使用——**唯独语言模型漏了** |
+| H2 | **maxRetries 不可配** | ✅ default 2,可设 0 关闭 | ❌ Node 无法关闭/调整 | binding 暴露 | Rust `RetryConfig`(max_retries=2,initial_delay=2s,backoff=2,尊重 retry-after,只重试 is_retryable)已实现并在 HTTP 层生效,但 Node 工厂([lib.rs:165](../bindings/node/src/lib.rs#L165))和 `GenerateTextOptions`([generate.rs:37-55](../aimux-core/src/generate.rs#L37))都没透出。"无法关闭重试"对测试和延迟敏感场景是真实痛点 |
+| H3 | **timeout** | ✅ 丰富 `TimeoutConfiguration`(totalMs/stepMs/firstChunkMs/chunkMs/toolMs) | ❌ 无任何超时控制 | core 架构 | 无对应字段或实现 |
+| H4 | **多步工具循环(agent)** | ✅ steps/stopWhen/toolResults/prepareStep/activeTools | ❌ 单次调用,不执行工具 | core 架构 | aimux `generate_text`/`stream_text` 是单次调用,只返回 tool_calls,无 tool_results/steps。无自动多步 agent 循环 |
+
+### 2.2 中优先级(影响完整度/易用性)
+
+| # | 缺口 | Vercel | aimux | 性质 | 证据 |
+|---|------|--------|-------|------|------|
+| M1 | **工厂级 headers/org/project/retry 未透出** | ✅ `createOpenAI({headers, organization, project})` | ❌ 工厂签名只有 `(apiKey, modelId, baseUrl)` | binding 暴露 | Rust `OpenAIConfig` 的 `with_headers`/`with_org_id`/`with_project`/`with_retry_config` 全有([openai/mod.rs:94-167](../aimux-providers/src/openai/mod.rs#L94)),Node napi 工厂([lib.rs:165](../bindings/node/src/lib.rs#L165))只透 3 参。AnthropicConfig 同理 |
+| M2 | **includeRawChunks / raw passthrough** | ✅ `LanguageModelV4CallOptions.includeRawChunks` | ❌ variant 已定义但未接线 | core | `StreamPart::Raw` variant 已存在([stream_part.rs:165](../aimux-core/src/stream_part.rs#L165)),但 provider 从不 emit;`CallOptions`/`GenerateTextOptions` 无 `include_raw_chunks` 字段。测试明确注释 "requires an `include_raw_chunks` option not present"([openai_model_test.rs:1522](../aimux-providers/tests/openai_model_test.rs#L1522)) |
+| M3 | **logprobs 请求** | ✅ `@ai-sdk/openai` | ❌ 只解析响应,不能请求 | core | aimux 在响应里解析 logprobs([types.rs:25-27](../aimux-providers/src/openai/types.rs#L25)、[model.rs:310-316](../aimux-providers/src/openai/model.rs#L310)),但 `build_request_body` 从不写入 `logprobs`/`top_logprobs`([convert.rs:1098-1329](../aimux-providers/src/openai/convert.rs#L1098))。注:openai-compatible 同样不支持,仅相对 `@ai-sdk/openai` 是缺口 |
+| M4 | **通用 providerOptions 透传** | ✅ openai-compatible 把未知 key 透传 | ❌ 只发硬编码白名单 key | core | Vercel openai-compatible 把 `providerOptions[provider]` 下所有未知 key 过滤已知项后直接铺进请求体([openai-compatible-chat-language-model.ts:297-307](../reference/ai/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts#L297))。aimux 只发送硬编码白名单,用户无法通过 providerOptions 发送任意新 API 参数 |
+| M5 | **transformRequestBody 通用钩子** | ✅ 通用 `transformRequestBody` | ❌ 仅 DeepSeek 封闭枚举 | core | aimux `RequestBodyOverride` 是封闭枚举(仅 `DeepSeek`),([openai/mod.rs:52-55](../aimux-providers/src/openai/mod.rs#L52)),第三方代理/厂商无法自定义请求体变换 |
+| M6 | **自定义 fetch / proxy** | ✅ `FetchFunction` + 显式 proxy | ❌ 共享 reqwest client | core 架构 | aimux 用进程级共享 reqwest client([model.rs:33](../aimux-providers/src/openai/model.rs#L33)),无法注入自定义 fetch/中间件;proxy 仅靠 reqwest 默认读取 `HTTP_PROXY`/`HTTPS_PROXY` 环境变量 |
+| M7 | **顶层结果聚合**(reasoning/files/sources/responseMessages) | ✅ 顶层便捷字段 | ⚠️ 数据在 `raw` 里 | core | 非流式 reasoning 藏在 `raw.content`(GenerateContent::Reasoning),未提取到顶层;files/sources 同理。无 `responseMessages`(无法直接把结果回填为下一轮消息) |
+| M8 | **StreamPart 缺 3 个 variant** | ✅ | ❌ | core | 缺 `tool-approval-request`(provider-executed 工具审批流)、`custom`(provider 专有内容块)、`reasoning-file`(推理产物中的文件);`source` 无法表达 `document` 子类型(缺 mediaType/filename) |
+| M9 | **stream-start warnings 被丢弃** | ✅ 透传 unsupported/deprecated 警告 | ❌ 恒为空 `vec![]` | core | `build_request_body_with_warnings_fallible` 计算出 warnings,但 `execute_stream` 丢弃,`StreamStart{warnings:vec![]}` |
+| M10 | **usage.raw 未填充** | ✅ `raw: usage` | ❌ 写死 None | core | `convert_usage` 把 `raw` 写死 None([model.rs:111-126](../aimux-providers/src/openai/model.rs#L111)),丢失 provider 原始 usage(额外字段无法透传) |
+| M11 | **streamText 高层聚合器** | ✅ `.text`/`.fullStream`/`.toUIMessageStream()`/`.consumeStream()` | ❌ 只 yield 原始 StreamPart | binding | `streamText` 只 `yield` 原始 StreamPart,缺少高层聚合 |
+| M12 | **结构化 output / generateObject** | ✅ | ❌ | core | 只有 `response_format` JSON,无类型化 `output` 返回路径 |
+| M13 | **生命周期 callbacks** | ✅ onStart/onStepStart/onStepFinish/onEnd/onToolExecution* | ❌ | core | 无生成生命周期回调 |
+
+### 2.3 低优先级
+
+| # | 缺口 | Vercel | aimux | 证据 |
+|---|------|--------|-------|------|
+| L1 | `response-metadata.timestamp` 恒 None | ✅ 用 `created*1000` 填充 | ❌ | [stream_part.rs](../aimux-core/src/stream_part.rs) |
+| L2 | `tool-call.input` 类型为 `Value`(解析后 JSON) vs V4 规范的 `string` | ✅ string | ⚠️ Value | 可能是 aimux 有意设计(Node 侧消费更友好),非确认缺口 |
+| L3 | supportsStructuredOutputs / includeUsage 可配置化 | ✅ | ❌ 硬编码 | [openai/mod.rs](../aimux-providers/src/openai/mod.rs) |
+| L4 | env 自动读取 apiKey/baseUrl | ✅ `OPENAI_API_KEY`/`OPENAI_BASE_URL` | ❌ Node 强制传参(Rust 有 `from_env()` 但 Node 未用) | [lib.rs:165](../bindings/node/src/lib.rs#L165) |
+| L5 | telemetry | ✅ | ❌ | — |
+| L6 | toolApproval | ✅ | ❌ | — |
+| L7 | queryParams / errorStructure / supportedUrls / metadataExtractor / convertUsage | ✅ | ❌ | [openai-compatible-provider.ts:49-118](../reference/ai/packages/openai-compatible/src/openai-compatible-provider.ts#L49) |
+
+---
+
+## 3. 已对齐的能力(确认无缺口)
+
+为避免重复劳动,记录已经对齐或超出的能力:
+
+### 3.1 CallOptions 字段(完整对齐)
+`prompt`、`max_output_tokens`、`temperature`、`top_p`、`top_k`(aimux 比 openai-compatible 更强——后者只发 warning)、`stop_sequences`、`presence_penalty`、`frequency_penalty`、`seed`、`response_format`、`tools`(含 strict)、`tool_choice`、`headers`(per-request)、`provider_options`、`reasoning`(7 个变体与 V4 完全对齐)、`instructions`。
+
+### 3.2 请求体字段(超出 openai-compatible)
+aimux 已发送:`model`、`messages`、`stream`+`stream_options`(include_usage)、`top_k`、`max_tokens`/`max_completion_tokens`(reasoning 感知)、`temperature`/`top_p`/`frequency_penalty`/`presence_penalty`(reasoning 剥离)、`stop`、`seed`、`response_format`、`logit_bias`、`user`、`parallel_tool_calls`、`verbosity`、`store`、`metadata`、`prediction`、`prompt_cache_*`、`safety_identifier`、`reasoning_effort`、`service_tier`(含 flex/priority 校验)、`tools`/`tool_choice`、DeepSeek `thinking` override。
+
+### 3.3 usage 解析(颗粒度更细)
+`TokenUsage` 字段齐全(noCache/cacheRead/cacheWrite + reasoning/text 拆分),`convert_usage` 正确计算 cached_tokens(含 Moonshot 顶层格式)、cacheWrite、noCache。比 openai-compatible 更完整。
+
+### 3.4 StreamPart 核心类型(基本对齐)
+`text-start/delta/end`、`reasoning-start/delta/end`、`tool-input-start/delta/end`、`tool-call`、`tool-result`、`file`、`source`(url)、`finish`、`error`、`stream-start`、`response-metadata`、`raw`(variant 存在)均有定义。覆盖度优于或持平 Vercel。
+
+### 3.5 Responses API(已实现且超出)
+aimux 的 `OpenAIResponsesModel`([responses/mod.rs](../aimux-providers/src/openai/responses/mod.rs))已实现 `do_generate`/`do_stream`,支持 input 数组、instructions、store、previous_response_id、reasoning(effort/summary)、response_format、流式主链路 + function_call_arguments + reasoning_summary_text。**openai-compatible 无 Responses API,aimux 在此项超出**。
+
+### 3.6 retry 机制(已实现)
+`RetryConfig`(max_retries=2,initial_delay=2s,backoff=2,尊重 retry-after,只重试 is_retryable)已实现并在 HTTP 层生效。缺口仅在 binding 未透出(H2)。
+
+---
+
+## 4. 补齐路径(按优先级)
+
+### 第一批:低风险、高收益(binding 暴露层,core 不动)
+
+可放进下一个 patch 版本(0.1.3),不破坏兼容:
+
+- **M1** 工厂函数加 options 对象:Node `openai()`/`deepseek()`/`anthropic()` 等工厂接收可选 `{ headers, organization, project, maxRetries }`,透传到 Rust 的 `with_headers`/`with_org_id`/`with_project`/`with_retry_config`
+- **H2** `GenerateTextOptions` 加 `max_retries` 字段,透传到 per-call RetryConfig 覆盖
+- **L4**(顺带)Node 工厂支持 env 自动读取 apiKey/baseUrl
+
+预计改动:`bindings/node/src/lib.rs`(工厂签名)+ `aimux-core/src/generate.rs`(`GenerateTextOptions` 加字段)+ 同步 TS 类型。无 core 行为变化。
+
+### 第二批:中等 core 改动
+
+- **H1** abortSignal 接线:基础设施已就绪,改动集中在 `CallOptions`/`GenerateTextOptions` 加 `abort_signal` 字段 + `do_generate`/`do_stream` 传参 + Node napi 把 JS `AbortSignal` 桥接为 native `AbortSignal`(tokio `CancellationToken`)。其他模型 trait 已有此字段,语言模型只需对齐
+- **M2** includeRawChunks 接线:`CallOptions` 加 `include_raw_chunks`,provider do_stream 在 `include_raw_chunks=true` 时 emit `StreamPart::Raw`
+- **M9** stream-start warnings 透传:`execute_stream` 把 `build_request_body_with_warnings_fallible` 的 warnings 传入 `StreamStart`
+- **M10** usage.raw 填充:`convert_usage` 保留原始 usage JSON
+
+### 第三批:架构性(需设计)
+
+- **H3** timeout:设计 `TimeoutConfiguration`(参考 Vercel 的 totalMs/firstChunkMs/chunkMs)
+- **M4/M5** 通用 providerOptions 透传 + transformRequestBody 钩子:从白名单改为"已知项特殊处理 + 未知项透传",并开放 `RequestBodyOverride` 为闭包/trait
+- **M6** 自定义 fetch / proxy:设计注入点(reqwest client builder 或 trait 抽象)
+- **H4** 多步工具循环:设计 agent 层(steps/stopWhen/toolResults/responseMessages/callbacks),这是最大的架构增量
+- **M7/M11/M12/M13** 顶层结果聚合、streamText 聚合器、结构化 output、callbacks:依赖多步循环或独立设计
+
+---
+
+## 5. 与已有 RFC 的关系
+
+- **RFC-0009(request resilience)**:retry 已落地,timeout 是本 RFC H3 的前置;abortSignal(H1)与 retry 正交但同属"请求生命周期控制"
+- **RFC-0014(logging)**:可观测性缺口(retry 是否生效、流式断点诊断)依赖本 RFC 的能力补齐后才有意义;abortSignal 的取消事件也需日志埋点
+
+---
+
+## 6. 开放问题
+
+1. **H1 abortSignal 的 napi 桥接**:JS `AbortSignal` → Rust `AbortSignal` 的最佳桥接方式需验证(napi 的 `tokio_rt` feature + `CancellationToken`)。其他模型 trait 已有 `abort_signal` 字段,但 Node 是否已为它们桥接过 signal 需确认。
+2. **L2 tool-call.input 类型**:aimux 用 `Value`(解析后 JSON)而非 V4 规范的 `string`。需确认是否回归 V4 的 string 形态,还是保留为 aimux 的有意设计(Node 侧消费更友好)。
+3. **M4 通用 providerOptions 透传的安全边界**:从白名单改为透传后,需确保不会把内部字段(如 `prompt_cache_breakpoint` 已在白名单)重复发送。
+4. **H4 多步工具循环的范围**:是否对标 Vercel `generateText` 的完整多步(stopWhen/maxSteps/prepareStep/activeTools/toolOrder/refineToolInput/repairToolCall),还是先做最小可用版(tools 自动执行 + steps)。

--- a/rfc/0017-provider-config-dx.md
+++ b/rfc/0017-provider-config-dx.md
@@ -1,0 +1,321 @@
+# RFC-0017: 统一 provider 配置与 request override(DX 提升)
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-01
+> **Scope**: 统一 aimux 的 provider 配置层——把 Rust core 已有但 Node 未透出的能力(headers/org/project/retry)暴露出来,引入通用 `bodyOverrides`(JSON deep merge)替代闭包式 transform,并为 Qwen/Kimi/GLM 等厂商的思考开关提供可扩展的特化机制
+> **Related**: [RFC-0016](0016-align-with-aisdk.md) 对齐 Vercel AI SDK 能力缺口(本 RFC 补齐 M1/M5 + 厂商思考开关特化),[RFC-0009](0009-request-resilience.md) retry(本 RFC 透出 maxRetries)
+
+---
+
+## 1. 背景与动机
+
+### 1.1 问题
+
+aimux 的 Rust core 实现度很高(`OpenAIConfig` 有 headers/org/project/retry 的 builder,`apply_deepseek_override` 实现了 DeepSeek 的 thinking 字段),但存在两个 DX 断层:
+
+1. **Node binding 不透出**:工厂函数 `openai(apiKey, modelId, baseUrl?)` 只有 3 个参数,Rust 的 `with_headers`/`with_org_id`/`with_project`/`with_retry_config` 全部用不到。用户无法设全局 header、无法关闭重试、无法设 org/project。
+2. **厂商特化封闭**:`RequestBodyOverride` 是封闭枚举(只有 `DeepSeek`),Qwen/Kimi/GLM 等厂商的思考开关(`enable_thinking`/`thinking_budget`/`thinking:{type}`)无法在不改 Rust 源码的情况下接入。
+
+### 1.2 为什么不用闭包式 transformRequestBody
+
+Vercel AI SDK 的 `createOpenAICompatible` 提供了 `transformRequestBody: (body) => body` 闭包钩子。但在 aimux(Rust core + napi binding)中桥接 JS 闭包到 Rust `Box<dyn Fn>` 需要 napi `ThreadsafeFunction` + JSON 序列化往返,复杂度高且性能差。
+
+分析 Vercel `transformRequestBody` 的实际用途(Fireworks 为例),闭包做的三件事:
+- **删除字段**(删 `reasoningHistory`/`promptCacheKey` 等)——这些字段是 Vercel providerOptions 注入的,aimux 不注入就不需要删
+- **重命名字段**(`promptCacheKey`→`prompt_cache_key`)——aimux 的 `convert.rs` 已在构建时做了正确的字段命名
+- **条件映射**(`minimal`→`low`,`xhigh`→`high`)——aimux 的 Groq profile 已内置
+
+结论:闭包的"独家能力"(删除、条件逻辑)在 aimux 架构下由内置 profile 处理更合适。用户真正需要的是**注入/覆盖字段**——这用一个 JSON 对象 deep merge 就能实现,纯数据,不需要跨语言函数桥接。
+
+### 1.3 设计原则
+
+- **简单优先**:纯 JSON 数据,不引入闭包/函数桥接
+- **两级覆盖**:provider 级(每次请求) + per-call 级(单次),后者在前者之后 merge
+- **内置特化 + 用户兜底**:厂商思考开关由内置 `RequestBodyOverride` 处理(带 warnings),用户 `bodyOverrides` 做兜底注入
+
+---
+
+## 2. 设计
+
+### 2.1 Provider 工厂:options 对象(透出 Rust 能力)
+
+把工厂函数从固定参数改为接收可选的 options 对象,向后兼容:
+
+```ts
+// 之前
+openai(apiKey: string, modelId: string, baseUrl?: string): Promise<Model>
+
+// 之后(向后兼容:第 3 参数既接受 string 也接受 options 对象)
+openai(apiKey: string, modelId: string, config?: string | ProviderConfig): Promise<Model>
+
+interface ProviderConfig {
+  baseUrl?: string
+  headers?: Record<string, string>
+  organization?: string        // OpenAI 专属
+  project?: string             // OpenAI 专属
+  maxRetries?: number          // 0 = 关闭重试
+  bodyOverrides?: Record<string, any>   // 请求体覆盖(provider 级,每次请求 merge)
+}
+```
+
+向后兼容策略:napi 层第 3 参数为 `Option<Either<String, ProviderConfigObj>>`。string 走旧路径,对象展开各字段。
+
+### 2.2 bodyOverrides:JSON deep merge
+
+#### Rust 层
+
+`OpenAIConfig` 和 `CallOptions` 各加一个 `body_overrides` 字段:
+
+```rust
+pub struct OpenAIConfig {
+    // ... 现有字段 ...
+    /// 请求体覆盖(provider 级)。在标准请求体 + 内置 override 之后 deep merge。
+    pub body_overrides: Option<Value>,
+}
+
+pub struct CallOptions {
+    // ... 现有字段 ...
+    /// 请求体覆盖(per-call 级)。在 provider 级 body_overrides 之后 deep merge。
+    pub body_overrides: Option<Value>,
+}
+```
+
+`build_request_body` 末尾执行顺序:
+
+```rust
+// 1. 标准 OpenAI 请求体构建(convert.rs 已有)
+// 2. 内置厂商特化(DeepSeek/Qwen/Kimi... 的 RequestBodyOverride)
+if let Some(ref override_kind) = profile.request_body_override { ... }
+
+// 3. provider 级 body_overrides(deep merge)
+if let Some(ref overrides) = provider_body_overrides {
+    deep_merge_json(&mut body, overrides);
+}
+
+// 4. per-call body_overrides(deep merge,覆盖 provider 级)
+if let Some(ref overrides) = options.body_overrides {
+    deep_merge_json(&mut body, overrides);
+}
+```
+
+#### deep merge 语义
+
+```rust
+/// 递归合并两个 JSON 对象。`patch` 中的值覆盖 `target`:
+/// - 对象:递归合并
+/// - 标量/数组:覆盖
+/// - null:删除 target 中对应的 key(显式删除能力)
+fn deep_merge_json(target: &mut Value, patch: &Value) {
+    match (target, patch) {
+        (Value::Object(t), Value::Object(p)) => {
+            for (k, v) in p {
+                match v {
+                    Value::Null => { t.remove(k); }  // null = 删除
+                    _ => {
+                        deep_merge_json(t.entry(k).or_insert(Value::Null), v);
+                    }
+                }
+            }
+        }
+        (target, patch) => *target = patch.clone(),  // 标量/数组:覆盖
+    }
+}
+```
+
+`null = 删除` 是唯一需要的"闭包能力"——用户可以用 `{ "reasoning_effort": null }` 删除某个字段。这覆盖了 Vercel 闭包删除字段的场景,且无需函数桥接。
+
+#### Node 层
+
+```ts
+// GenerateTextOptions 也加 bodyOverrides(per-call)
+interface GenerateTextOptions {
+  // ... 现有字段 ...
+  maxRetries?: number
+  bodyOverrides?: Record<string, any>
+}
+```
+
+### 2.3 厂商思考开关:内置特化
+
+#### 新增 RequestBodyOverride variants
+
+```rust
+pub enum RequestBodyOverride {
+    DeepSeek,       // 已有
+    /// Qwen: enable_thinking: bool + thinking_budget
+    Qwen,
+    /// Kimi (Moonshot): thinking_budget(0 = 关闭)
+    Kimi,
+    /// GLM/Zhipu + MiMo/Minimax: thinking: {type: "enabled"|"disabled"}
+    ThinkingToggle,
+}
+```
+
+统一实现(复用 `reasoning → thinking` 映射):
+
+```rust
+fn apply_vendor_override(body: &mut Value, warnings: &mut Vec<Warning>,
+                         options: &CallOptions, vendor: RequestBodyOverride) {
+    match vendor {
+        RequestBodyOverride::DeepSeek => apply_deepseek_override(body, warnings, options),
+        RequestBodyOverride::Qwen => {
+            if options.reasoning == Some(ReasoningEffort::None) {
+                body["enable_thinking"] = json!(false);
+            } else if let Some(r) = options.reasoning {
+                if r != ReasoningEffort::ProviderDefault {
+                    body["enable_thinking"] = json!(true);
+                    body["thinking_budget"] = json!(effort_to_budget(r));
+                }
+            }
+        }
+        RequestBodyOverride::Kimi => {
+            if options.reasoning == Some(ReasoningEffort::None) {
+                body["thinking_budget"] = json!(0);
+            }
+        }
+        RequestBodyOverride::ThinkingToggle => {
+            // 与 DeepSeek 同形: thinking: {type: "enabled"|"disabled"}
+            if options.reasoning == Some(ReasoningEffort::None) {
+                body["thinking"] = json!({ "type": "disabled" });
+            } else if options.reasoning != Some(ReasoningEffort::ProviderDefault) {
+                body["thinking"] = json!({ "type": "enabled" });
+            }
+        }
+    }
+}
+```
+
+#### providerOptions 细粒度控制
+
+用户也可通过 `providerOptions` 传厂商原汁原味的参数(优先级高于顶层 reasoning,由 override 函数读取):
+
+```ts
+// 方式 1:顶层 reasoning(跨厂商通用)
+generateText(model, prompt, { reasoning: "none" })
+
+// 方式 2:providerOptions(厂商原汁原味)
+generateText(model, prompt, {
+  provider_options: { qwen: { enable_thinking: false } }
+})
+
+// 方式 3:bodyOverrides(任意字段注入/覆盖)
+generateText(model, prompt, {
+  bodyOverrides: { enable_thinking: false, thinking_budget: 4096 }
+})
+```
+
+### 2.4 maxRetries(per-call)
+
+`GenerateTextOptions` 和 `CallOptions` 新增 `max_retries`:
+
+```rust
+pub struct GenerateTextOptions {
+    // ... 现有字段 ...
+    pub max_retries: Option<u32>,
+}
+```
+
+在 `generate_text`/`stream_text` 入口,如果 `max_retries` 非 None,覆盖 provider config 的 `RetryConfig.max_retries`。
+
+### 2.5 统一的 DX 形态
+
+```ts
+import { openai, generateText } from 'aimux'
+
+// 1. 标准厂商:options 对象配置
+const model = await openai(apiKey, 'gpt-4o', {
+  headers: { 'X-Custom': 'value' },
+  organization: 'org-xxx',
+  maxRetries: 0,
+})
+
+// 2. relay:bodyOverrides 注入 relay 专属字段(provider 级)
+const relay = await openai(apiKey, 'deepseek-v4-flash', {
+  baseUrl: 'https://my-relay.dev/v1',
+  bodyOverrides: { 'X-Relay-Tag': 'my-team' },
+})
+
+// 3. Qwen 等厂商:顶层 reasoning 统一控制思考(内置特化)
+const qwen = await openai(apiKey, 'qwen3-coder', {
+  baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+})
+await generateText(qwen, prompt, { reasoning: 'none' })  // → enable_thinking: false
+
+// 4. 任意厂商:per-call bodyOverrides 精细覆盖
+await generateText(model, prompt, {
+  bodyOverrides: {
+    enable_thinking: false,        // 注入
+    temperature: 0.5,              // 覆盖
+    'reasoning_effort': null,      // 删除
+  },
+})
+```
+
+---
+
+## 3. 实现计划
+
+### 阶段 1: binding 透出 + bodyOverrides(低风险)
+
+**改动**:
+- `aimux-core/src/options.rs` — `CallOptions` 加 `body_overrides`、`max_retries`
+- `aimux-core/src/generate.rs` — `GenerateTextOptions` 加同名字段;`into_call_options` 透传
+- `aimux-providers/src/openai/mod.rs` — `OpenAIConfig` 加 `body_overrides` + `with_body_overrides` builder
+- `aimux-providers/src/openai/convert.rs` — 新增 `deep_merge_json`;`build_request_body` 末尾 merge(provider 级 + per-call 级)
+- `aimux-core/src/util.rs`(或新文件)— `deep_merge_json` 工具函数
+- `bindings/node/src/lib.rs` — 工厂函数第 3 参数改 `Option<Either<String, ProviderConfigObj>>`
+- `bindings/node/src/types/` — 新增/更新类型
+
+### 阶段 2: 厂商思考开关特化(中等 core 改动)
+
+**改动**:
+- `aimux-providers/src/openai/mod.rs` — `RequestBodyOverride` 加 `Qwen`/`Kimi`/`ThinkingToggle`
+- `aimux-providers/src/openai/convert.rs` — 新增 `apply_vendor_override`,match 分发
+- `aimux-providers/src/openai_compat_registry.rs` — Qwen/Kimi/GLM 厂商声明改用新 profile
+- `aimux-providers/tests/` — 新增厂商思考开关测试
+
+---
+
+## 4. 向后兼容
+
+| 变更 | 兼容性 | 说明 |
+|------|--------|------|
+| 工厂第 3 参数 `string → string \| object` | ✅ | 旧代码传 string 不受影响 |
+| `GenerateTextOptions` 加 `max_retries`/`body_overrides` | ✅ | 新字段默认 None |
+| `RequestBodyOverride` 加新 variants | ✅ | 枚举加 variant 不破坏现有 DeepSeek 分支 |
+| `OpenAIConfig` 加 `body_overrides` | ✅ | 默认 None |
+
+---
+
+## 5. 待支持的厂商思考开关(清单)
+
+| 厂商 | 关闭思考的 wire 参数 | 实现方式 | 状态 |
+|------|---------------------|---------|------|
+| DeepSeek | `thinking: {type: "disabled"}` | `RequestBodyOverride::DeepSeek` | ✅ 已实现 |
+| OpenAI 官方 | `reasoning_effort: "none"` | 通用路径 | ✅ 已实现 |
+| Anthropic | thinking config disabled | 独立 convert | ✅ 已实现 |
+| Groq | 跳过 reasoning_effort | `groq()` profile | ✅ 已实现 |
+| **Qwen** | `enable_thinking: false` | `RequestBodyOverride::Qwen`(阶段 2) | 🔲 待支持 |
+| **Kimi (Moonshot)** | `thinking_budget: 0` | `RequestBodyOverride::Kimi`(阶段 2) | 🔲 待支持 |
+| **GLM/Zhipu** | `thinking: {type: "disabled"}` | `RequestBodyOverride::ThinkingToggle`(阶段 2) | 🔲 待支持 |
+| **MiMo/Minimax** | `thinking: {type: "disabled"}` | `RequestBodyOverride::ThinkingToggle`(阶段 2) | 🔲 待支持 |
+| **任意厂商/relay** | 用户自定义 | `bodyOverrides`(阶段 1) | 🔲 待支持 |
+
+---
+
+## 6. 与 RFC-0016 的关系
+
+本 RFC 补齐 RFC-0016 中的:
+- **M1**(工厂级 headers/org/project/retry 未透出)→ 阶段 1
+- **M5**(transformRequestBody 通用钩子)→ 阶段 1(简化为 `bodyOverrides` JSON merge)
+- **H2**(maxRetries 不可配)→ 阶段 1
+- 新增:厂商思考开关特化(Qwen/Kimi/GLM/MiMo)→ 阶段 2
+
+---
+
+## 7. 开放问题
+
+1. **deep merge 中 null=删除**:是否需要?Fireworks 用闭包删字段,aimux 不注入那些字段所以一般不需要删。但 `null=删除` 成本极低(一行 match),且给用户显式删除能力,建议保留。
+2. **GLM 与 DeepSeek 同形**:`thinking:{type}` 格式相同,合并为 `ThinkingToggle` 还是按厂商分开?建议合并(格式相同,差异由 profile 其他字段表达)。
+3. **Qwen thinking_budget 档位映射**:`reasoning` 的 7 档映射到 `thinking_budget` 的具体 token 数需查 Qwen 文档确认。
+4. **bodyOverrides 是否够用**:相比 Vercel 闭包,merge body 不能做"读取 body 中某字段值后条件变换"。但这种逻辑性特化由内置 profile 做,用户层只需注入/覆盖——merge 够用。


### PR DESCRIPTION
## 概述

两份 RFC 文档,后续实现基于此。

### RFC-0016: 对齐 Vercel AI SDK 能力缺口

系统对比 aimux 0.1.2 与 Vercel AI SDK (`@ai-sdk/openai` / `@ai-sdk/openai-compatible` / `@ai-sdk/provider` V4),覆盖三个维度:
- OpenAI 兼容 provider 的接口与实现(CallOptions 字段、请求体、provider 特化、Responses API)
- 流式输出与 StreamPart 类型完整性
- Node binding 的 API 暴露

按优先级分档:
- **高**:abortSignal、maxRetries 不可配、timeout、多步工具循环
- **中**:工厂级 headers/org/project/retry 未透出、includeRawChunks、logprobs 请求、通用 providerOptions 透传、StreamPart 缺 3 个 variant 等
- **低**:timestamp、env 自动读取、telemetry 等

同时确认已对齐能力(CallOptions 字段、请求体字段、usage 解析、StreamPart 核心、Responses API、retry),避免重复劳动。

### RFC-0017: 统一 provider 配置与 request override(DX 提升)

设计目标:把 Rust core 已有但 Node 未透出的能力暴露出来,引入通用请求体覆盖机制。

**核心设计决策:用 `bodyOverrides`(JSON deep-merge)而非闭包式 `transformRequestBody`。**

原因:aimux 服务 7 种语言(Node/Python/Go/Java/Kotlin/Swift/Flutter),其中 6 种走 C ABI(JSON 字符串边界),闭包无法跨语言传递。Vercel 能用闭包是因为只有 JS/TS 一种语言。`bodyOverrides` 是纯 JSON,7 种语言零成本透传。

设计要点:
- **工厂 options 对象**:第 3 参数 `string | ProviderConfig`(向后兼容),透出 headers/org/project/maxRetries/bodyOverrides
- **bodyOverrides deep-merge**:对象递归合并,标量覆盖,`null=删除`;provider 级 + per-call 级,last-wins
- **厂商思考开关特化**:`RequestBodyOverride` 加 Qwen/Kimi/GLM/MiMo variants,顶层 `reasoning: "none"` 统一映射
- **maxRetries per-call**:`GenerateTextOptions` 加字段,覆盖 provider 默认

实现分两阶段:
1. 阶段 1:binding 透出 + bodyOverrides + maxRetries(低风险)
2. 阶段 2:厂商思考开关特化(Qwen/Kimi/GLM/MiMo)

## 改动

仅文档,无代码改动。

- \`rfc/0016-align-with-aisdk.md\` — 缺口分析
- \`rfc/0017-provider-config-dx.md\` — DX 设计

## 测试

无(纯文档)。