### PR TITLE
feat(node): publish bindings for six desktop targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,40 @@ jobs:
       - name: Test workspace
         run: cargo test --workspace
 
-  # ── Node binding: build + test (main platforms) ─────────────────────────────
+  # ── Node binding: build all desktop targets, test on native hosts ───────────
   node-binding:
     name: Node binding (${{ matrix.settings.target }})
     runs-on: ${{ matrix.settings.host }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     strategy:
       fail-fast: false
       matrix:
         settings:
-          - host: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: aimux.win32-x64-msvc.node
+            test: true
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            binary: aimux.win32-arm64-msvc.node
+            test: false
+          - host: macos-15-intel
+            target: x86_64-apple-darwin
+            binary: aimux.darwin-x64.node
+            test: true
           - host: macos-latest
             target: aarch64-apple-darwin
+            binary: aimux.darwin-arm64.node
+            test: true
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: aimux.linux-x64-gnu.node
+            test: true
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary: aimux.linux-arm64-gnu.node
+            test: false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -45,17 +67,53 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Install dependencies
         working-directory: bindings/node
-        run: npm install
+        run: npm ci
+      - name: Build Linux (glibc 2.17 baseline)
+        if: contains(matrix.settings.target, 'unknown-linux-gnu')
+        working-directory: bindings/node
+        shell: bash
+        env:
+          TARGET_CC: clang
+          TARGET_CXX: clang++
+        run: npx napi build --platform --target ${{ matrix.settings.target }} --use-napi-cross
       - name: Build
+        if: ${{ !contains(matrix.settings.target, 'unknown-linux-gnu') }}
+        working-directory: bindings/node
+        shell: bash
+        run: npx napi build --platform --target ${{ matrix.settings.target }}
+      - name: Verify artifact
+        working-directory: bindings/node
+        shell: bash
+        run: test -f '${{ matrix.settings.binary }}'
+      - name: Verify glibc baseline
+        if: contains(matrix.settings.target, 'unknown-linux-gnu')
         working-directory: bindings/node
         shell: bash
         run: |
-          npx napi build --platform --target ${{ matrix.settings.target }}
-          ls -la *.node 2>/dev/null || echo "WARNING: No .node files in root"
+          highest=$(readelf --version-info '${{ matrix.settings.binary }}' | grep -oE 'GLIBC_[0-9.]+' | sort -Vu | tail -1)
+          test -n "$highest"
+          test "$(printf '%s\n' GLIBC_2.17 "$highest" | sort -V | tail -1)" = GLIBC_2.17
+      - name: Verify static Windows CRT
+        if: contains(matrix.settings.target, 'windows-msvc')
+        working-directory: bindings/node
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $install = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $install) { throw 'Visual Studio C++ tools not found' }
+          $toolsVersion = (Get-Content "$install\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt").Trim()
+          $targetArch = if ('${{ matrix.settings.target }}' -like 'aarch64-*') { 'arm64' } else { 'x64' }
+          $dumpbin = "$install\VC\Tools\MSVC\$toolsVersion\bin\Hostx64\$targetArch\dumpbin.exe"
+          $dependencies = & $dumpbin /DEPENDENTS '${{ matrix.settings.binary }}' | Out-String
+          if ($LASTEXITCODE -ne 0) { throw 'dumpbin failed' }
+          if ($dependencies -match '(?im)^\s*(?:VCRUNTIME|MSVCP|UCRTBASE|api-ms-win-crt)[^\s]*\.dll\s*$') {
+            throw "Dynamic MSVC runtime dependency found:`n$dependencies"
+          }
       - name: Test
+        if: matrix.settings.test
         working-directory: bindings/node
         run: npm test
       - name: Upload artifact
@@ -170,7 +228,7 @@ jobs:
       - name: Build Node binding
         working-directory: bindings/node
         run: |
-          npm install
+          npm ci
           npx napi build --platform
       - name: Run Node contract tests
         working-directory: contract-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,15 +110,31 @@ jobs:
   node-build:
     name: Node build (${{ matrix.settings.target }})
     runs-on: ${{ matrix.settings.host }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     if: github.event_name == 'push' || github.event.inputs.node == 'true'
     strategy:
       fail-fast: false
       matrix:
         settings:
-          - host: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: aimux.win32-x64-msvc.node
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            binary: aimux.win32-arm64-msvc.node
+          - host: macos-15-intel
+            target: x86_64-apple-darwin
+            binary: aimux.darwin-x64.node
           - host: macos-latest
             target: aarch64-apple-darwin
+            binary: aimux.darwin-arm64.node
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: aimux.linux-x64-gnu.node
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary: aimux.linux-arm64-gnu.node
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -127,15 +143,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Install dependencies
         working-directory: bindings/node
-        run: npm install
-      - name: Build
+        run: npm ci
+      - name: Build Linux (glibc 2.17 baseline)
+        if: contains(matrix.settings.target, 'unknown-linux-gnu')
         working-directory: bindings/node
         shell: bash
-        run: |
-          npx napi build --platform --release --target ${{ matrix.settings.target }}
+        env:
+          TARGET_CC: clang
+          TARGET_CXX: clang++
+        run: npx napi build --platform --release --target ${{ matrix.settings.target }} --use-napi-cross
+      - name: Build
+        if: ${{ !contains(matrix.settings.target, 'unknown-linux-gnu') }}
+        working-directory: bindings/node
+        shell: bash
+        run: npx napi build --platform --release --target ${{ matrix.settings.target }}
+      - name: Verify artifact
+        working-directory: bindings/node
+        shell: bash
+        run: test -f '${{ matrix.settings.binary }}'
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -152,27 +180,43 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - name: Install dependencies
         working-directory: bindings/node
-        run: npm install
+        run: npm ci
+      - name: Create platform packages
+        working-directory: bindings/node
+        run: npx napi create-npm-dirs
       - name: Download platform binaries
         uses: actions/download-artifact@v4
         with:
-          path: bindings/node
+          path: bindings/node/artifacts
           pattern: node-*
-          merge-multiple: true
-      - name: Verify binaries
+      - name: Collect and verify platform packages
         working-directory: bindings/node
-        run: ls -la *.node
-      - name: Publish (napi prepublish + npm)
-        working-directory: bindings/node
+        shell: bash
         run: |
-          npx napi prepublish -t npm
-          npm publish --provenance --access public
+          npx napi artifacts --output-dir artifacts --npm-dir npm
+          expected=(
+            npm/win32-x64-msvc/aimux.win32-x64-msvc.node
+            npm/win32-arm64-msvc/aimux.win32-arm64-msvc.node
+            npm/darwin-x64/aimux.darwin-x64.node
+            npm/darwin-arm64/aimux.darwin-arm64.node
+            npm/linux-x64-gnu/aimux.linux-x64-gnu.node
+            npm/linux-arm64-gnu/aimux.linux-arm64-gnu.node
+          )
+          for binary in "${expected[@]}"; do
+            test -f "$binary" || { echo "Missing $binary" >&2; exit 1; }
+          done
+          test "$(find npm -type f -name 'aimux.*.node' | wc -l | tr -d ' ')" = 6
+      - name: Publish
+        working-directory: bindings/node
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+          NPM_CONFIG_ACCESS: public
 
   # ── Python binding: build + publish platform wheels (OIDC trusted) ───────
   python-release:

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,10 @@ bindings/python/**/*.egg-info/
 bindings/flutter/.dart_tool/
 bindings/flutter/.packages
 bindings/node/node_modules/
+bindings/node/artifacts/
+bindings/node/npm/
 bindings/node/bench/node_modules/
 bindings/node/bench/package-lock.json
-bindings/node/package-lock.json
 bindings/python/**/__pycache__/
 bindings/python/uv.lock
 bindings/kotlin/build/

--- a/bindings/node/.cargo/config.toml
+++ b/bindings/node/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/bindings/node/ava.config.js
+++ b/bindings/node/ava.config.js
@@ -1,4 +1,5 @@
 export default {
+  workerThreads: false,
   extensions: {
     ts: 'module',
   },

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,23 +1,15 @@
 {
   "name": "@arcships/aimux",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcships/aimux",
-      "version": "0.1.0",
-      "cpu": [
-        "x64",
-        "arm64"
-      ],
+      "version": "0.1.2",
       "license": "MIT",
-      "os": [
-        "darwin",
-        "linux"
-      ],
       "devDependencies": {
-        "@napi-rs/cli": "^3.8.0",
+        "@napi-rs/cli": "3.8.2",
         "ava": "^6.0.0",
         "typescript": "^5.5.0"
       },
@@ -485,9 +477,9 @@
       }
     },
     "node_modules/@napi-rs/cli": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmmirror.com/@napi-rs/cli/-/cli-3.8.0.tgz",
-      "integrity": "sha512-RagwLdCJ1LigZTe3fE5Bc+2a4sHDV+1IAxvyFlZf25qSQj8e2Sdc8xq2xyN2ydNokdfDN4DprGQkU1eBJJCl8w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.8.2.tgz",
+      "integrity": "sha512-iFmp3Lo/ipXoJI1I/6V/xU4hQV42bXS3A7j8C+Wt3LOtYY7HFCilkhyUkN1igLJFXWMICq95kNxhNcwzNRd+Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -7,16 +7,7 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "dist/",
-    "*.node"
-  ],
-  "os": [
-    "darwin",
-    "linux"
-  ],
-  "cpu": [
-    "x64",
-    "arm64"
+    "dist/"
   ],
   "repository": {
     "type": "git",
@@ -34,20 +25,26 @@
     "./package.json": "./package.json"
   },
   "napi": {
-    "name": "aimux",
-    "package": {
-      "name": "@arcships/aimux"
-    }
+    "binaryName": "aimux",
+    "packageName": "@arcships/aimux",
+    "targets": [
+      "x86_64-pc-windows-msvc",
+      "aarch64-pc-windows-msvc",
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu"
+    ]
   },
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "build:typed": "tsc -p tsconfig.json",
     "test": "ava",
-    "prepublishOnly": "npm run build:typed && napi prepublish -t npm"
+    "prepublishOnly": "npm run build:typed && napi prepublish -t npm --no-gh-release"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.8.0",
+    "@napi-rs/cli": "3.8.2",
     "ava": "^6.0.0",
     "typescript": "^5.5.0"
   },

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -19,6 +19,36 @@ const result = await generateText(model, 'What is Rust?')
 console.log(result.text)
 ```
 
+## Desktop and Electron compatibility
+
+The package ships one Node-API 8 binary per desktop OS and architecture. The
+root package selects a platform package at load time, so installers do not
+carry binaries for the other five targets.
+
+| OS | Architecture | Native package | Runtime baseline |
+|---|---|---|---|
+| Windows | x64 | `@arcships/aimux-win32-x64-msvc` | Static MSVC CRT; no Visual C++ Redistributable required |
+| Windows | ARM64 | `@arcships/aimux-win32-arm64-msvc` | Static MSVC CRT; no Visual C++ Redistributable required |
+| macOS | x64 | `@arcships/aimux-darwin-x64` | Addon deployment target 10.13; system frameworks only |
+| macOS | ARM64 | `@arcships/aimux-darwin-arm64` | Addon deployment target 11.0; system frameworks only |
+| Linux | x64 | `@arcships/aimux-linux-x64-gnu` | glibc 2.17 or newer |
+| Linux | ARM64 | `@arcships/aimux-linux-arm64-gnu` | glibc 2.17 or newer |
+
+The addon uses Node-API rather than Electron's version-specific native ABI, so
+it does not require an Electron-specific rebuild. Load it from the main process
+or a Node-enabled preload script. Keep npm optional dependencies enabled when
+installing, because the native platform package is an optional dependency.
+
+When packaging with ASAR, keep native addons unpacked:
+
+```yaml
+asarUnpack:
+  - '**/*.node'
+```
+
+Linux musl distributions such as Alpine are not included in the six desktop
+targets. The GNU/Linux builds use rustls and do not require system OpenSSL.
+
 ## Text Generation
 
 Non-streaming text generation; returns the complete result.


### PR DESCRIPTION
## Summary

This PR expands the Node.js binding from two desktop targets to six platform-specific Node-API packages:

- Windows x64 and ARM64 (MSVC)
- macOS x64 and ARM64
- GNU/Linux x64 and ARM64

The root @arcships/aimux package now selects the matching optional platform package at install/load time, so users only receive the native binary for their current platform. Because the addon targets Node-API 8, the same binaries can be used by compatible Node.js and Electron releases without an Electron-specific rebuild.

### Build and release changes

- Add all six targets to the CI and release matrices.
- Build GNU/Linux artifacts against a glibc 2.17 baseline with napi-cross, and verify the resulting symbol ceiling.
- Statically link the MSVC CRT for both Windows targets, and verify that generated binaries do not import a dynamic MSVC/UCRT runtime.
- Set the macOS deployment target and build both Intel and Apple Silicon artifacts on native runners.
- Generate napi-rs platform package directories, collect all downloaded artifacts into them, and require exactly six native binaries before publishing.
- Use Node.js 24 and reproducible npm ci installs in binding workflows.
- Track package-lock.json, pin @napi-rs/cli to 3.8.2, and ignore generated artifacts/ and npm/ directories.

### Runtime and documentation changes

- Disable AVA worker threads to avoid napi-rs/Tokio teardown panics during the existing binding test suite.
- Document per-platform package names and runtime baselines.
- Document Electron main/preload usage, ASAR unpacking, and the requirement to keep npm optional dependencies enabled.
- Clarify that musl-based Linux distributions are outside the current target set.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] New provider
- [x] New / updated binding
- [x] Docs / RFC

## Checklist

- [x] cargo fmt --all -- --check passes
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] cargo test --workspace passes (cassette playback — no network/keys)
- [x] No cassette or contract fixture update is needed; this is a packaging/build change and the existing contract tests pass
- [x] Updated relevant Node binding documentation
- [x] Commit messages follow Conventional Commits

## Validation

The complete CI suite passed on the source branch, including builds for all six Node binding targets.

Native-host binding tests passed on:

- Windows x64
- macOS x64
- macOS ARM64
- GNU/Linux x64

Windows ARM64 and GNU/Linux ARM64 are cross-compiled and artifact-verified, but are not presented as native runtime-tested.

Additional Windows x64 validation:

- Loaded 24 native exports with Node.js 24.15.0 and Electron 40.10.5
- Passed all 45 existing Node binding tests without a Rust panic
- Verified that the PE import table has no dynamic MSVC runtime or OpenSSL dependency
- Validated npm platform manifests, package dry-run output, workflow YAML, and the final diff

## Notes for reviewers

The main review surface is the release packaging flow: every platform binary is uploaded independently, then collected into napi-rs-generated platform packages before the root package is published. The publish job fails unless all six expected binaries are present.