### PR TITLE
docs: provider-inventory 合并 reference-audit 审计结果 + RFC-0018/0019

### DIFF
--- a/provider-inventory/README.md
+++ b/provider-inventory/README.md
@@ -1,15 +1,18 @@
-# Provider statistics & extraction results
+﻿# Provider statistics & extraction results
 
 Data comes from 7 directory/constant sources across 6 local reference
-repositories, deduplicated by canonical provider ID.
+repositories, **merged with the 104-project reference audit**
+(`docs/internal/reference-audit/`, 2026-08-01), deduplicated by canonical
+provider ID.
 
 ## Summary
 
 - Raw provider records: **650**
-- Deduplicated providers: **325**
-- aimux native modules: **172**
-- Direct matches with aimux modules: **116**
-- Not directly matched with aimux modules: **209**
+- Deduplicated providers (v1.0): **325**
+- Audit canonicals merged in (2026-08-01): **552**(2026-08-01 裁剪后仅保留 2 个:**codex**、**azure_ai_foundry**)
+- **Total providers (v1.1,裁剪后): 327** = 325 原有 + 2 保留
+- Audit-matched existing providers: **293**
+- aimux native modules: **172** (157 have same-name inventory entries)
 - With endpoint metadata: **190**
 - With model metadata: **262**
 
@@ -24,6 +27,30 @@ repositories, deduplicated by canonical provider ID.
 | pydantic_ai | 17 |
 | rust_genai | 29 |
 | tokenhub | 155 |
+| reference-audit (104 projects) | 552 new(保留 2) |
+
+## Classification (provider_kind, v1.1)
+
+| Category | Total | 说明 |
+|---|---:|---|
+| model_vendor | 274 | 云 LLM 厂商/API 服务 |
+| gateway_aggregator | 10 | 网关/聚合/路由服务(litellm、openrouter、one-api…) |
+| deployment_platform | 11 | 模型托管/部署平台(replicate、baseten、modal…) |
+| cloud_platform | 11 | 云平台通道(azure_openai、google_vertex、bedrock、azure_ai_foundry…) |
+| local_runtime | 10 | 本地/自托管推理引擎(ollama、vllm、lmstudio…) |
+| subscription_proxy | 3 | 订阅/登录通道(github_copilot、chatgpt、codex) |
+| modal_service | 4 | 模态服务(elevenlabs、midjourney、stability…) |
+| embedding | 2 | 向量嵌入服务(voyage、jina) |
+| search_provider | 2 | 搜索服务(tavily、serper) |
+
+> 分类为启发式推断(名称名单 + 审计 access 证据),新条目 `trust.status=review`,
+> 协议未经官方文档核验,集成前必须按 [RFC-0006](../rfc/0006-provider-development.md) 复核。
+
+## Integration candidates (from audit)
+
+审计数据曾为新条目标注 `integration_candidate.priority`(按支持项目数);2026-08-01 已裁剪,仅保留 `codex` 与 `azure_ai_foundry` 两个候选:
+**high ≥4 项目(10 个)、medium 2–3 项目(37 个)、low 1 项目(505 个)**;裁剪后仅保留 high 中的 codex 与 azure_ai_foundry。
+候选历史见 [INTEGRATION-CANDIDATES.md](INTEGRATION-CANDIDATES.md)(留档),聚焦版见 [INTEGRATION-PRIORITY.md](INTEGRATION-PRIORITY.md)。
 
 ## Compatibility tier (auto-extracted / inferred)
 
@@ -33,14 +60,16 @@ repositories, deduplicated by canonical provider ID.
 | L2 | 65 |
 | L3 | 27 |
 | L4 | 5 |
-| unknown | 219 |
+| unknown | 221 |
 
 ## Output files
 
-- `providers.json`: complete structured data for 325 deduplicated providers.
-- `providers.csv`: a flat list for easy filtering and spreadsheet processing.
-- `raw-provider-records.jsonl`: 650 un-deduplicated source records, with
-  source tracing preserved.
+- `providers.json`: complete structured data for 327 providers(裁剪后) (schema 1.1.0,
+  新增 `audit` 字段与 `integration_candidate` 字段).
+- `providers.csv`: flat list with `audit_projects` / `audit_count` /
+  `integration_candidate` columns.
+- `raw-provider-records.jsonl`: 650 un-deduplicated source records.
+- 审计采集与分析文档(104 项目 md/json、去重清单、候选历史、经验核对)已移至 `reference/audit/`(gitignore,不入库);inventory 仅保留合并后的数据\n- 保留候选(codex、azure_ai_foundry)见 RFC-0018 与 `reference/audit/INTEGRATION-PRIORITY.md`
 
 ## Development entry point
 

--- a/provider-inventory/providers.csv
+++ b/provider-inventory/providers.csv
@@ -1,326 +1,328 @@
-id,display_name,implemented_in_aimux,provider_kind,tier,protocol,openai_compatible,sources,base_urls,model_count,capabilities
-abacus,Abacus,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://routellm.abacus.ai/v1,100,chat
-abliteration_ai,abliteration.ai,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.abliteration.ai/v1,2,chat
-advanced_custom,Advanced Custom,false,model_vendor,unknown,unknown,,new_api,,0,chat
-ai21,Ai21,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,12,chat;completion
-ai302,302.AI,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.302.ai/v1,97,chat;image_generation
-ai_router,AI-ROUTER,false,model_vendor,unknown,unknown,,mastra_registry,https://api.ai-router.dev/v1,5,chat
-aiand,ai&,false,model_vendor,unknown,unknown,,mastra_registry,https://api.aiand.com/v1,10,chat
-aigc2d,AIGC2D,true,model_vendor,unknown,unknown,,new_api,https://api.aigc2d.com,0,chat
-aihubmix,AIHubMix,true,model_vendor,L2,openai,True,rust_genai;tokenhub,,787,audio_speech;chat;embedding;image_generation;rerank
-ails,AILS,true,model_vendor,unknown,unknown,,new_api,https://api.caipacity.com,0,chat
-aiml,Aiml,true,model_vendor,L3,unknown,True,litellm_constants;litellm_prices,,13,image_generation
-aiproxy,AIProxy,false,model_vendor,unknown,unknown,,new_api,https://api.aiproxy.io,0,chat
-aiproxy_library,AIProxyLibrary,false,model_vendor,unknown,unknown,,new_api,https://api.aiproxy.io,0,chat
-aki_io,AKI.IO,false,model_vendor,unknown,unknown,,mastra_registry,https://aki.io/v1,6,chat
-ali,Ali,false,model_vendor,unknown,unknown,,new_api,https://dashscope.aliyuncs.com,0,chat
-alibaba,Alibaba,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;rust_genai;tokenhub,https://dashscope-intl.aliyuncs.com/compatible-mode/v1,114,chat;image_generation
-alibaba_cn,Alibaba (China),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://dashscope.aliyuncs.com/compatible-mode/v1,112,chat
-alibaba_coding_plan,Alibaba Coding Plan,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://coding-intl.dashscope.aliyuncs.com/v1,12,chat
-alibaba_coding_plan_cn,Alibaba Coding Plan (China),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://coding.dashscope.aliyuncs.com/v1,12,chat
-alibaba_token_plan,Alibaba Token Plan,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1,22,chat;image_generation
-alibaba_token_plan_cn,Alibaba Token Plan (China),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1,22,chat;image_generation
-ambient,Ambient,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.ambient.xyz/v1,9,chat
-anthropic,Anthropic,true,model_vendor,L1,anthropic,False,litellm_constants;litellm_prices;mastra_registry;new_api;pydantic_ai;rust_genai;tokenhub,https://api.anthropic.com,33,chat
-anthropic_text,Anthropic Text,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-anyapi,AnyAPI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.anyapi.ai/v1,30,chat
-anyscale,Anyscale,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,12,chat
-apertis,Apertis,false,model_vendor,L2,openai,True,litellm_constants,,0,
-api2gpt,API2GPT,true,model_vendor,unknown,unknown,,new_api,https://api.api2gpt.com,0,chat
-apiserpent,Apiserpent,true,model_vendor,L3,unknown,,litellm_prices,,2,search
-assemblyai,Assemblyai,true,model_vendor,L3,unknown,,litellm_prices,,2,audio_transcription
-atlascloud,Atlascloud,true,model_vendor,L2,openai,True,rust_genai,,0,chat
-atomic_chat,Atomic Chat,false,local_runtime,unknown,unknown,,mastra_registry;tokenhub,http://127.0.0.1:1337/v1,5,chat
-auriko,Auriko,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.auriko.ai/v1,15,chat
-aws,AWS,false,model_vendor,unknown,unknown,,new_api,,0,chat
-aws_polly,AWS Polly,false,model_vendor,L3,unknown,,litellm_prices,,4,audio_speech
-azure,Azure,true,cloud_platform,L1,azure_openai,False,litellm_constants;litellm_prices;new_api;tokenhub,,323,audio_speech;audio_transcription;chat;embedding;image_generation;realtime;responses;video_generation
-azure_ai,Azure AI,true,cloud_platform,L2,openai,True,litellm_constants;litellm_prices,,97,chat;embedding;image_generation;other;rerank;responses
-azure_cognitive_services,Azure Cognitive Services,false,model_vendor,unknown,unknown,,tokenhub,,94,chat;embedding
-azure_text,Azure Text,false,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,3,chat;completion
-baidu,Baidu,true,model_vendor,L2,openai,True,new_api;rust_genai,https://aip.baidubce.com,0,chat
-baidu_v2,BaiduV2,false,model_vendor,unknown,unknown,,new_api,https://qianfan.baidubce.com,0,chat
-bailing,Bailing,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.tbox.cn/api/llm/v1/chat/completions,2,chat
-baseten,Baseten,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://inference.baseten.co/v1,27,chat
-bedrock,Amazon Bedrock,true,cloud_platform,L1,aws_bedrock,False,litellm_constants;litellm_prices;pydantic_ai;rust_genai;tokenhub,,423,chat;embedding;image_edit;image_generation;rerank
-bedrock_mantle,Bedrock Mantle,false,model_vendor,unknown,unknown,,litellm_prices;pydantic_ai,,24,chat;responses
-berget,Berget.AI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.berget.ai/v1,8,chat
-bigmodel,Zhipu AI,true,model_vendor,L2,openai,True,mastra_registry;new_api;rust_genai;tokenhub,https://open.bigmodel.cn;https://open.bigmodel.cn/api/paas/v4,13,chat
-black_forest_labs,Black Forest Labs,true,model_vendor,L3,unknown,,litellm_prices,,8,image_edit;image_generation
-blueclaw,Blue Claw,false,model_vendor,unknown,unknown,,mastra_registry,https://openai.blueclaw.network/v1,2,chat
-burncloud,burncloud,false,model_vendor,unknown,unknown,,tokenhub,,34,audio_speech;chat;image_generation;video_generation
-bytedance,Bytedance,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,12,chat;embedding
-bytez,Bytez,true,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-cerebras,Cerebras,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;pydantic_ai;tokenhub,,12,chat
-chat_gpt_subscription_codex,ChatGPT Subscription (Codex),false,model_vendor,unknown,unknown,,new_api,https://chatgpt.com,0,chat
-chatgpt,Chatgpt,true,subscription_proxy,L2,openai,True,litellm_constants;litellm_prices,,10,chat;responses
-cherryin,cherryin,false,model_vendor,unknown,unknown,,tokenhub,,125,chat;completion;embedding;image_generation;rerank
-chutes,Chutes,false,model_vendor,L2,openai,True,litellm_constants;mastra_registry;tokenhub,https://llm.chutes.ai/v1,43,chat
-clarifai,Clarifai,true,model_vendor,L2,openai,True,litellm_constants;mastra_registry;tokenhub,https://api.clarifai.com/v2/ext/openai/v1,12,chat
-claudinio,Claudinio,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.claudin.io/v1,2,chat
-cline_pass,ClinePass,true,model_vendor,unknown,unknown,,mastra_registry,https://api.cline.bot/api/v1,11,chat
-cloudferro_sherlock,CloudFerro Sherlock,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api-sherlock.cloudferro.com/openai/v1,5,chat
-cloudflare,Cloudflare,false,cloud_platform,unknown,unknown,,litellm_constants;litellm_prices;new_api,https://api.cloudflare.com,30,chat
-cloudflare_ai_gateway,Cloudflare AI Gateway,false,model_vendor,unknown,unknown,,tokenhub,,77,chat;embedding;rerank
-cloudflare_workers_ai,Cloudflare Workers AI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1,22,chat
-codestral,Codestral,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,2,chat
-cohere,Cohere,true,model_vendor,L1,cohere,False,litellm_constants;litellm_prices;new_api;pydantic_ai;rust_genai;tokenhub,https://api.cohere.ai,29,chat;completion;embedding;rerank
-cohere_chat,Cohere Chat,false,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,7,chat
-cometapi,Cometapi,true,model_vendor,L2,openai,True,litellm_constants,,0,chat
-copilot,GitHub Copilot,true,subscription_proxy,L2,openai,True,litellm_constants;litellm_prices;rust_genai;tokenhub,https://api.githubcopilot.com,56,chat;completion;embedding;responses
-cortecs,Cortecs,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.cortecs.ai/v1,58,chat
-coze,Coze,true,model_vendor,unknown,unknown,,new_api,https://api.coze.cn,0,chat
-crof,CrofAI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://crof.ai/v1,26,chat
-crossmodel,CrossModel,false,model_vendor,unknown,unknown,,mastra_registry,https://api.crossmodel.ai/v1,46,chat
-crusoe,Crusoe,false,model_vendor,unknown,unknown,,litellm_prices,,7,chat
-custom_provider,custom provider,false,model_vendor,unknown,unknown,,tokenhub,,30,chat
-daoxe,DaoXE,false,model_vendor,unknown,unknown,,mastra_registry,https://daoxe.com/v1,9,chat
-darkbloom,Darkbloom,false,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,2,chat
-databricks,Databricks,true,cloud_platform,unknown,unknown,,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://${databricks_host}/ai-gateway/mlflow/v1,58,chat;embedding
-dataforseo,Dataforseo,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-datarobot,Datarobot,true,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-deepgram,Deepgram,true,model_vendor,L3,unknown,,litellm_prices,,36,audio_transcription
-deepinfra,Deep Infra,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,,108,chat
-deepseek,DeepSeek,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;new_api;pydantic_ai;rust_genai;tokenhub,https://api.deepseek.com,12,chat
-dify,Dify,false,model_vendor,unknown,unknown,,new_api,https://api.dify.ai,0,chat
-digitalocean,DigitalOcean,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://inference.do-ai.run/v1,82,chat;embedding;rerank
-dinference,DInference,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.dinference.com/v1,6,chat
-docker_model_runner,Docker Model Runner,true,local_runtime,L2,openai,True,litellm_constants,,0,chat
-doubao,Doubao,false,model_vendor,unknown,unknown,,tokenhub,,33,chat;embedding;image_generation;video_generation
-doubao_video,DoubaoVideo,false,model_vendor,unknown,unknown,,new_api,https://ark.cn-beijing.volces.com,0,chat
-drun,D.Run (China),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://chat.d.run/v1,3,chat
-duckduckgo,Duckduckgo,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-ebcloud,EBCloud,false,model_vendor,unknown,unknown,,mastra_registry,https://maas-api.ebcloud.com/v1,4,chat
-elevenlabs,Elevenlabs,true,model_vendor,L3,unknown,,litellm_prices,,4,audio_speech;audio_transcription
-empiriolabs,EmpirioLabs AI,false,model_vendor,unknown,unknown,,mastra_registry,https://api.empiriolabs.ai/v1,36,chat
-empower,Empower,false,model_vendor,L2,openai,True,litellm_constants,,0,chat
-evroc,evroc,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://models.think.evroc.com/v1,21,chat;embedding
-exa_ai,EXA AI,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-fal,FAL,true,model_vendor,L3,unknown,,litellm_prices,,14,image_generation
-fastgpt,FastGPT,true,model_vendor,unknown,unknown,,new_api,https://fastgpt.run/api/openapi,0,chat
-fastrouter,FastRouter,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://go.fastrouter.ai/api/v1,47,chat;image_generation
-featherless_ai,Featherless AI,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,2,chat
-firecrawl,Firecrawl,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-firepass,Fireworks (Firepass),false,model_vendor,unknown,unknown,,tokenhub,https://api.fireworks.ai/inference/v1,1,chat
-fireworks,Fireworks AI,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;rust_genai;tokenhub,https://api.fireworks.ai/inference/v1,318,audio_transcription;chat;embedding;image_generation;rerank
-freemodel,FreeModel,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://cc.freemodel.dev/v1,10,chat
-friendliai,Friendli,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://api.friendli.ai/serverless/v1,11,chat
-frogbot,FrogBot,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://app.frogbot.ai/api/v1,26,chat
-galadriel,Galadriel,true,model_vendor,L2,openai,True,litellm_constants,,0,chat
-gdc,GDC,true,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-gigachat,Gigachat,true,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,6,chat;embedding
-github,GitHub Models,true,model_vendor,L2,openai,True,litellm_constants;mastra_registry;tokenhub,https://models.github.ai/inference,55,chat
-gitlab,GitLab Duo,false,model_vendor,unknown,unknown,,tokenhub,,18,chat
-gmi,GMI,false,model_vendor,unknown,unknown,,litellm_prices,,17,chat
-gmicloud,GMI Cloud,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.gmi-serving.com/v1,13,chat
-google,Google,true,model_vendor,L1,google_gemini,False,litellm_constants;litellm_prices;mastra_registry;new_api;pydantic_ai;rust_genai;tokenhub,https://generativelanguage.googleapis.com,114,audio_speech;chat;embedding;image_generation;realtime;video_generation
-google_pse,Google PSE,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-google_vertex,Vertex,false,model_vendor,unknown,unknown,,tokenhub,,35,chat;embedding
-google_vertex_anthropic,Vertex (Anthropic),false,model_vendor,unknown,unknown,,tokenhub,,11,chat
-gradient_ai,Gradient AI,true,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,13,chat
-groq,Groq,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;pydantic_ai;rust_genai;tokenhub,https://api.groq.com/openai/v1,33,audio_speech;audio_transcription;chat
-helicone,Helicone,true,gateway_aggregator,L4,mixed,True,litellm_constants;mastra_registry;tokenhub,https://ai-gateway.helicone.ai/v1,90,chat
-heroku,Heroku,true,model_vendor,unknown,unknown,,litellm_constants;litellm_prices;pydantic_ai,,27,chat
-hetzner,Hetzner,false,model_vendor,unknown,unknown,,mastra_registry,https://inference.hetzner.com/api/v1,1,chat
-hosted_vllm,Hosted Vllm,true,deployment_platform,L2,openai,True,litellm_constants,,0,chat
-hpc_ai,HPC-AI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.hpc-ai.com/inference/v1,9,chat
-huggingface,Hugging Face,true,deployment_platform,unknown,unknown,,litellm_constants;mastra_registry;pydantic_ai;tokenhub,https://router.huggingface.co/v1,57,chat;embedding
-hyper,Charm Hyper,false,model_vendor,unknown,unknown,,mastra_registry,https://hyper.charm.land/v1,20,chat
-hyperbolic,Hyperbolic,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,16,chat
-iflowcn,iFlow,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://apis.iflow.cn/v1,14,chat
-inception,Inception,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://api.inceptionlabs.ai/v1,3,chat
-inceptron,Inceptron,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.inceptron.io/v1,7,chat
-inference_net,Inference,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://inference.net/v1,9,chat;embedding
-inferx,InferX,false,model_vendor,unknown,unknown,,mastra_registry,https://model.inferx.net/endpoints/v1,6,chat
-io_net,IO.NET,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.intelligence.io.solutions/api/v1,17,chat
-jiekou,Jiekou.AI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.jiekou.ai/openai,153,chat
-jimeng,Jimeng,false,model_vendor,unknown,unknown,,new_api,https://visual.volcengineapi.com,0,chat
-jina,Jina,false,model_vendor,unknown,unknown,,new_api,https://api.jina.ai,0,chat
-jina_ai,Jina AI,false,model_vendor,L3,unknown,,litellm_prices,,1,rerank
-kenari,Kenari,false,model_vendor,unknown,unknown,,mastra_registry,https://kenari.id/v1,38,chat
-kilo,Kilo Gateway,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.kilo.ai/api/gateway,346,chat;image_generation
-kimi,Kimi,false,model_vendor,unknown,unknown,,rust_genai,,0,chat
-kimi_for_coding,Kimi For Coding,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.kimi.com/coding/v1,4,chat
-kling,Kling,false,model_vendor,unknown,unknown,,new_api,https://api.klingai.com,0,chat
-kuae_cloud_coding_plan,KUAE Cloud Coding Plan,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://coding-plan-endpoint.kuaecloud.net/v1,1,chat
-lambda_ai,Lambda AI,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,20,chat
-lemonade,Lemonade,false,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,5,chat
-libertai,Libertai,false,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,12,chat;embedding
-lilac,Lilac,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.getlilac.com/v1,6,chat
-lingyiwanwu,LingYiWanWu,true,model_vendor,unknown,unknown,,new_api,https://api.lingyiwanwu.com,0,chat
-linkup,Linkup,false,model_vendor,L3,unknown,,litellm_prices,,2,search
-litellm_proxy,Litellm Proxy,true,gateway_aggregator,L4,mixed,True,litellm_constants,,0,chat
-llama,Llama,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.llama.com/compat/v1,7,chat
-llamafile,Llamafile,true,local_runtime,L2,openai,True,litellm_constants,,0,chat
-llamagate,Llamagate,false,model_vendor,unknown,unknown,,litellm_prices,,16,chat;embedding
-llmgateway,LLM Gateway,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.llmgateway.io/v1,224,chat
-llmtr,LLMTR,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://llmtr.com/v1,6,chat
-lmstudio,LMStudio,true,local_runtime,L2,openai,True,litellm_constants;mastra_registry;tokenhub,http://127.0.0.1:1234/v1,3,chat
-longcat,LongCat,true,model_vendor,unknown,unknown,,mastra_registry,https://api.longcat.chat/openai,1,chat
-lucidquery,LucidQuery,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.lucidquery.com/v1;https://lucidquery.com/api/v1,4,chat
-lynkr,Lynkr,false,local_runtime,unknown,unknown,,mastra_registry,http://127.0.0.1:8081/v1,1,chat
-maritalk,Maritalk,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-meganova,Meganova,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.meganova.ai/v1,19,chat
-merge_gateway,Merge Gateway,false,model_vendor,unknown,unknown,,tokenhub,,83,chat
-meta,Meta,false,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry,https://api.meta.ai/v1,2,chat
-meta_llama,Meta Llama,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,4,chat
-midjourney,Midjourney,false,model_vendor,unknown,unknown,,new_api,https://oa.api2d.net,0,chat
-midjourney_plus,MidjourneyPlus,false,model_vendor,unknown,unknown,,new_api,https://api.openai-sb.com,0,chat
-mimo,Mimo,false,model_vendor,unknown,unknown,,rust_genai,,0,chat
-minimax,MiniMax (minimax.io),true,model_vendor,unknown,unknown,,litellm_prices;mastra_registry;new_api;rust_genai;tokenhub,https://api.minimax.chat;https://api.minimax.io/anthropic/v1,17,audio_speech;chat
-minimax_cn,MiniMax (minimaxi.com),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.minimaxi.com/anthropic/v1,7,chat
-minimax_cn_coding_plan,MiniMax Token Plan (minimaxi.com),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.minimaxi.com/anthropic/v1,7,chat
-minimax_coding_plan,MiniMax Token Plan (minimax.io),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.minimax.io/anthropic/v1,7,chat
-mistral,Mistral,true,model_vendor,L1,mistral,False,litellm_constants;litellm_prices;mastra_registry;new_api;pydantic_ai;tokenhub,https://api.mistral.ai;https://api.mistral.ai/v1,89,chat;embedding;other
-mixlayer,Mixlayer,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://models.mixlayer.ai/v1,5,chat
-moark,Moark,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://moark.com/v1,2,chat
-model_oracle_ai,Model Oracle AI,false,model_vendor,unknown,unknown,,mastra_registry,https://api.modeloracle.com/api/v1,15,chat
-modelscope,ModelScope,true,model_vendor,L2,openai,True,litellm_constants;mastra_registry;tokenhub,https://api-inference.modelscope.cn/v1,7,chat
-moka_ai,MokaAI,false,model_vendor,unknown,unknown,,new_api,https://api.moka.ai,0,chat
-moonshotai,Moonshot AI,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;new_api;pydantic_ai;rust_genai;tokenhub,https://api.moonshot.ai/anthropic/v1;https://api.moonshot.ai/v1;https://api.moonshot.cn;https://api.moonshot.cn/v1,41,chat
-moonshotai_cn,Moonshot AI (China),false,model_vendor,unknown,unknown,,mastra_registry,https://api.moonshot.cn/anthropic/v1,10,chat
-morph,Morph,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://api.morphllm.com/v1,5,chat
-nanogpt,NanoGPT,true,model_vendor,L2,openai,True,litellm_constants;mastra_registry;tokenhub,https://nano-gpt.com/api/v1,617,chat;image_generation
-nearai,NEAR AI Cloud,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://cloud-api.near.ai/v1,37,chat;embedding;rerank
-nebius,Nebius Token Factory,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;rust_genai;tokenhub,https://api.tokenfactory.nebius.com/v1,63,chat;embedding
-neon,Neon,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,,37,chat
-netlify,Netlify,false,model_vendor,unknown,unknown,,mastra_registry,,68,chat
-neuralwatt,Neuralwatt,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.neuralwatt.com/v1,24,chat
-new_api,New API,false,model_vendor,unknown,unknown,,new_api,,0,chat
-nlp_cloud,NLP Cloud,true,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,2,chat;completion
-nova,Nova,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.nova.amazon.com/v1,2,chat
-novita,NovitaAI,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://api.novita.ai/openai,192,chat;embedding;rerank
-nscale,Nscale,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,16,chat;image_generation
-nvidia_nim,Nvidia,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://integrate.api.nvidia.com/v1,107,chat;embedding;image_generation;rerank
-oci,OCI,false,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,44,chat;embedding
-ofox,Ofox,false,model_vendor,unknown,unknown,,mastra_registry,https://api.ofox.ai/v1,13,chat
-ohmygpt,OhMyGPT,true,model_vendor,unknown,unknown,,new_api,https://api.ohmygpt.com,0,chat
-ollama,Ollama Cloud,true,local_runtime,L2,openai,True,litellm_constants;litellm_prices;new_api;rust_genai;tokenhub,http://localhost:11434;https://ollama.com/v1,590,chat;completion;embedding
-ollama_chat,Ollama Chat,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-ollama_cloud,Ollama Cloud,true,model_vendor,L2,openai,True,mastra_registry;rust_genai,https://ollama.com/v1,19,chat
-omlx,Omlx,true,local_runtime,L2,openai,True,rust_genai,,0,chat
-oobabooga,Oobabooga,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-openai,OpenAI,true,model_vendor,L1,openai,,litellm_constants;litellm_prices;mastra_registry;new_api;pydantic_ai;rust_genai;tokenhub,https://api.openai.com,223,audio_speech;audio_transcription;chat;embedding;image_generation;moderation;realtime;responses;video_generation
-openaimax,OpenAIMax,true,model_vendor,unknown,unknown,,new_api,https://api.openaimax.com,0,chat
-opencode,OpenCode Zen,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://opencode.ai/zen/v1,85,chat
-opencode_go,OpenCode Go,true,model_vendor,unknown,unknown,,mastra_registry;rust_genai;tokenhub,https://opencode.ai/zen/go/v1,22,chat
-openrouter,OpenRouter,true,gateway_aggregator,L4,mixed,True,litellm_constants;litellm_prices;mastra_registry;new_api;rust_genai;tokenhub,https://openrouter.ai/api;https://openrouter.ai/api/v1,472,audio_speech;chat;image_generation
-orcarouter,OrcaRouter,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.orcarouter.ai/v1,81,chat
-ovhcloud,OVHcloud AI Endpoints,true,model_vendor,unknown,unknown,,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://oai.endpoints.kepler.ai.cloud.ovh.net/v1,30,chat
-pa_lm,PaLM,false,model_vendor,unknown,unknown,,new_api,,0,chat
-palm,Palm,false,model_vendor,unknown,unknown,,litellm_prices,,6,chat;completion
-parallel_ai,Parallel AI,false,model_vendor,L3,unknown,,litellm_prices,,2,search
-parasail,Parasail,true,model_vendor,L2,openai,True,litellm_constants,,0,
-perplexity,Perplexity,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;new_api;tokenhub,https://api.perplexity.ai,45,chat;embedding;responses;search
-perplexity_agent,Perplexity Agent,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.perplexity.ai/v1,18,chat
-petals,Petals,true,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-pinstripes,Pinstripes,false,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,6,chat
-pioneer,Pioneer,true,model_vendor,unknown,unknown,,mastra_registry,https://api.pioneer.ai/v1,76,chat
-poe,Poe,false,model_vendor,L2,openai,True,litellm_constants;mastra_registry;tokenhub,https://api.poe.com/v1,137,chat;image_generation
-poolside,Poolside,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://inference.poolside.ai/v1,4,chat
-ppinfra,PPInfra,false,model_vendor,unknown,unknown,,tokenhub,,101,chat
-predibase,Predibase,true,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-privatemode_ai,Privatemode AI,false,local_runtime,unknown,unknown,,mastra_registry;tokenhub,http://localhost:8080/v1,7,chat;embedding
-publicai,Publicai,false,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,9,chat
-qihang_ai,QiHang,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.qhaigc.net/v1,9,chat
-qihoo360,360,true,model_vendor,unknown,unknown,,new_api,https://api.360.cn,0,chat
-qiniu_ai,Qiniu,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.qnaigc.com/v1,91,chat;image_generation
-ragflow,Ragflow,false,model_vendor,L2,openai,True,litellm_constants,,0,
-recraft,Recraft,false,model_vendor,L3,unknown,,litellm_prices,,2,image_generation
-reducto,Reducto,false,model_vendor,L3,unknown,,litellm_prices,,2,other
-regolo_ai,Regolo AI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.regolo.ai/v1,13,chat;embedding;image_generation;rerank
-replicate,Replicate,true,model_vendor,unknown,unknown,,litellm_constants;litellm_prices;new_api,https://api.replicate.com,40,chat
-requesty,Requesty,true,gateway_aggregator,L4,mixed,,mastra_registry;tokenhub,https://router.requesty.ai/v1,38,chat
-routing_run,routing.run,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://ai.routing.sh/v1;https://api.routing.run/v1,41,chat
-runwayml,Runwayml,false,model_vendor,L3,unknown,,litellm_prices,,6,audio_speech;image_generation;video_generation
-sagemaker,Sagemaker,false,cloud_platform,unknown,unknown,,litellm_constants;litellm_prices,,6,chat;completion
-sagemaker_chat,Sagemaker Chat,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-sagemaker_nova,Sagemaker Nova,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-sakana,Sakana AI,true,model_vendor,unknown,unknown,,mastra_registry,https://api.sakana.ai/v1,3,chat
-sambanova,Sambanova,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,19,chat
-sap_ai_core,SAP AI Core,false,model_vendor,unknown,unknown,,tokenhub,,26,chat
-sarvam,Sarvam AI,true,model_vendor,unknown,unknown,,litellm_prices;mastra_registry;tokenhub,https://api.sarvam.ai/v1,3,chat
-scaleway,Scaleway,true,model_vendor,unknown,unknown,,litellm_prices;mastra_registry;tokenhub,https://api.scaleway.ai/v1,34,audio_transcription;chat;embedding
-searxng,Searxng,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-serper,Serper,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-siliconflow,SiliconFlow,true,model_vendor,unknown,unknown,,mastra_registry;new_api;tokenhub,https://api.siliconflow.cn;https://api.siliconflow.cn/v1;https://api.siliconflow.com/v1,174,audio_speech;chat;embedding;image_edit;other;rerank;video_generation
-snowflake,Snowflake,false,model_vendor,unknown,unknown,,litellm_prices,,37,chat;embedding
-snowflake_cortex,Snowflake Cortex,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://${snowflake_account}.snowflakecomputing.com/api/v2/cortex/v1,21,chat
-soniox,Soniox,false,model_vendor,L3,unknown,,litellm_prices,,2,audio_transcription
-sora,Sora,false,model_vendor,unknown,unknown,,new_api,https://api.openai.com,0,chat
-stability,Stability,false,model_vendor,L3,unknown,,litellm_prices,,23,image_edit;image_generation
-stackit,STACKIT,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1,10,chat
-stepfun,StepFun (Global),true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.stepfun.ai/step_plan/v1;https://api.stepfun.ai/v1;https://api.stepfun.com/v1,8,chat
-stepfun_ai_step_plan,StepFun Step Plan (Global),false,model_vendor,unknown,unknown,,mastra_registry,https://api.stepfun.ai/step_plan/v1,3,chat
-stepfun_step_plan,StepFun Step Plan (China),false,model_vendor,unknown,unknown,,mastra_registry,https://api.stepfun.com/step_plan/v1,4,chat
-sub2_api,Sub2API,false,model_vendor,unknown,unknown,,new_api,,0,chat
-subconscious,Subconscious,false,model_vendor,unknown,unknown,,mastra_registry,https://api.subconscious.dev/v1,2,chat
-submodel,submodel,true,model_vendor,unknown,unknown,,mastra_registry;new_api;tokenhub,https://llm.submodel.ai;https://llm.submodel.ai/v1,9,chat
-suno_api,SunoAPI,false,model_vendor,unknown,unknown,,new_api,,0,chat
-synthetic,Synthetic,false,model_vendor,L2,openai,True,litellm_constants;mastra_registry;tokenhub,https://api.synthetic.new/openai/v1,38,chat
-tavily,Tavily,false,model_vendor,L3,unknown,,litellm_prices,,2,search
-tencent,Tencent,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;new_api,https://hunyuan.tencentcloudapi.com,2,chat
-tencent_coding_plan,Tencent Coding Plan (China),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.lkeap.cloud.tencent.com/coding/v3,8,chat
-tencent_token_plan,Tencent Token Plan,false,model_vendor,unknown,unknown,,mastra_registry,https://api.lkeap.cloud.tencent.com/plan/v3,1,chat
-tencent_token_plan_enterprise_auto,腾讯云 Token Plan / Token Plan 企业版轻享套餐,false,model_vendor,unknown,unknown,,tokenhub,https://tokenhub.tencentmaas.com/plan/v3,1,chat
-tencent_token_plan_enterprise_pro,腾讯云 Token Plan / Token Plan 企业版专业套餐,false,model_vendor,unknown,unknown,,tokenhub,https://tokenhub.tencentmaas.com/plan/v3,16,chat
-tencent_token_plan_general_personal,腾讯云 Token Plan / 通用 Token Plan（个人版）,false,model_vendor,unknown,unknown,,tokenhub,https://api.lkeap.cloud.tencent.com/plan/v3,8,chat
-tencent_token_plan_hy_personal,腾讯云 Token Plan / Hy Token Plan（个人版）,false,model_vendor,unknown,unknown,,tokenhub,https://api.lkeap.cloud.tencent.com/plan/v3,2,chat
-tencent_tokenhub,Tencent TokenHub,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://tokenhub.tencentmaas.com/v1,2,chat
-tensormesh,Tensormesh,false,model_vendor,L2,openai,True,litellm_constants;litellm_prices,,10,chat
-text_completion_codestral,Text Completion Codestral,false,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,2,chat;completion
-text_completion_inception,Text Completion Inception,false,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,1,chat;completion
-the_grid_ai,The Grid AI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.thegrid.ai/v1,9,chat
-thinkingmachines,Thinking Machines,false,model_vendor,unknown,unknown,,mastra_registry,https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1,2,chat
-tinfoil,Tinfoil,false,model_vendor,unknown,unknown,,mastra_registry,https://inference.tinfoil.sh/v1,7,chat
-tinyfish,Tinyfish,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-togetherai,Together AI,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;rust_genai;tokenhub,,77,chat;embedding
-tokenflux,Tokenflux,false,model_vendor,unknown,unknown,,tokenhub,,164,chat
-triton,Triton,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-trustedrouter,TrustedRouter,false,model_vendor,unknown,unknown,,mastra_registry,https://api.trustedrouter.com/v1,7,chat
-umans_ai,Umans AI,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.code.umans.ai/v1,6,chat
-umans_ai_coding_plan,Umans AI Coding Plan,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.code.umans.ai/v1,7,chat
-unorouter,UnoRouter,false,model_vendor,unknown,unknown,,mastra_registry,https://api.unorouter.com/v1,23,chat
-upstage,Upstage,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.upstage.ai/v1/solar,3,chat
-v0,v0,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;tokenhub,,6,chat
-venice,Venice AI,false,model_vendor,unknown,unknown,,tokenhub,,75,chat
-vercel,Vercel AI Gateway,true,gateway_aggregator,L4,mixed,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,,426,chat;embedding;image_generation
-vertex,VertexAI,true,cloud_platform,L1,google_vertex,False,litellm_constants;litellm_prices;new_api;pydantic_ai;rust_genai,,60,audio_speech;audio_transcription;chat;embedding;image_generation;other;video_generation
-vertex_ai_ai21_models,Vertex AI Ai21 Models,false,model_vendor,unknown,unknown,,litellm_prices,,5,chat
-vertex_ai_anthropic_models,Vertex AI Anthropic Models,false,model_vendor,unknown,unknown,,litellm_prices,,37,chat
-vertex_ai_deepseek_models,Vertex AI Deepseek Models,false,model_vendor,unknown,unknown,,litellm_prices,,3,chat
-vertex_ai_language_models,Vertex AI Language Models,false,model_vendor,unknown,unknown,,litellm_prices,,42,chat;embedding;image_generation;realtime
-vertex_ai_llama_models,Vertex AI Llama Models,false,model_vendor,unknown,unknown,,litellm_prices,,11,chat
-vertex_ai_minimax_models,Vertex AI Minimax Models,false,model_vendor,unknown,unknown,,litellm_prices,,1,chat
-vertex_ai_mistral_models,Vertex AI Mistral Models,false,model_vendor,unknown,unknown,,litellm_prices,,19,chat
-vertex_ai_moonshot_models,Vertex AI Moonshot Models,false,model_vendor,unknown,unknown,,litellm_prices,,1,chat
-vertex_ai_openai_models,Vertex AI Openai Models,false,model_vendor,unknown,unknown,,litellm_prices,,3,chat
-vertex_ai_qwen_models,Vertex AI Qwen Models,false,model_vendor,unknown,unknown,,litellm_prices,,4,chat
-vertex_ai_text_models,Vertex AI Text Models,false,model_vendor,unknown,unknown,,litellm_prices,,2,completion
-vertex_ai_zai_models,Vertex AI ZAI Models,false,model_vendor,unknown,unknown,,litellm_prices,,2,chat
-vidu,Vidu,false,model_vendor,unknown,unknown,,new_api,https://api.vidu.cn,0,chat
-vivgrid,Vivgrid,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.vivgrid.com/v1,17,chat
-vllm,Vllm,true,local_runtime,L2,openai,True,litellm_constants,,0,chat
-volc_engine,VolcEngine,false,model_vendor,unknown,unknown,,new_api,https://ark.cn-beijing.volces.com,0,chat
-voyage,Voyage,true,model_vendor,L3,voyage,False,litellm_prices,,19,embedding;rerank
-vultr,Vultr,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.vultrinference.com/v1,12,chat
-wafer,Wafer,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://pass.wafer.ai/v1,10,chat
-wandb,Weights & Biases,false,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;tokenhub,https://api.inference.wandb.ai/v1,48,chat
-watsonx,Watsonx,false,model_vendor,unknown,unknown,,litellm_constants;litellm_prices,,29,audio_transcription;chat
-watsonx_text,Watsonx Text,false,model_vendor,unknown,unknown,,litellm_constants,,0,chat
-xai,xAI,true,model_vendor,L1,xai,True,litellm_constants;litellm_prices;mastra_registry;new_api;pydantic_ai;rust_genai;tokenhub,https://api.x.ai,87,chat
-xiaomi_token_plan_ams,Xiaomi Token Plan (Europe),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://token-plan-ams.xiaomimimo.com/v1,8,chat
-xiaomi_token_plan_cn,Xiaomi Token Plan (China),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://token-plan-cn.xiaomimimo.com/v1,8,chat
-xiaomi_token_plan_sgp,Xiaomi Token Plan (Singapore),false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://token-plan-sgp.xiaomimimo.com/v1,8,chat
-xiaomimimo,Xiaomi,true,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.xiaomimimo.com/v1,6,chat
-xinference,Xinference,true,local_runtime,L2,openai,True,litellm_constants;new_api,,0,chat
-xpersona,Xpersona,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://www.xpersona.co/v1,3,chat
-xunfei,Xunfei,false,model_vendor,unknown,unknown,,new_api,,0,chat
-you_com,YOU COM,false,model_vendor,L3,unknown,,litellm_prices,,1,search
-zai,Z.AI,true,model_vendor,L2,openai,True,litellm_constants;litellm_prices;mastra_registry;pydantic_ai;rust_genai;tokenhub,https://api.z.ai/api/paas/v4,33,chat
-zai_coding_plan,Z.AI Coding Plan,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.z.ai/api/coding/paas/v4,6,chat
-zeldoc,Zeldoc,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://api.zeldoc.ai/v1,1,chat
-zenifra,Zenifra,false,model_vendor,unknown,unknown,,mastra_registry,https://ai.zenifra.com/v1,1,chat
-zenmux,ZenMux,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://zenmux.ai/api/v1,164,chat;embedding;image_generation
-zhipu_v4,ZhipuV4,false,model_vendor,unknown,unknown,,new_api,https://open.bigmodel.cn,0,chat
-zhipuai_coding_plan,Zhipu AI Coding Plan,false,model_vendor,unknown,unknown,,mastra_registry;tokenhub,https://open.bigmodel.cn/api/coding/paas/v4,7,chat
+﻿id,display_name,implemented_in_aimux,provider_kind,tier,protocol,openai_compatible,sources,base_urls,model_count,capabilities,audit_projects,audit_count,integration_candidate
+abacus,Abacus,False,model_vendor,unknown,unknown,,,https://routellm.abacus.ai/v1,100,chat,mastra;opencode,2,
+abliteration_ai,abliteration.ai,False,model_vendor,unknown,unknown,,,https://api.abliteration.ai/v1,2,chat,mastra;opencode,2,
+advanced_custom,Advanced Custom,False,model_vendor,unknown,unknown,,,,0,chat,new-api,1,
+ai21,Ai21,True,model_vendor,L2,openai,True,,,12,chat;completion,ferro-ai-gateway;langchain;litellm;llama_index;portkey-gateway,5,
+ai302,302.AI,True,model_vendor,unknown,unknown,,,https://api.302.ai/v1,97,chat;image_generation,mastra;opencode;portkey-gateway,3,
+ai_router,AI-ROUTER,False,model_vendor,unknown,unknown,,,https://api.ai-router.dev/v1,5,chat,mastra;opencode,2,
+aiand,ai&,False,model_vendor,unknown,unknown,,,https://api.aiand.com/v1,10,chat,mastra;opencode,2,
+aigc2d,AIGC2D,True,model_vendor,unknown,unknown,,,https://api.aigc2d.com,0,chat,one-api,1,
+aihubmix,AIHubMix,True,gateway_aggregator,L2,openai,True,,,787,audio_speech;chat;embedding;image_generation;rerank,awaken;axonhub;cc-switch;cline;mastra;opencode;rust-genai,7,
+ails,AILS,True,model_vendor,unknown,unknown,,,https://api.caipacity.com,0,chat,one-api,1,
+aiml,Aiml,True,model_vendor,L3,unknown,True,,,13,image_generation,litellm,1,
+aiproxy,AIProxy,False,model_vendor,unknown,unknown,,,https://api.aiproxy.io,0,chat,one-api,1,
+aiproxy_library,AIProxyLibrary,False,model_vendor,unknown,unknown,,,https://api.aiproxy.io,0,chat,one-api,1,
+aki_io,AKI.IO,False,model_vendor,unknown,unknown,,,https://aki.io/v1,6,chat,mastra;opencode,2,
+ali,Ali,False,model_vendor,unknown,unknown,,,https://dashscope.aliyuncs.com,0,chat,aiproxy,1,
+alibaba,Alibaba,True,model_vendor,L2,openai,True,,https://dashscope-intl.aliyuncs.com/compatible-mode/v1,114,chat;image_generation,agent-of-empires;ai;aisuite;APIPark;awaken;axonhub;ccs-nicremo;cc-switch;chats;cline;eino;ferro-ai-gateway;higress;langchain4j;langchain-rust;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencodex;OpenHands;otari;portkey-gateway;Roo-Code;rust-genai;simple-one-api;swiftide,46,
+alibaba_cn,Alibaba (China),False,model_vendor,unknown,unknown,,,https://dashscope.aliyuncs.com/compatible-mode/v1,112,chat,agent-of-empires;ai;aisuite;APIPark;awaken;axonhub;ccs-nicremo;cc-switch;chats;cline;eino;ferro-ai-gateway;higress;langchain4j;langchain-rust;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencodex;OpenHands;otari;portkey-gateway;Roo-Code;rust-genai;simple-one-api;swiftide,46,
+alibaba_coding_plan,Alibaba Coding Plan,False,model_vendor,unknown,unknown,,,https://coding-intl.dashscope.aliyuncs.com/v1,12,chat,agent-of-empires;ai;aisuite;APIPark;awaken;axonhub;ccs-nicremo;cc-switch;chats;cline;eino;ferro-ai-gateway;higress;langchain4j;langchain-rust;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencodex;OpenHands;otari;portkey-gateway;Roo-Code;rust-genai;simple-one-api;swiftide,46,
+alibaba_coding_plan_cn,Alibaba Coding Plan (China),False,model_vendor,unknown,unknown,,,https://coding.dashscope.aliyuncs.com/v1,12,chat,agent-of-empires;ai;aisuite;APIPark;awaken;axonhub;ccs-nicremo;cc-switch;chats;cline;eino;ferro-ai-gateway;higress;langchain4j;langchain-rust;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencodex;OpenHands;otari;portkey-gateway;Roo-Code;rust-genai;simple-one-api;swiftide,46,
+alibaba_token_plan,Alibaba Token Plan,False,model_vendor,unknown,unknown,,,https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1,22,chat;image_generation,agent-of-empires;ai;aisuite;APIPark;awaken;axonhub;ccs-nicremo;cc-switch;chats;cline;eino;ferro-ai-gateway;higress;langchain4j;langchain-rust;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencodex;OpenHands;otari;portkey-gateway;Roo-Code;rust-genai;simple-one-api;swiftide,46,
+alibaba_token_plan_cn,Alibaba Token Plan (China),False,model_vendor,unknown,unknown,,,https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1,22,chat;image_generation,agent-of-empires;ai;aisuite;APIPark;awaken;axonhub;ccs-nicremo;cc-switch;chats;cline;eino;ferro-ai-gateway;higress;langchain4j;langchain-rust;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencodex;OpenHands;otari;portkey-gateway;Roo-Code;rust-genai;simple-one-api;swiftide,46,
+ambient,Ambient,False,model_vendor,unknown,unknown,,,https://api.ambient.xyz/v1,9,chat,mastra;opencode,2,
+anthropic,Anthropic,True,model_vendor,L1,anthropic,False,,https://api.anthropic.com,33,chat,agent-of-empires;agentsdk;ai;ai.rs;aider;aiproxy;aisuite;APIPark;async-anthropic;autogen;AutoGPT;awaken;axonhub;bifrost;chats;claude-code-router;cline;coai;continue;crewAI;dspy;edgequake-llm;eino;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;instructor-go;kalosm;langchain;langchain4j;LangChain-csharp;langchaingo;langchainjs;langchain-rust;litellm;litellm-rust;llama_index;LlamaIndexTS;llm-connector;llmgateway;llmrust;manifest;mastra;mirascope;multi-llm;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;otari;outlines;pi;pinchbench;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust_ai_sdk;rust-genai;semantic-kernel;simple-one-api;smg;spring-ai;swiftide;tensorzero;textgrad;traceloop-hub;unia;uni-api,85,
+anthropic_text,Anthropic Text,False,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+anyapi,AnyAPI,False,model_vendor,unknown,unknown,,,https://api.anyapi.ai/v1,30,chat,mastra;opencode,2,
+anyscale,Anyscale,True,deployment_platform,L2,openai,True,,,12,chat,dspy;instructor;litellm;llama_index;portkey-gateway,5,
+apertis,Apertis,False,model_vendor,L2,openai,True,,,0,,litellm;llama_index,2,
+api2gpt,API2GPT,True,model_vendor,unknown,unknown,,,https://api.api2gpt.com,0,chat,one-api,1,
+apiserpent,Apiserpent,True,model_vendor,L3,unknown,,,,2,search,litellm,1,
+assemblyai,Assemblyai,True,model_vendor,L3,unknown,,,,2,audio_transcription,,,
+atlascloud,Atlascloud,True,model_vendor,L2,openai,True,,,0,chat,awaken;axonhub;llmgateway;rust-genai,4,
+atomic_chat,Atomic Chat,False,local_runtime,unknown,unknown,,,http://127.0.0.1:1337/v1,5,chat,mastra;opencode,2,
+auriko,Auriko,False,model_vendor,unknown,unknown,,,https://api.auriko.ai/v1,15,chat,mastra;opencode,2,
+aws,AWS,False,model_vendor,unknown,unknown,,,,0,chat,agentsdk;ai;aider;aiproxy;aisuite;APIPark;awaken;bifrost;cc-switch;claude-code;cline;codex;continue;crewAI;edgequake-llm;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;langchain;langchain4j;langchaingo;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencode-ai;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;semantic-kernel;smg;spring-ai;swiftide;tensorzero;textgrad;traceloop-hub;uni-api,62,
+aws_polly,AWS Polly,False,model_vendor,L3,unknown,,,,4,audio_speech,litellm,1,
+azure,Azure,True,cloud_platform,L1,azure_openai,False,,,323,audio_speech;audio_transcription;chat;embedding;image_generation;realtime;responses;video_generation,ai;aider;aiproxy;aisuite;APIPark;autogen;bifrost;cc-switch;coai;codex;continue;crewAI;dotnet-extensions;dspy;edgequake-llm;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;guidance;haystack;higress;instructor;langchain;langchain4j;LangChain-csharp;langchaingo;langchainjs;langchain-rust;litellm;llama_index;LlamaIndexTS;llm-connector;llmgateway;mastra;new-api;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;plano;portkey-gateway;rig;rllm;semantic-kernel;semantic-kernel-java;simple-one-api;smg;swiftide;tensorzero;textgrad;traceloop-hub;uni-api,55,
+azure_ai,Azure AI,True,cloud_platform,L2,openai,True,,,97,chat;embedding;image_generation;other;rerank;responses,langchain;litellm;portkey-gateway,3,
+azure_cognitive_services,Azure Cognitive Services,False,model_vendor,unknown,unknown,,,,94,chat;embedding,opencode,1,
+azure_text,Azure Text,False,model_vendor,unknown,unknown,,,,3,chat;completion,,,
+baidu,Baidu,True,model_vendor,L2,openai,True,,https://aip.baidubce.com,0,chat,aiproxy;awaken;eino;higress;langchain4j;langchaingo;langchain-swift;llama_index;one-api;one-hub;opencodex;rust-genai;simple-one-api,16,
+baidu_v2,BaiduV2,False,model_vendor,unknown,unknown,,,https://qianfan.baidubce.com,0,chat,new-api,1,
+bailing,Bailing,False,model_vendor,unknown,unknown,,,https://api.tbox.cn/api/llm/v1/chat/completions,2,chat,cc-switch;mastra;opencode,3,
+baseten,Baseten,True,deployment_platform,L2,openai,True,,https://inference.baseten.co/v1,27,chat,ai;cline;langchain;litellm;llama_index;mastra;opencode;Roo-Code,8,
+bedrock,Amazon Bedrock,True,cloud_platform,L1,aws_bedrock,False,,,423,chat;embedding;image_edit;image_generation;rerank,agentsdk;ai;aider;aiproxy;aisuite;APIPark;awaken;bifrost;cc-switch;claude-code;cline;codex;continue;crewAI;edgequake-llm;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;langchain;langchain4j;langchaingo;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencode-ai;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;semantic-kernel;smg;spring-ai;swiftide;tensorzero;textgrad;traceloop-hub;uni-api,62,
+bedrock_mantle,Bedrock Mantle,False,model_vendor,unknown,unknown,,,,24,chat;responses,agentsdk;ai;aider;aiproxy;aisuite;APIPark;awaken;bifrost;cc-switch;claude-code;cline;codex;continue;crewAI;edgequake-llm;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;langchain;langchain4j;langchaingo;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;manifest;mastra;new-api;one-hub;opencode;opencode-ai;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;semantic-kernel;smg;spring-ai;swiftide;tensorzero;textgrad;traceloop-hub;uni-api,62,
+berget,Berget.AI,False,model_vendor,unknown,unknown,,,https://api.berget.ai/v1,8,chat,mastra;opencode,2,
+bigmodel,Zhipu AI,True,model_vendor,L2,openai,True,,https://open.bigmodel.cn;https://open.bigmodel.cn/api/paas/v4,13,chat,aiproxy;APIPark;awaken;axonhub;chats;higress;langchain4j;langchain-swift;llama_index;mastra;one-api;one-hub;opencode;OpenHands;plano;portkey-gateway;rust-genai;simple-one-api,22,
+black_forest_labs,Black Forest Labs,True,model_vendor,L3,unknown,,,,8,image_edit;image_generation,litellm,1,
+blueclaw,Blue Claw,False,model_vendor,unknown,unknown,,,https://openai.blueclaw.network/v1,2,chat,mastra;opencode,2,
+burncloud,burncloud,False,model_vendor,unknown,unknown,,,,34,audio_speech;chat;image_generation;video_generation,axonhub,1,
+bytedance,Bytedance,True,model_vendor,L2,openai,True,,,12,chat;embedding,llmgateway,1,
+bytez,Bytez,True,model_vendor,unknown,unknown,,,,0,chat,litellm;portkey-gateway,2,
+cerebras,Cerebras,True,deployment_platform,L2,openai,True,,,12,chat,agentsdk;ai;aisuite;axonhub;bifrost;cline;continue;crewAI;ferro-ai-gateway;instructor;langchain;langchainjs;litellm;llama_index;llmgateway;manifest;mastra;oh-my-opencode-slim;opencode;opencodex;otari;pi;portkey-gateway;pydantic-ai;Roo-Code,25,
+chat_gpt_subscription_codex,ChatGPT Subscription (Codex),False,model_vendor,unknown,unknown,,,https://chatgpt.com,0,chat,,,
+chatgpt,Chatgpt,True,subscription_proxy,L2,openai,True,,,10,chat;responses,litellm;plano;rig,3,
+cherryin,cherryin,False,model_vendor,unknown,unknown,,,,125,chat;completion;embedding;image_generation;rerank,,,
+chutes,Chutes,False,model_vendor,L2,openai,True,,https://llm.chutes.ai/v1,43,chat,litellm;mastra;opencode;Roo-Code,4,
+clarifai,Clarifai,True,model_vendor,L2,openai,True,,https://api.clarifai.com/v2/ext/openai/v1,12,chat,litellm;llama_index;mastra;opencode,4,
+claudinio,Claudinio,False,model_vendor,unknown,unknown,,,https://api.claudin.io/v1,2,chat,mastra;opencode,2,
+cline_pass,ClinePass,True,model_vendor,unknown,unknown,,,https://api.cline.bot/api/v1,11,chat,cline;manifest;mastra;opencode,4,
+cloudferro_sherlock,CloudFerro Sherlock,False,model_vendor,unknown,unknown,,,https://api-sherlock.cloudferro.com/openai/v1,5,chat,mastra;opencode,2,
+cloudflare,Cloudflare,False,cloud_platform,unknown,unknown,,,https://api.cloudflare.com,30,chat,aiproxy;continue;ferro-ai-gateway;higress;langchain;langchain4j;langchaingo;langchainjs;litellm;mastra;one-api;opencode;opencodex;pi;portkey-gateway;simple-one-api;uni-api,17,
+cloudflare_ai_gateway,Cloudflare AI Gateway,False,model_vendor,unknown,unknown,,,,77,chat;embedding;rerank,agentsdk;llama_index;mastra;new-api;opencode;opencodex;pi,7,
+cloudflare_workers_ai,Cloudflare Workers AI,False,model_vendor,unknown,unknown,,,https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1,22,chat,aiproxy;continue;ferro-ai-gateway;higress;langchain;langchain4j;langchaingo;langchainjs;litellm;mastra;one-api;opencode;opencodex;pi;portkey-gateway;simple-one-api;uni-api,17,
+codestral,Codestral,True,model_vendor,L2,openai,True,,,2,chat,litellm,1,
+cohere,Cohere,True,model_vendor,L1,cohere,False,,https://api.cohere.ai,29,chat;completion;embedding;rerank,agentsdk;ai;aider;aiproxy;aisuite;APIPark;awaken;bifrost;continue;edgequake-llm;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;haystack;higress;instructor;instructor-go;langchain;langchain4j;langchaingo;langchainjs;litellm;llama_index;mastra;new-api;one-api;one-hub;opencode;otari;portkey-gateway;pydantic-ai;rig;rllm;rust-genai;textgrad;uni-api,36,
+cohere_chat,Cohere Chat,False,model_vendor,unknown,unknown,,,,7,chat,litellm,1,
+cometapi,Cometapi,True,model_vendor,L2,openai,True,,,0,chat,continue;haystack;litellm;llama_index;portkey-gateway,5,
+copilot,GitHub Copilot,True,subscription_proxy,L2,openai,True,,https://api.githubcopilot.com,56,chat;completion;embedding;responses,agent-of-empires;agentsdk;ai.rs;aider;awaken;axonhub;litellm;manifest;oh-my-opencode-slim;opencode;opencode-ai;opencodex;pi;rig;rust-genai,15,
+cortecs,Cortecs,False,model_vendor,unknown,unknown,,,https://api.cortecs.ai/v1,58,chat,mastra;opencode,2,
+coze,Coze,True,gateway_aggregator,unknown,unknown,,,https://api.coze.cn,0,chat,aiproxy;coai;higress;new-api;one-api;one-hub,6,
+crof,CrofAI,False,model_vendor,unknown,unknown,,,https://crof.ai/v1,26,chat,mastra;opencode,2,
+crossmodel,CrossModel,False,model_vendor,unknown,unknown,,,https://api.crossmodel.ai/v1,46,chat,mastra;opencode,2,
+crusoe,Crusoe,False,model_vendor,unknown,unknown,,,,7,chat,aisuite;langchain,2,
+custom_provider,custom provider,False,model_vendor,unknown,unknown,,,,30,chat,awaken;claude-code-router;litellm;litellm-rust;llmgateway;manifest;one-api;one-hub;rust-genai;smg,10,
+daoxe,DaoXE,False,model_vendor,unknown,unknown,,,https://daoxe.com/v1,9,chat,mastra;opencode,2,
+darkbloom,Darkbloom,False,model_vendor,L2,openai,True,,,2,chat,litellm,1,
+databricks,Databricks,True,cloud_platform,unknown,unknown,,,https://${databricks_host}/ai-gateway/mlflow/v1,58,chat;embedding,bifrost;dspy;ferro-ai-gateway;instructor;langchain;litellm;llama_index;mastra;one-hub;opencode;otari;uni-api,12,
+dataforseo,Dataforseo,False,model_vendor,L3,unknown,,,,1,search,litellm,1,
+datarobot,Datarobot,True,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+deepgram,Deepgram,True,modal_service,L3,unknown,,,,36,audio_transcription,aisuite;litellm,2,
+deepinfra,Deep Infra,True,deployment_platform,L2,openai,True,,,108,chat,agentsdk;ai;axonhub;continue;envoy-ai-gateway;ferro-ai-gateway;litellm;llama_index;LlamaIndexTS;llmgateway;mastra;opencode;otari;portkey-gateway;Roo-Code,15,
+deepseek,DeepSeek,True,model_vendor,L2,openai,True,,https://api.deepseek.com,12,chat,ai;aider;aiproxy;aisuite;APIPark;awaken;axonhub;bifrost;ccs-nicremo;cc-switch;ccswitch-deepseek;chats;claude-code-router;cline;coai;continue;crewAI;eino;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;helicone-ai-gateway;higress;instructor;langchain;langchainjs;langchain-rust;litellm;llama_index;LlamaIndexTS;llm-connector;llmgateway;llmrust;manifest;mastra;new-api;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;simple-one-api;spring-ai;tensorzero;unia,54,
+dify,Dify,False,gateway_aggregator,unknown,unknown,,,https://api.dify.ai,0,chat,cline;coai;higress;new-api;simple-one-api,5,
+digitalocean,DigitalOcean,False,model_vendor,unknown,unknown,,,https://inference.do-ai.run/v1,82,chat;embedding;rerank,mastra;opencode;plano,3,
+dinference,DInference,False,model_vendor,unknown,unknown,,,https://api.dinference.com/v1,6,chat,mastra;opencode,2,
+docker_model_runner,Docker Model Runner,True,local_runtime,L2,openai,True,,,0,chat,litellm,1,
+doubao,Doubao,False,model_vendor,unknown,unknown,,,,33,chat;embedding;image_generation;video_generation,aiproxy;axonhub;chats;cline;eino;higress;litellm;new-api;one-api;Roo-Code;simple-one-api,13,
+doubao_video,DoubaoVideo,False,model_vendor,unknown,unknown,,,https://ark.cn-beijing.volces.com,0,chat,,,
+drun,D.Run (China),False,model_vendor,unknown,unknown,,,https://chat.d.run/v1,3,chat,mastra;opencode,2,
+duckduckgo,Duckduckgo,False,model_vendor,L3,unknown,,,,1,search,litellm,1,
+ebcloud,EBCloud,False,model_vendor,unknown,unknown,,,https://maas-api.ebcloud.com/v1,4,chat,mastra;opencode,2,
+elevenlabs,Elevenlabs,True,modal_service,L3,unknown,,,,4,audio_speech;audio_transcription,bifrost;graniet-llm;litellm;llmgateway;rllm;spring-ai,6,
+empiriolabs,EmpirioLabs AI,False,model_vendor,unknown,unknown,,,https://api.empiriolabs.ai/v1,36,chat,langchain;mastra;opencode,3,
+empower,Empower,False,model_vendor,L2,openai,True,,,0,chat,litellm,1,
+evroc,evroc,False,model_vendor,unknown,unknown,,,https://models.think.evroc.com/v1,21,chat;embedding,mastra;opencode,2,
+exa_ai,EXA AI,False,model_vendor,L3,unknown,,,,1,search,litellm,1,
+fal,FAL,True,model_vendor,L3,unknown,,,,14,image_generation,edgequake-llm,1,
+fastgpt,FastGPT,True,model_vendor,unknown,unknown,,,https://fastgpt.run/api/openapi,0,chat,one-api,1,
+fastrouter,FastRouter,True,model_vendor,unknown,unknown,,,https://go.fastrouter.ai/api/v1,47,chat;image_generation,mastra;opencode,2,
+featherless_ai,Featherless AI,True,model_vendor,L2,openai,True,,,2,chat,langchain;litellm;portkey-gateway,3,
+firecrawl,Firecrawl,False,model_vendor,L3,unknown,,,,1,search,litellm,1,
+firepass,Fireworks (Firepass),False,model_vendor,unknown,unknown,,,https://api.fireworks.ai/inference/v1,1,chat,opencodex,1,
+fireworks,Fireworks AI,True,deployment_platform,L2,openai,True,,https://api.fireworks.ai/inference/v1,318,audio_transcription;chat;embedding;image_generation;rerank,ai;aisuite;APIPark;awaken;axonhub;bifrost;continue;ferro-ai-gateway;higress;instructor;langchain;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;manifest;mastra;oh-my-opencode-slim;opencode;opencodex;otari;pi;portkey-gateway;pydantic-ai;Roo-Code;rust-genai;tensorzero;unia,29,
+freemodel,FreeModel,False,model_vendor,unknown,unknown,,,https://cc.freemodel.dev/v1,10,chat,mastra;opencode,2,
+friendliai,Friendli,True,model_vendor,L2,openai,True,,https://api.friendli.ai/serverless/v1,11,chat,litellm,1,
+frogbot,FrogBot,False,model_vendor,unknown,unknown,,,https://app.frogbot.ai/api/v1,26,chat,mastra;opencode,2,
+galadriel,Galadriel,True,model_vendor,L2,openai,True,,,0,chat,litellm,1,
+gdc,GDC,True,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+gigachat,Gigachat,True,model_vendor,unknown,unknown,,,,6,chat;embedding,litellm;llama_index,2,
+github,GitHub Models,True,model_vendor,L2,openai,True,,https://models.github.ai/inference,55,chat,axonhub;chats;higress;langchain4j;litellm;mastra;one-hub;opencode;plano;portkey-gateway,10,
+gitlab,GitLab Duo,False,cloud_platform,unknown,unknown,,,,18,chat,agentsdk;opencode,2,
+gmi,GMI,False,model_vendor,unknown,unknown,,,,17,chat,mastra;opencode,2,
+gmicloud,GMI Cloud,False,model_vendor,unknown,unknown,,,https://api.gmi-serving.com/v1,13,chat,mastra;opencode,2,
+google,Google,True,model_vendor,L1,google_gemini,False,,https://generativelanguage.googleapis.com,114,audio_speech;chat;embedding;image_generation;realtime;video_generation,agent-of-empires;agentsdk;ai;aider;aiproxy;aisuite;APIPark;async-openai;autogen;awaken;axonhub;bifrost;CCSwitcher;chats;claude-code-router;claude-worker-proxy;cline;continue;crewAI;dspy;edgequake-llm;eino;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;instructor-go;langchain;langchain4j;LangChain-csharp;langchainjs;langchain-swift;litellm;litellm-rust;llama_index;LlamaIndexTS;llm-connector;llmrust;manifest;mastra;mirascope;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;otari;outlines;pi;plano;portkey-gateway;rig;rllm;Roo-Code;rust_ai_sdk;rust-genai;semantic-kernel;simple-one-api;smg;spring-ai;swiftide;textgrad;unia;uni-api,73,
+google_pse,Google PSE,False,model_vendor,L3,unknown,,,,1,search,litellm,1,
+google_vertex,Vertex,False,model_vendor,unknown,unknown,,,,35,chat;embedding,agentsdk;ai;aider;aiproxy;APIPark;awaken;bifrost;cc-switch;cline;continue;dspy;edgequake-llm;ferro-ai-gateway;haystack;higress;instructor;langchain;langchaingo;langchainjs;litellm;llama_index;llmgateway;mastra;new-api;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;otari;pi;portkey-gateway;rig;Roo-Code;rust-genai;semantic-kernel;simple-one-api;traceloop-hub,39,
+google_vertex_anthropic,Vertex (Anthropic),False,model_vendor,unknown,unknown,,,,11,chat,agent-of-empires;agentsdk;ai;ai.rs;aider;aiproxy;aisuite;APIPark;async-anthropic;autogen;AutoGPT;awaken;axonhub;bifrost;chats;claude-code-router;cline;coai;continue;crewAI;dspy;edgequake-llm;eino;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;instructor-go;kalosm;langchain;langchain4j;LangChain-csharp;langchaingo;langchainjs;langchain-rust;litellm;litellm-rust;llama_index;LlamaIndexTS;llm-connector;llmgateway;llmrust;manifest;mastra;mirascope;multi-llm;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;otari;outlines;pi;pinchbench;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust_ai_sdk;rust-genai;semantic-kernel;simple-one-api;smg;spring-ai;swiftide;tensorzero;textgrad;traceloop-hub;unia;uni-api,85,
+gradient_ai,Gradient AI,True,model_vendor,unknown,unknown,,,,13,chat,litellm,1,
+groq,Groq,True,model_vendor,L2,openai,True,,https://api.groq.com/openai/v1,33,audio_speech;audio_transcription;chat,agentsdk;ai;aider;aiproxy;aisuite;APIPark;AutoGPT;awaken;bifrost;cline;coai;continue;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;helicone-ai-gateway;higress;instructor;langchain;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;manifest;mastra;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;simple-one-api;swiftide;tensorzero;textgrad;unia,46,
+helicone,Helicone,True,gateway_aggregator,L4,mixed,True,,https://ai-gateway.helicone.ai/v1,90,chat,litellm;llama_index;mastra;opencode,4,
+heroku,Heroku,True,model_vendor,unknown,unknown,,,,27,chat,litellm;llama_index;pydantic-ai,3,
+hetzner,Hetzner,False,model_vendor,unknown,unknown,,,https://inference.hetzner.com/api/v1,1,chat,mastra;opencode,2,
+hosted_vllm,Hosted Vllm,True,deployment_platform,L2,openai,True,,,0,chat,litellm,1,
+hpc_ai,HPC-AI,False,model_vendor,unknown,unknown,,,https://api.hpc-ai.com/inference/v1,9,chat,mastra;opencode,2,
+huggingface,Hugging Face,True,deployment_platform,unknown,unknown,,,https://router.huggingface.co/v1,57,chat;embedding,ai;aisuite;bifrost;cline;continue;edgequake-llm;ferro-ai-gateway;graniet-llm;haystack;langchain;langchain4j;LangChain-csharp;langchaingo;langchain-swift;litellm;llama_index;LlamaIndexTS;manifest;mastra;opencode;opencodex;otari;pi;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;semantic-kernel;semantic-kernel-java,32,
+hyper,Charm Hyper,False,model_vendor,unknown,unknown,,,https://hyper.charm.land/v1,20,chat,mastra;opencode,2,
+hyperbolic,Hyperbolic,True,deployment_platform,L2,openai,True,,,16,chat,helicone-ai-gateway;litellm;portkey-gateway;rig;tensorzero;unia,6,
+iflowcn,iFlow,False,model_vendor,unknown,unknown,,,https://apis.iflow.cn/v1,14,chat,mastra;opencode,2,
+inception,Inception,True,model_vendor,L2,openai,True,,https://api.inceptionlabs.ai/v1,3,chat,aisuite;continue;litellm;mastra;opencode;otari,6,
+inceptron,Inceptron,False,model_vendor,unknown,unknown,,,https://api.inceptron.io/v1,7,chat,mastra;opencode,2,
+inference_net,Inference,True,model_vendor,unknown,unknown,,,https://inference.net/v1,9,chat;embedding,llmgateway;portkey-gateway,2,
+inferx,InferX,False,model_vendor,unknown,unknown,,,https://model.inferx.net/endpoints/v1,6,chat,mastra;opencode,2,
+io_net,IO.NET,False,model_vendor,unknown,unknown,,,https://api.intelligence.io.solutions/api/v1,17,chat,mastra;opencode,2,
+jiekou,Jiekou.AI,False,model_vendor,unknown,unknown,,,https://api.jiekou.ai/openai,153,chat,mastra;opencode,2,
+jimeng,Jimeng,False,model_vendor,unknown,unknown,,,https://visual.volcengineapi.com,0,chat,new-api,1,
+jina,Jina,False,embedding,unknown,unknown,,,https://api.jina.ai,0,chat,aiproxy;axonhub;edgequake-llm;haystack;new-api;one-hub;portkey-gateway,7,
+jina_ai,Jina AI,False,model_vendor,L3,unknown,,,,1,rerank,litellm,1,
+kenari,Kenari,False,model_vendor,unknown,unknown,,,https://kenari.id/v1,38,chat,mastra;opencode,2,
+kilo,Kilo Gateway,True,model_vendor,unknown,unknown,,,https://api.kilo.ai/api/gateway,346,chat;image_generation,cline;manifest;mastra;opencode;opencodex;pinchbench,6,
+kimi,Kimi,False,model_vendor,unknown,unknown,,,,0,chat,agent-of-empires;ai;aiproxy;APIPark;awaken;axonhub;chats;cline;coai;continue;ferro-ai-gateway;higress;langchain;litellm;llm-connector;llmgateway;llmrust;manifest;mastra;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;Roo-Code;rust-genai;unia,43,
+kimi_for_coding,Kimi For Coding,False,model_vendor,unknown,unknown,,,https://api.kimi.com/coding/v1,4,chat,agent-of-empires;ai;aiproxy;APIPark;awaken;axonhub;chats;cline;coai;continue;ferro-ai-gateway;higress;langchain;litellm;llm-connector;llmgateway;llmrust;manifest;mastra;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;Roo-Code;rust-genai;unia,43,
+kling,Kling,False,model_vendor,unknown,unknown,,,https://api.klingai.com,0,chat,new-api;one-hub,2,
+kuae_cloud_coding_plan,KUAE Cloud Coding Plan,False,model_vendor,unknown,unknown,,,https://coding-plan-endpoint.kuaecloud.net/v1,1,chat,mastra;opencode,2,
+lambda_ai,Lambda AI,True,model_vendor,L2,openai,True,,,20,chat,litellm,1,
+lemonade,Lemonade,False,model_vendor,unknown,unknown,,,,5,chat,continue;litellm,2,
+libertai,Libertai,False,model_vendor,L2,openai,True,,,12,chat;embedding,litellm,1,
+lilac,Lilac,False,model_vendor,unknown,unknown,,,https://api.getlilac.com/v1,6,chat,mastra;opencode,2,
+lingyiwanwu,LingYiWanWu,True,model_vendor,unknown,unknown,,,https://api.lingyiwanwu.com,0,chat,aiproxy;new-api;one-api,3,
+linkup,Linkup,False,model_vendor,L3,unknown,,,,2,search,litellm,1,
+litellm_proxy,Litellm Proxy,True,gateway_aggregator,L4,mixed,True,,,0,chat,cline;haystack;instructor;langchain;litellm;llama_index;opencodex;OpenHands;pydantic-ai;Roo-Code;textgrad,11,
+llama,Llama,False,model_vendor,unknown,unknown,,,https://api.llama.com/compat/v1,7,chat,mastra;opencode,2,
+llamafile,Llamafile,True,local_runtime,L2,openai,True,,,0,chat,continue;langchaingo;litellm;llama_index;otari;rig,6,
+llamagate,Llamagate,False,model_vendor,unknown,unknown,,,,16,chat;embedding,,,
+llmgateway,LLM Gateway,False,gateway_aggregator,unknown,unknown,,,https://api.llmgateway.io/v1,224,chat,llmgateway;mastra;opencode,3,
+llmtr,LLMTR,False,model_vendor,unknown,unknown,,,https://llmtr.com/v1,6,chat,mastra;opencode,2,
+lmstudio,LMStudio,True,local_runtime,L2,openai,True,,http://127.0.0.1:1234/v1,3,chat,aider;aisuite;APIPark;cline;codex;continue;edgequake-llm;langchain-swift;litellm;llama_index;manifest;mastra;multi-llm;opencode;opencodex;otari;outlines;Roo-Code,18,
+longcat,LongCat,True,model_vendor,unknown,unknown,,,https://api.longcat.chat/openai,1,chat,axonhub;cc-switch;llm-connector;mastra;opencode,5,
+lucidquery,LucidQuery,False,model_vendor,unknown,unknown,,,https://api.lucidquery.com/v1;https://lucidquery.com/api/v1,4,chat,mastra;opencode,2,
+lynkr,Lynkr,False,local_runtime,unknown,unknown,,,http://127.0.0.1:8081/v1,1,chat,mastra;opencode,2,
+maritalk,Maritalk,False,model_vendor,unknown,unknown,,,,0,chat,litellm;llama_index,2,
+meganova,Meganova,False,model_vendor,unknown,unknown,,,https://api.meganova.ai/v1,19,chat,mastra;opencode,2,
+merge_gateway,Merge Gateway,False,model_vendor,unknown,unknown,,,,83,chat,opencode,1,
+meta,Meta,False,model_vendor,L2,openai,True,,https://api.meta.ai/v1,2,chat,haystack;langchain;litellm;llama_index;llmgateway;mastra;opencode;plano,9,
+meta_llama,Meta Llama,True,model_vendor,L2,openai,True,,,4,chat,haystack;langchain;litellm;llama_index;llmgateway;mastra;opencode;plano,9,
+midjourney,Midjourney,False,modal_service,unknown,unknown,,,https://oa.api2d.net,0,chat,coai;one-hub,2,
+midjourney_plus,MidjourneyPlus,False,model_vendor,unknown,unknown,,,https://api.openai-sb.com,0,chat,,,
+mimo,Mimo,False,model_vendor,unknown,unknown,,,,0,chat,awaken;continue;rust-genai,3,
+minimax,MiniMax (minimax.io),True,model_vendor,unknown,unknown,,,https://api.minimax.chat;https://api.minimax.io/anthropic/v1,17,audio_speech;chat,ai;aiproxy;APIPark;awaken;axonhub;ccs-nicremo;chats;cline;continue;higress;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;rig;Roo-Code;rust-genai;simple-one-api,37,
+minimax_cn,MiniMax (minimaxi.com),False,model_vendor,unknown,unknown,,,https://api.minimaxi.com/anthropic/v1,7,chat,ai;aiproxy;APIPark;awaken;axonhub;ccs-nicremo;chats;cline;continue;higress;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;rig;Roo-Code;rust-genai;simple-one-api,37,
+minimax_cn_coding_plan,MiniMax Token Plan (minimaxi.com),False,model_vendor,unknown,unknown,,,https://api.minimaxi.com/anthropic/v1,7,chat,ai;aiproxy;APIPark;awaken;axonhub;ccs-nicremo;chats;cline;continue;higress;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;rig;Roo-Code;rust-genai;simple-one-api,37,
+minimax_coding_plan,MiniMax Token Plan (minimax.io),False,model_vendor,unknown,unknown,,,https://api.minimax.io/anthropic/v1,7,chat,ai;aiproxy;APIPark;awaken;axonhub;ccs-nicremo;chats;cline;continue;higress;litellm;llama_index;llm-connector;llmgateway;manifest;mastra;new-api;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;rig;Roo-Code;rust-genai;simple-one-api,37,
+mistral,Mistral,True,model_vendor,L1,mistral,False,,https://api.mistral.ai;https://api.mistral.ai/v1,89,chat;embedding;other,agentsdk;ai;aider;aiproxy;aisuite;APIPark;bifrost;claude-code-router;cline;continue;edgequake-llm;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;langchain;langchain4j;langchaingo;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;manifest;mastra;new-api;one-api;one-hub;opencode;opencodex;OpenGateLLM;OpenHands;otari;outlines;pi;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;semantic-kernel;spring-ai;tensorzero;unia,48,
+mixlayer,Mixlayer,False,model_vendor,unknown,unknown,,,https://models.mixlayer.ai/v1,5,chat,mastra;opencode,2,
+moark,Moark,False,model_vendor,unknown,unknown,,,https://moark.com/v1,2,chat,mastra;opencode,2,
+model_oracle_ai,Model Oracle AI,False,model_vendor,unknown,unknown,,,https://api.modeloracle.com/api/v1,15,chat,mastra;opencode,2,
+modelscope,ModelScope,True,model_vendor,L2,openai,True,,https://api-inference.modelscope.cn/v1,7,chat,axonhub;cc-switch;langchain;litellm;llama_index;mastra;opencode,7,
+moka_ai,MokaAI,False,model_vendor,unknown,unknown,,,https://api.moka.ai,0,chat,,,
+moonshotai,Moonshot AI,True,model_vendor,L2,openai,True,,https://api.moonshot.ai/anthropic/v1;https://api.moonshot.ai/v1;https://api.moonshot.cn;https://api.moonshot.cn/v1,41,chat,agent-of-empires;ai;aiproxy;APIPark;awaken;axonhub;chats;cline;coai;continue;ferro-ai-gateway;higress;langchain;litellm;llm-connector;llmgateway;llmrust;manifest;mastra;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;Roo-Code;rust-genai;unia,43,
+moonshotai_cn,Moonshot AI (China),False,model_vendor,unknown,unknown,,,https://api.moonshot.cn/anthropic/v1,10,chat,agent-of-empires;ai;aiproxy;APIPark;awaken;axonhub;chats;cline;coai;continue;ferro-ai-gateway;higress;langchain;litellm;llm-connector;llmgateway;llmrust;manifest;mastra;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencodex;OpenHands;otari;pi;plano;portkey-gateway;pydantic-ai;rig;Roo-Code;rust-genai;unia,43,
+morph,Morph,True,model_vendor,L2,openai,True,,https://api.morphllm.com/v1,5,chat,litellm;mastra;opencode,3,
+nanogpt,NanoGPT,True,model_vendor,L2,openai,True,,https://nano-gpt.com/api/v1,617,chat;image_generation,axonhub;litellm;llmgateway;mastra;opencode;opencodex,6,
+nearai,NEAR AI Cloud,False,model_vendor,unknown,unknown,,,https://cloud-api.near.ai/v1,37,chat;embedding;rerank,mastra;opencode,2,
+nebius,Nebius Token Factory,True,deployment_platform,L2,openai,True,,https://api.tokenfactory.nebius.com/v1,63,chat;embedding,aisuite;awaken;bifrost;cline;continue;langchain;litellm;llama_index;llmgateway;mastra;opencode;otari;portkey-gateway;pydantic-ai;rust-genai,15,
+neon,Neon,False,model_vendor,unknown,unknown,,,,37,chat,mastra;opencode,2,
+netlify,Netlify,False,model_vendor,unknown,unknown,,,,68,chat,mastra,1,
+neuralwatt,Neuralwatt,False,model_vendor,unknown,unknown,,,https://api.neuralwatt.com/v1,24,chat,langchain;mastra;opencode;opencodex,4,
+new_api,New API,False,gateway_aggregator,unknown,unknown,,,,0,chat,new-api,1,
+nlp_cloud,NLP Cloud,True,model_vendor,unknown,unknown,,,,2,chat;completion,litellm,1,
+nova,Nova,False,model_vendor,unknown,unknown,,,https://api.nova.amazon.com/v1,2,chat,mastra;opencode,2,
+novita,NovitaAI,True,model_vendor,L2,openai,True,,https://api.novita.ai/openai,192,chat;embedding;rerank,aiproxy;APIPark;cc-switch;chats;continue;ferro-ai-gateway;litellm;llama_index;llmgateway;mastra;one-api;opencode;portkey-gateway,13,
+nscale,Nscale,True,model_vendor,L2,openai,True,,,16,chat;image_generation,litellm;portkey-gateway,2,
+nvidia_nim,Nvidia,True,model_vendor,L2,openai,True,,https://integrate.api.nvidia.com/v1,107,chat;embedding;image_generation;rerank,APIPark;AutoGPT;cc-switch;claude-code-router;continue;edgequake-llm;ferro-ai-gateway;haystack;langchain;litellm;llama_index;manifest;mastra;oh-my-opencode-slim;opencode;opencodex;OpenHands;pi;semantic-kernel;simple-one-api,20,
+oci,OCI,False,model_vendor,unknown,unknown,,,,44,chat;embedding,litellm,1,
+ofox,Ofox,False,model_vendor,unknown,unknown,,,https://api.ofox.ai/v1,13,chat,mastra;opencode,2,
+ohmygpt,OhMyGPT,True,model_vendor,unknown,unknown,,,https://api.ohmygpt.com,0,chat,one-api,1,
+ollama,Ollama Cloud,True,local_runtime,L2,openai,True,,http://localhost:11434;https://ollama.com/v1,590,chat;completion;embedding,agentsdk;aider;aiproxy;aisuite;APIPark;async-openai;autogen;AutoGPT;awaken;axonhub;bifrost;chats;cline;codex;continue;crewAI;dotnet-extensions;dspy;edgequake-llm;eino;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;instructor-go;langchain;langchain4j;LangChain-csharp;langchaingo;langchainjs;langchain-rust;langchain-swift;litellm;llama_index;LlamaIndexTS;llm-connector;llmrust;manifest;mastra;mirascope;multi-llm;new-api;ollama-rs;one-api;one-hub;opencode;opencodex;OpenHands;otari;outlines;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;semantic-kernel;simple-one-api;smg;spring-ai;swiftide;textgrad;unia,73,
+ollama_chat,Ollama Chat,False,model_vendor,unknown,unknown,,,,0,chat,agentsdk;aider;aiproxy;aisuite;APIPark;async-openai;autogen;AutoGPT;awaken;axonhub;bifrost;chats;cline;codex;continue;crewAI;dotnet-extensions;dspy;edgequake-llm;eino;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;instructor-go;langchain;langchain4j;LangChain-csharp;langchaingo;langchainjs;langchain-rust;langchain-swift;litellm;llama_index;LlamaIndexTS;llm-connector;llmrust;manifest;mastra;mirascope;multi-llm;new-api;ollama-rs;one-api;one-hub;opencode;opencodex;OpenHands;otari;outlines;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;semantic-kernel;simple-one-api;smg;spring-ai;swiftide;textgrad;unia,73,
+ollama_cloud,Ollama Cloud,True,model_vendor,L2,openai,True,,https://ollama.com/v1,19,chat,agentsdk;aider;aiproxy;aisuite;APIPark;async-openai;autogen;AutoGPT;awaken;axonhub;bifrost;chats;cline;codex;continue;crewAI;dotnet-extensions;dspy;edgequake-llm;eino;ferro-ai-gateway;graniet-llm;haystack;helicone-ai-gateway;higress;instructor;instructor-go;langchain;langchain4j;LangChain-csharp;langchaingo;langchainjs;langchain-rust;langchain-swift;litellm;llama_index;LlamaIndexTS;llm-connector;llmrust;manifest;mastra;mirascope;multi-llm;new-api;ollama-rs;one-api;one-hub;opencode;opencodex;OpenHands;otari;outlines;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;semantic-kernel;simple-one-api;smg;spring-ai;swiftide;textgrad;unia,73,
+omlx,Omlx,True,local_runtime,L2,openai,True,,,0,chat,awaken;edgequake-llm;rust-genai,3,
+oobabooga,Oobabooga,False,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+openai,OpenAI,True,model_vendor,L1,openai,,,https://api.openai.com,223,audio_speech;audio_transcription;chat;embedding;image_generation;moderation;realtime;responses;video_generation,ai;ai.rs;aider;aiproxy;aisuite;APIPark;async-openai;autogen;AutoGPT;awaken;axonhub;bifrost;chats;claude-code-router;claude-worker-proxy;cline;coai;codex;continue;crewAI;dotnet-extensions;dspy;edgequake-llm;eino;envoy-ai-gateway;ferro-ai-gateway;graniet-llm;guidance;haystack;helicone-ai-gateway;higress;instructor;instructor-go;kalosm;langchain;langchain4j;LangChain-csharp;langchaingo;langchainjs;langchain-rust;langchain-swift;litellm;litellm-rust;llama_index;LlamaIndexTS;llm-chain;llm-connector;llmgateway;llmrust;manifest;mastra;mirascope;multi-llm;new-api;oh-my-opencode-slim;one-api;one-hub;opencode;opencode-ai;opencodex;OpenGateLLM;OpenHands;otari;outlines;pi;pinchbench;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust_ai_sdk;rust-genai;semantic-kernel;semantic-kernel-java;simple-one-api;smg;spring-ai;swiftide;tensorzero;textgrad;traceloop-hub;unia,92,
+openaimax,OpenAIMax,True,model_vendor,unknown,unknown,,,https://api.openaimax.com,0,chat,one-api,1,
+opencode,OpenCode Zen,False,model_vendor,unknown,unknown,,,https://opencode.ai/zen/v1,85,chat,agent-of-empires;bifrost;claude-code-router;cline;mastra;opencode;pi,7,
+opencode_go,OpenCode Go,True,model_vendor,unknown,unknown,,,https://opencode.ai/zen/go/v1,22,chat,awaken;axonhub;manifest;mastra;opencode;opencodex;pi;rust-genai,8,
+openrouter,OpenRouter,True,gateway_aggregator,L4,mixed,True,,https://openrouter.ai/api;https://openrouter.ai/api/v1,472,audio_speech;chat;image_generation,agentsdk;ai.rs;aider;aiproxy;aisuite;APIPark;AutoGPT;awaken;axonhub;bifrost;cc-switch;chats;claude-code-router;cline;continue;crewAI;dspy;edgequake-llm;eino;ferro-ai-gateway;graniet-llm;haystack;higress;instructor;kalosm;langchain;LangChain-csharp;langchainjs;litellm;litellm-rust;llama_index;llm-connector;llmrust;manifest;mastra;mirascope;new-api;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;otari;outlines;pi;pinchbench;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;simple-one-api;swiftide;tensorzero;unia;uni-api,59,
+orcarouter,OrcaRouter,True,model_vendor,unknown,unknown,,,https://api.orcarouter.ai/v1,81,chat,haystack;mastra;opencode;opencodex;outlines,5,
+ovhcloud,OVHcloud AI Endpoints,True,model_vendor,unknown,unknown,,,https://oai.endpoints.kepler.ai.cloud.ovh.net/v1,30,chat,continue;litellm;llama_index;LlamaIndexTS;mastra;opencode;portkey-gateway;pydantic-ai,8,
+pa_lm,PaLM,False,model_vendor,unknown,unknown,,,,0,chat,,,
+palm,Palm,False,model_vendor,unknown,unknown,,,,6,chat;completion,litellm;llama_index;one-api;one-hub;portkey-gateway,5,
+parallel_ai,Parallel AI,False,model_vendor,L3,unknown,,,,2,search,,,
+parasail,Parasail,True,model_vendor,L2,openai,True,,,0,,bifrost;litellm,2,
+perplexity,Perplexity,True,model_vendor,L2,openai,True,,https://api.perplexity.ai,45,chat;embedding;responses;search,agentsdk;ai;bifrost;ferro-ai-gateway;haystack;instructor;langchain;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;mastra;new-api;opencode;otari;rig;unia,20,
+perplexity_agent,Perplexity Agent,False,model_vendor,unknown,unknown,,,https://api.perplexity.ai/v1,18,chat,agentsdk;ai;bifrost;ferro-ai-gateway;haystack;instructor;langchain;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;mastra;new-api;opencode;otari;rig;unia,20,
+petals,Petals,True,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+pinstripes,Pinstripes,False,model_vendor,L2,openai,True,,,6,chat,litellm,1,
+pioneer,Pioneer,True,model_vendor,unknown,unknown,,,https://api.pioneer.ai/v1,76,chat,manifest;mastra;opencode,3,
+poe,Poe,False,model_vendor,L2,openai,True,,https://api.poe.com/v1,137,chat;image_generation,litellm;mastra;opencode;Roo-Code,4,
+poolside,Poolside,False,model_vendor,unknown,unknown,,,https://inference.poolside.ai/v1,4,chat,cline;mastra;opencode,3,
+ppinfra,PPInfra,False,model_vendor,unknown,unknown,,,,101,chat,,,
+predibase,Predibase,True,model_vendor,unknown,unknown,,,,0,chat,litellm;llama_index;portkey-gateway,3,
+privatemode_ai,Privatemode AI,False,local_runtime,unknown,unknown,,,http://localhost:8080/v1,7,chat;embedding,mastra;opencode,2,
+publicai,Publicai,False,model_vendor,L2,openai,True,,,9,chat,litellm,1,
+qihang_ai,QiHang,False,model_vendor,unknown,unknown,,,https://api.qhaigc.net/v1,9,chat,mastra;opencode,2,
+qihoo360,360,True,model_vendor,unknown,unknown,,,https://api.360.cn,0,chat,,,
+qiniu_ai,Qiniu,True,model_vendor,unknown,unknown,,,https://api.qnaigc.com/v1,91,chat;image_generation,mastra;opencode,2,
+ragflow,Ragflow,False,model_vendor,L2,openai,True,,,0,,litellm,1,
+recraft,Recraft,False,model_vendor,L3,unknown,,,,2,image_generation,litellm;one-hub,2,
+reducto,Reducto,False,model_vendor,L3,unknown,,,,2,other,litellm,1,
+regolo_ai,Regolo AI,False,model_vendor,unknown,unknown,,,https://api.regolo.ai/v1,13,chat;embedding;image_generation;rerank,mastra;opencode,2,
+replicate,Replicate,True,deployment_platform,unknown,unknown,,,https://api.replicate.com,40,chat,bifrost;continue;ferro-ai-gateway;litellm;llama_index;LlamaIndexTS;new-api;one-api;one-hub;portkey-gateway,10,
+requesty,Requesty,True,gateway_aggregator,L4,mixed,,,https://router.requesty.ai/v1,38,chat,aisuite;cline;mastra;opencode;outlines;Roo-Code,6,
+routing_run,routing.run,False,model_vendor,unknown,unknown,,,https://ai.routing.sh/v1;https://api.routing.run/v1,41,chat,mastra;opencode,2,
+runwayml,Runwayml,False,model_vendor,L3,unknown,,,,6,audio_speech;image_generation;video_generation,litellm,1,
+sagemaker,Sagemaker,False,cloud_platform,unknown,unknown,,,,6,chat;completion,continue;dspy;litellm;llama_index;llm-chain;otari;portkey-gateway,7,
+sagemaker_chat,Sagemaker Chat,False,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+sagemaker_nova,Sagemaker Nova,False,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+sakana,Sakana AI,True,model_vendor,unknown,unknown,,,https://api.sakana.ai/v1,3,chat,llmgateway;mastra;opencode,3,
+sambanova,Sambanova,True,deployment_platform,L2,openai,True,,,19,chat,aisuite;cline;continue;envoy-ai-gateway;ferro-ai-gateway;instructor;langchain;litellm;otari;portkey-gateway;pydantic-ai;Roo-Code,12,
+sap_ai_core,SAP AI Core,False,model_vendor,unknown,unknown,,,,26,chat,agentsdk;opencode,2,
+sarvam,Sarvam AI,True,model_vendor,unknown,unknown,,,https://api.sarvam.ai/v1,3,chat,bifrost;langchain;llama_index;mastra;opencode,5,
+scaleway,Scaleway,True,model_vendor,unknown,unknown,,,https://api.scaleway.ai/v1,34,audio_transcription;chat;embedding,continue;mastra;opencode,3,
+searxng,Searxng,False,model_vendor,L3,unknown,,,,1,search,litellm,1,
+serper,Serper,False,search_provider,L3,unknown,,,,1,search,litellm,1,
+siliconflow,SiliconFlow,True,model_vendor,unknown,unknown,,,https://api.siliconflow.cn;https://api.siliconflow.cn/v1;https://api.siliconflow.com/v1,174,audio_speech;chat;embedding;image_edit;other;rerank;video_generation,aiproxy;APIPark;axonhub;chats;claude-code-router;continue;llama_index;mastra;new-api;one-api;one-hub;opencode;opencodex;portkey-gateway;simple-one-api,17,
+snowflake,Snowflake,False,cloud_platform,unknown,unknown,,,,37,chat;embedding,crewAI;litellm;mastra;opencode,4,
+snowflake_cortex,Snowflake Cortex,False,model_vendor,unknown,unknown,,,https://${snowflake_account}.snowflakecomputing.com/api/v2/cortex/v1,21,chat,crewAI;litellm;mastra;opencode,4,
+soniox,Soniox,False,model_vendor,L3,unknown,,,,2,audio_transcription,litellm,1,
+sora,Sora,False,model_vendor,unknown,unknown,,,https://api.openai.com,0,chat,new-api,1,
+stability,Stability,False,modal_service,L3,unknown,,,,23,image_edit;image_generation,litellm;one-hub;portkey-gateway;spring-ai,4,
+stackit,STACKIT,False,model_vendor,unknown,unknown,,,https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1,10,chat,haystack;mastra;opencode,3,
+stepfun,StepFun (Global),True,model_vendor,unknown,unknown,,,https://api.stepfun.ai/step_plan/v1;https://api.stepfun.ai/v1;https://api.stepfun.com/v1,8,chat,aiproxy;APIPark;cc-switch;higress;llama_index;mastra;one-api;opencode,14,
+stepfun_ai_step_plan,StepFun Step Plan (Global),False,model_vendor,unknown,unknown,,,https://api.stepfun.ai/step_plan/v1,3,chat,aiproxy;APIPark;cc-switch;higress;llama_index;mastra;one-api;opencode,14,
+stepfun_step_plan,StepFun Step Plan (China),False,model_vendor,unknown,unknown,,,https://api.stepfun.com/step_plan/v1,4,chat,aiproxy;APIPark;cc-switch;higress;llama_index;mastra;one-api;opencode,14,
+sub2_api,Sub2API,False,model_vendor,unknown,unknown,,,,0,chat,,,
+subconscious,Subconscious,False,model_vendor,unknown,unknown,,,https://api.subconscious.dev/v1,2,chat,mastra;opencode,2,
+submodel,submodel,True,model_vendor,unknown,unknown,,,https://llm.submodel.ai;https://llm.submodel.ai/v1,9,chat,mastra;new-api;opencode,3,
+suno_api,SunoAPI,False,model_vendor,unknown,unknown,,,,0,chat,new-api;one-hub,2,
+synthetic,Synthetic,False,model_vendor,L2,openai,True,,https://api.synthetic.new/openai/v1,38,chat,litellm;mastra;opencode;opencodex,4,
+tavily,Tavily,False,search_provider,L3,unknown,,,,2,search,langchainjs;litellm,2,
+tencent,Tencent,True,model_vendor,L2,openai,True,,https://hunyuan.tencentcloudapi.com,2,chat,aiproxy;APIPark;chats;cline;coai;higress;litellm;llm-connector;mastra;new-api;one-api;one-hub;opencode;opencodex;simple-one-api,19,
+tencent_coding_plan,Tencent Coding Plan (China),False,model_vendor,unknown,unknown,,,https://api.lkeap.cloud.tencent.com/coding/v3,8,chat,aiproxy;APIPark;chats;cline;coai;higress;litellm;llm-connector;mastra;new-api;one-api;one-hub;opencode;opencodex;simple-one-api,19,
+tencent_token_plan,Tencent Token Plan,False,model_vendor,unknown,unknown,,,https://api.lkeap.cloud.tencent.com/plan/v3,1,chat,aiproxy;APIPark;chats;cline;coai;higress;litellm;llm-connector;mastra;new-api;one-api;one-hub;opencode;opencodex;simple-one-api,19,
+tencent_token_plan_enterprise_auto,腾讯云 Token Plan / Token Plan 企业版轻享套餐,False,model_vendor,unknown,unknown,,,https://tokenhub.tencentmaas.com/plan/v3,1,chat,,,
+tencent_token_plan_enterprise_pro,腾讯云 Token Plan / Token Plan 企业版专业套餐,False,model_vendor,unknown,unknown,,,https://tokenhub.tencentmaas.com/plan/v3,16,chat,,,
+tencent_token_plan_general_personal,腾讯云 Token Plan / 通用 Token Plan（个人版）,False,model_vendor,unknown,unknown,,,https://api.lkeap.cloud.tencent.com/plan/v3,8,chat,,,
+tencent_token_plan_hy_personal,腾讯云 Token Plan / Hy Token Plan（个人版）,False,model_vendor,unknown,unknown,,,https://api.lkeap.cloud.tencent.com/plan/v3,2,chat,,,
+tencent_tokenhub,Tencent TokenHub,False,model_vendor,unknown,unknown,,,https://tokenhub.tencentmaas.com/v1,2,chat,aiproxy;APIPark;chats;cline;coai;higress;litellm;llm-connector;mastra;new-api;one-api;one-hub;opencode;opencodex;simple-one-api,19,
+tensormesh,Tensormesh,False,model_vendor,L2,openai,True,,,10,chat,litellm,1,
+text_completion_codestral,Text Completion Codestral,False,model_vendor,unknown,unknown,,,,2,chat;completion,litellm,1,
+text_completion_inception,Text Completion Inception,False,model_vendor,unknown,unknown,,,,1,chat;completion,litellm,1,
+the_grid_ai,The Grid AI,False,model_vendor,unknown,unknown,,,https://api.thegrid.ai/v1,9,chat,mastra;opencode,2,
+thinkingmachines,Thinking Machines,False,model_vendor,unknown,unknown,,,https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1,2,chat,mastra;opencode,2,
+tinfoil,Tinfoil,False,model_vendor,unknown,unknown,,,https://inference.tinfoil.sh/v1,7,chat,mastra;opencode,2,
+tinyfish,Tinyfish,False,model_vendor,L3,unknown,,,,1,search,,,
+togetherai,Together AI,True,model_vendor,L2,openai,True,,,77,chat;embedding,agentsdk;ai;aisuite;awaken;cline;continue;dspy;envoy-ai-gateway;ferro-ai-gateway;haystack;higress;instructor;langchain;langchainjs;litellm;llama_index;LlamaIndexTS;llmgateway;mastra;mirascope;one-api;opencode;opencodex;otari;pi;plano;portkey-gateway;pydantic-ai;rig;rust-genai;tensorzero;textgrad;unia,33,
+tokenflux,Tokenflux,False,model_vendor,unknown,unknown,,,,164,chat,,,
+triton,Triton,False,model_vendor,unknown,unknown,,,,0,chat,higress;litellm;portkey-gateway,3,
+trustedrouter,TrustedRouter,False,model_vendor,unknown,unknown,,,https://api.trustedrouter.com/v1,7,chat,mastra;opencode,2,
+umans_ai,Umans AI,False,model_vendor,unknown,unknown,,,https://api.code.umans.ai/v1,6,chat,mastra;opencode,2,
+umans_ai_coding_plan,Umans AI Coding Plan,False,model_vendor,unknown,unknown,,,https://api.code.umans.ai/v1,7,chat,mastra;opencode,2,
+unorouter,UnoRouter,False,model_vendor,unknown,unknown,,,https://api.unorouter.com/v1,23,chat,mastra;opencode,2,
+upstage,Upstage,True,model_vendor,unknown,unknown,,,https://api.upstage.ai/v1/solar,3,chat,APIPark;langchain;llama_index;mastra;opencode;portkey-gateway,6,
+v0,v0,True,model_vendor,L2,openai,True,,,6,chat,agentsdk;ai;AutoGPT;axonhub;cline;litellm;llama_index;LlamaIndexTS;mastra;opencode;opencodex;pi;plano;pydantic-ai;Roo-Code,18,
+venice,Venice AI,False,model_vendor,unknown,unknown,,,,75,chat,continue;opencode;opencodex,3,
+vercel,Vercel AI Gateway,True,gateway_aggregator,L4,mixed,True,,,426,chat;embedding;image_generation,agentsdk;ai;AutoGPT;axonhub;cline;litellm;llama_index;LlamaIndexTS;mastra;opencode;opencodex;pi;plano;pydantic-ai;Roo-Code,18,
+vertex,VertexAI,True,cloud_platform,L1,google_vertex,False,,,60,audio_speech;audio_transcription;chat;embedding;image_generation;other;video_generation,agentsdk;ai;aider;aiproxy;APIPark;awaken;bifrost;cc-switch;cline;continue;dspy;edgequake-llm;ferro-ai-gateway;haystack;higress;instructor;langchain;langchaingo;langchainjs;litellm;llama_index;llmgateway;mastra;new-api;one-api;one-hub;opencode;opencode-ai;opencodex;OpenHands;otari;pi;portkey-gateway;rig;Roo-Code;rust-genai;semantic-kernel;simple-one-api;traceloop-hub,39,
+vertex_ai_ai21_models,Vertex AI Ai21 Models,False,model_vendor,unknown,unknown,,,,5,chat,,,
+vertex_ai_anthropic_models,Vertex AI Anthropic Models,False,model_vendor,unknown,unknown,,,,37,chat,,,
+vertex_ai_deepseek_models,Vertex AI Deepseek Models,False,model_vendor,unknown,unknown,,,,3,chat,,,
+vertex_ai_language_models,Vertex AI Language Models,False,model_vendor,unknown,unknown,,,,42,chat;embedding;image_generation;realtime,,,
+vertex_ai_llama_models,Vertex AI Llama Models,False,model_vendor,unknown,unknown,,,,11,chat,,,
+vertex_ai_minimax_models,Vertex AI Minimax Models,False,model_vendor,unknown,unknown,,,,1,chat,,,
+vertex_ai_mistral_models,Vertex AI Mistral Models,False,model_vendor,unknown,unknown,,,,19,chat,,,
+vertex_ai_moonshot_models,Vertex AI Moonshot Models,False,model_vendor,unknown,unknown,,,,1,chat,,,
+vertex_ai_openai_models,Vertex AI Openai Models,False,model_vendor,unknown,unknown,,,,3,chat,,,
+vertex_ai_qwen_models,Vertex AI Qwen Models,False,model_vendor,unknown,unknown,,,,4,chat,,,
+vertex_ai_text_models,Vertex AI Text Models,False,model_vendor,unknown,unknown,,,,2,completion,,,
+vertex_ai_zai_models,Vertex AI ZAI Models,False,model_vendor,unknown,unknown,,,,2,chat,,,
+vidu,Vidu,False,model_vendor,unknown,unknown,,,https://api.vidu.cn,0,chat,new-api,1,
+vivgrid,Vivgrid,False,model_vendor,unknown,unknown,,,https://api.vivgrid.com/v1,17,chat,mastra;opencode,2,
+vllm,Vllm,True,local_runtime,L2,openai,True,,,0,chat,bifrost;continue;dynamo;haystack;langchain;litellm;llama_index;LlamaIndexTS;opencodex;OpenGateLLM;otari;outlines;smg;tensorzero;textgrad,15,
+volc_engine,VolcEngine,False,model_vendor,unknown,unknown,,,https://ark.cn-beijing.volces.com,0,chat,aiproxy;axonhub;chats;cline;eino;higress;litellm;new-api;one-api;Roo-Code;simple-one-api,13,
+voyage,Voyage,True,embedding,L3,voyage,False,,,19,embedding;rerank,continue;litellm;otari;portkey-gateway;pydantic-ai;rig,6,
+vultr,Vultr,False,model_vendor,unknown,unknown,,,https://api.vultrinference.com/v1,12,chat,mastra;opencode,2,
+wafer,Wafer,True,model_vendor,unknown,unknown,,,https://pass.wafer.ai/v1,10,chat,bifrost,1,
+wandb,Weights & Biases,False,model_vendor,L2,openai,True,,https://api.inference.wandb.ai/v1,48,chat,cline;litellm;mastra;opencode,4,
+watsonx,Watsonx,False,cloud_platform,unknown,unknown,,,,29,audio_transcription;chat,aisuite;continue;haystack;langchain4j;langchaingo;langchainjs;litellm;llama_index;otari,9,
+watsonx_text,Watsonx Text,False,model_vendor,unknown,unknown,,,,0,chat,litellm,1,
+xai,xAI,True,model_vendor,L1,xai,True,,https://api.x.ai,87,chat,agentsdk;ai;aider;aiproxy;aisuite;awaken;axonhub;bifrost;cc-switch;chats;cline;continue;edgequake-llm;ferro-ai-gateway;graniet-llm;helicone-ai-gateway;instructor;langchain;langchainjs;litellm;litellm-rust;LlamaIndexTS;llmgateway;manifest;mastra;mirascope;new-api;one-api;one-hub;opencode;opencode-ai;opencodex;otari;pi;plano;portkey-gateway;pydantic-ai;rig;rllm;Roo-Code;rust-genai;smg;tensorzero;unia,44,
+xiaomi_token_plan_ams,Xiaomi Token Plan (Europe),False,model_vendor,unknown,unknown,,,https://token-plan-ams.xiaomimimo.com/v1,8,chat,axonhub;chats;cline;llm-connector;llmgateway;manifest;mastra;opencode;opencodex;pi;plano,20,
+xiaomi_token_plan_cn,Xiaomi Token Plan (China),False,model_vendor,unknown,unknown,,,https://token-plan-cn.xiaomimimo.com/v1,8,chat,axonhub;chats;cline;llm-connector;llmgateway;manifest;mastra;opencode;opencodex;pi;plano,20,
+xiaomi_token_plan_sgp,Xiaomi Token Plan (Singapore),False,model_vendor,unknown,unknown,,,https://token-plan-sgp.xiaomimimo.com/v1,8,chat,axonhub;chats;cline;llm-connector;llmgateway;manifest;mastra;opencode;opencodex;pi;plano,20,
+xiaomimimo,Xiaomi,True,model_vendor,unknown,unknown,,,https://api.xiaomimimo.com/v1,6,chat,rig,1,
+xinference,Xinference,True,local_runtime,L2,openai,True,,,0,chat,APIPark;langchain;langchain4j;litellm;llama_index;llm-connector;new-api,7,
+xpersona,Xpersona,False,model_vendor,unknown,unknown,,,https://www.xpersona.co/v1,3,chat,mastra;opencode,2,
+xunfei,Xunfei,False,model_vendor,unknown,unknown,,,,0,chat,aiproxy;APIPark;higress;new-api;one-api;one-hub,6,
+you_com,YOU COM,False,model_vendor,L3,unknown,,,,1,search,litellm,1,
+zai,Z.AI,True,model_vendor,L2,openai,True,,https://api.z.ai/api/paas/v4,33,chat,awaken;axonhub;cline;continue;litellm;litellm-rust;llmgateway;manifest;mastra;oh-my-opencode-slim;opencode;opencodex;pi;pydantic-ai;rig;Roo-Code;rust-genai,20,
+zai_coding_plan,Z.AI Coding Plan,False,model_vendor,unknown,unknown,,,https://api.z.ai/api/coding/paas/v4,6,chat,awaken;axonhub;cline;continue;litellm;litellm-rust;llmgateway;manifest;mastra;oh-my-opencode-slim;opencode;opencodex;pi;pydantic-ai;rig;Roo-Code;rust-genai,20,
+zeldoc,Zeldoc,False,model_vendor,unknown,unknown,,,https://api.zeldoc.ai/v1,1,chat,mastra;opencode,2,
+zenifra,Zenifra,False,model_vendor,unknown,unknown,,,https://ai.zenifra.com/v1,1,chat,mastra;opencode,2,
+zenmux,ZenMux,False,model_vendor,unknown,unknown,,,https://zenmux.ai/api/v1,164,chat;embedding;image_generation,agentsdk;mastra;opencode;opencodex,4,
+zhipu_v4,ZhipuV4,False,model_vendor,unknown,unknown,,,https://open.bigmodel.cn,0,chat,,,
+zhipuai_coding_plan,Zhipu AI Coding Plan,False,model_vendor,unknown,unknown,,,https://open.bigmodel.cn/api/coding/paas/v4,7,chat,aiproxy;APIPark;awaken;axonhub;chats;higress;langchain4j;langchain-swift;llama_index;mastra;one-api;one-hub;opencode;OpenHands;plano;portkey-gateway;rust-genai;simple-one-api,22,
+codex,codex,False,subscription_proxy,unknown,unknown,,,,,,agent-of-empires;axonhub;CCSwitcher;cline;pi;Roo-Code;uni-api,7,high
+azure_ai_foundry,azure (AI Foundry),False,cloud_platform,unknown,unknown,,,,,,chats;dotnet-extensions;ferro-ai-gateway;guidance;llmgateway;pydantic-ai,6,high

--- a/provider-inventory/providers.json
+++ b/provider-inventory/providers.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "1.0.0",
-  "generated_at": "2026-07-28T08:34:03Z",
-  "description": "Provider inventory extracted from six local reference catalogs and deduplicated by canonical provider ID.",
+  "schema_version": "1.1.0",
+  "generated_at": "2026-08-02T13:41:28Z",
+  "description": "Provider inventory extracted from six local reference catalogs, merged with reference-audit findings (104 projects, 2026-08-01). Deduplicated by canonical provider ID; audit-sourced entries are marked with audit.source and require protocol verification.",
   "summary": {
     "raw_source_records": 650,
     "canonical_providers": 325,
@@ -34,7 +34,16 @@
       "local_runtime": 10,
       "model_vendor": 299,
       "subscription_proxy": 2
-    }
+    },
+    "audit_merged_at": "2026-08-01",
+    "audit_extra_providers": 2,
+    "audit_matched_existing": 293,
+    "total_providers": 327,
+    "audit_kept": [
+      "azure_ai_foundry",
+      "codex"
+    ],
+    "audit_candidates_removed": 550
   },
   "source_revisions": {
     "litellm": {
@@ -407,7 +416,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "abacus"
+        ]
+      }
     },
     {
       "id": "abliteration_ai",
@@ -490,7 +515,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "abliteration-ai"
+        ]
+      }
     },
     {
       "id": "advanced_custom",
@@ -536,7 +577,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "new-api"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "Advanced Custom"
+        ]
+      }
     },
     {
       "id": "ai21",
@@ -644,7 +700,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "ferro-ai-gateway",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 2,
+          "native": 2,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "ai21"
+        ]
+      }
     },
     {
       "id": "ai302",
@@ -801,7 +878,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "mastra",
+          "opencode",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "302ai"
+        ]
+      }
     },
     {
       "id": "ai_router",
@@ -872,7 +966,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "ai-router"
+        ]
+      }
     },
     {
       "id": "aiand",
@@ -953,7 +1063,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "aiand"
+        ]
+      }
     },
     {
       "id": "aigc2d",
@@ -1012,13 +1138,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "AIGC2D"
+        ]
+      }
     },
     {
       "id": "aihubmix",
       "display_name": "AIHubMix",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "gateway_aggregator",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -1135,7 +1276,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "awaken",
+          "axonhub",
+          "cc-switch",
+          "cline",
+          "mastra",
+          "opencode",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 6,
+          "native": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "aihubmix"
+        ]
+      }
     },
     {
       "id": "ails",
@@ -1192,7 +1355,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "Ails"
+        ]
+      }
     },
     {
       "id": "aiml",
@@ -1281,7 +1459,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "aiml"
+        ]
+      }
     },
     {
       "id": "aiproxy",
@@ -1338,7 +1531,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "AIProxy"
+        ]
+      }
     },
     {
       "id": "aiproxy_library",
@@ -1395,7 +1603,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "AIProxy Library"
+        ]
+      }
     },
     {
       "id": "aki_io",
@@ -1468,7 +1691,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "aki-io"
+        ]
+      }
     },
     {
       "id": "ali",
@@ -1525,14 +1764,47 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "aiproxy"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "ali"
+        ]
+      }
     },
     {
       "id": "alibaba",
       "display_name": "Alibaba",
       "aliases": [
+        "Aliyun DashScope",
+        "Aliyun DashScope 通义千问",
+        "DashScope",
+        "Qwen (DashScope)",
+        "Qwen / DashScope",
+        "Qwen Coder",
+        "alibaba-cn",
+        "alibaba-coding-plan",
+        "alibaba-coding-plan-cn",
+        "alibaba-token-plan",
+        "alibaba-token-plan-cn",
         "aliyun",
-        "dashscope"
+        "bailian",
+        "dashscope",
+        "qwen",
+        "qwen-code",
+        "tongyi",
+        "通义 DashScope",
+        "阿里百炼 Bailian",
+        "阿里通义千问"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -1755,12 +2027,100 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 46,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "cc-switch",
+          "chats",
+          "cline",
+          "eino",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain4j",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "portkey-gateway",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide"
+        ],
+        "access": {
+          "openai_compat": 35,
+          "special": 6,
+          "native": 3,
+          "none": 2
+        },
+        "special_entries": 6,
+        "spellings": [
+          "alibaba",
+          "alibaba-cn",
+          "alibaba-coding-plan",
+          "alibaba-coding-plan-cn",
+          "alibaba-token-plan",
+          "alibaba-token-plan-cn",
+          "aliyun",
+          "Aliyun DashScope",
+          "Aliyun DashScope 通义千问",
+          "bailian",
+          "DashScope",
+          "qwen",
+          "Qwen (DashScope)",
+          "Qwen / DashScope",
+          "Qwen Coder",
+          "qwen-code",
+          "tongyi",
+          "阿里百炼 Bailian",
+          "阿里通义千问",
+          "通义 DashScope"
+        ]
+      }
     },
     {
       "id": "alibaba_cn",
       "display_name": "Alibaba (China)",
-      "aliases": [],
+      "aliases": [
+        "Aliyun DashScope",
+        "Aliyun DashScope 通义千问",
+        "DashScope",
+        "Qwen (DashScope)",
+        "Qwen / DashScope",
+        "Qwen Coder",
+        "alibaba",
+        "alibaba-coding-plan",
+        "alibaba-coding-plan-cn",
+        "alibaba-token-plan",
+        "alibaba-token-plan-cn",
+        "aliyun",
+        "bailian",
+        "qwen",
+        "qwen-code",
+        "tongyi",
+        "通义 DashScope",
+        "阿里百炼 Bailian",
+        "阿里通义千问"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -1908,12 +2268,100 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 46,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "cc-switch",
+          "chats",
+          "cline",
+          "eino",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain4j",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "portkey-gateway",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide"
+        ],
+        "access": {
+          "openai_compat": 35,
+          "special": 6,
+          "native": 3,
+          "none": 2
+        },
+        "special_entries": 6,
+        "spellings": [
+          "alibaba",
+          "alibaba-cn",
+          "alibaba-coding-plan",
+          "alibaba-coding-plan-cn",
+          "alibaba-token-plan",
+          "alibaba-token-plan-cn",
+          "aliyun",
+          "Aliyun DashScope",
+          "Aliyun DashScope 通义千问",
+          "bailian",
+          "DashScope",
+          "qwen",
+          "Qwen (DashScope)",
+          "Qwen / DashScope",
+          "Qwen Coder",
+          "qwen-code",
+          "tongyi",
+          "阿里百炼 Bailian",
+          "阿里通义千问",
+          "通义 DashScope"
+        ]
+      }
     },
     {
       "id": "alibaba_coding_plan",
       "display_name": "Alibaba Coding Plan",
-      "aliases": [],
+      "aliases": [
+        "Aliyun DashScope",
+        "Aliyun DashScope 通义千问",
+        "DashScope",
+        "Qwen (DashScope)",
+        "Qwen / DashScope",
+        "Qwen Coder",
+        "alibaba",
+        "alibaba-cn",
+        "alibaba-coding-plan-cn",
+        "alibaba-token-plan",
+        "alibaba-token-plan-cn",
+        "aliyun",
+        "bailian",
+        "qwen",
+        "qwen-code",
+        "tongyi",
+        "通义 DashScope",
+        "阿里百炼 Bailian",
+        "阿里通义千问"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -2022,12 +2470,100 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 46,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "cc-switch",
+          "chats",
+          "cline",
+          "eino",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain4j",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "portkey-gateway",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide"
+        ],
+        "access": {
+          "openai_compat": 35,
+          "special": 6,
+          "native": 3,
+          "none": 2
+        },
+        "special_entries": 6,
+        "spellings": [
+          "alibaba",
+          "alibaba-cn",
+          "alibaba-coding-plan",
+          "alibaba-coding-plan-cn",
+          "alibaba-token-plan",
+          "alibaba-token-plan-cn",
+          "aliyun",
+          "Aliyun DashScope",
+          "Aliyun DashScope 通义千问",
+          "bailian",
+          "DashScope",
+          "qwen",
+          "Qwen (DashScope)",
+          "Qwen / DashScope",
+          "Qwen Coder",
+          "qwen-code",
+          "tongyi",
+          "阿里百炼 Bailian",
+          "阿里通义千问",
+          "通义 DashScope"
+        ]
+      }
     },
     {
       "id": "alibaba_coding_plan_cn",
       "display_name": "Alibaba Coding Plan (China)",
-      "aliases": [],
+      "aliases": [
+        "Aliyun DashScope",
+        "Aliyun DashScope 通义千问",
+        "DashScope",
+        "Qwen (DashScope)",
+        "Qwen / DashScope",
+        "Qwen Coder",
+        "alibaba",
+        "alibaba-cn",
+        "alibaba-coding-plan",
+        "alibaba-token-plan",
+        "alibaba-token-plan-cn",
+        "aliyun",
+        "bailian",
+        "qwen",
+        "qwen-code",
+        "tongyi",
+        "通义 DashScope",
+        "阿里百炼 Bailian",
+        "阿里通义千问"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -2136,12 +2672,100 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 46,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "cc-switch",
+          "chats",
+          "cline",
+          "eino",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain4j",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "portkey-gateway",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide"
+        ],
+        "access": {
+          "openai_compat": 35,
+          "special": 6,
+          "native": 3,
+          "none": 2
+        },
+        "special_entries": 6,
+        "spellings": [
+          "alibaba",
+          "alibaba-cn",
+          "alibaba-coding-plan",
+          "alibaba-coding-plan-cn",
+          "alibaba-token-plan",
+          "alibaba-token-plan-cn",
+          "aliyun",
+          "Aliyun DashScope",
+          "Aliyun DashScope 通义千问",
+          "bailian",
+          "DashScope",
+          "qwen",
+          "Qwen (DashScope)",
+          "Qwen / DashScope",
+          "Qwen Coder",
+          "qwen-code",
+          "tongyi",
+          "阿里百炼 Bailian",
+          "阿里通义千问",
+          "通义 DashScope"
+        ]
+      }
     },
     {
       "id": "alibaba_token_plan",
       "display_name": "Alibaba Token Plan",
-      "aliases": [],
+      "aliases": [
+        "Aliyun DashScope",
+        "Aliyun DashScope 通义千问",
+        "DashScope",
+        "Qwen (DashScope)",
+        "Qwen / DashScope",
+        "Qwen Coder",
+        "alibaba",
+        "alibaba-cn",
+        "alibaba-coding-plan",
+        "alibaba-coding-plan-cn",
+        "alibaba-token-plan-cn",
+        "aliyun",
+        "bailian",
+        "qwen",
+        "qwen-code",
+        "tongyi",
+        "通义 DashScope",
+        "阿里百炼 Bailian",
+        "阿里通义千问"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -2276,12 +2900,100 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 46,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "cc-switch",
+          "chats",
+          "cline",
+          "eino",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain4j",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "portkey-gateway",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide"
+        ],
+        "access": {
+          "openai_compat": 35,
+          "special": 6,
+          "native": 3,
+          "none": 2
+        },
+        "special_entries": 6,
+        "spellings": [
+          "alibaba",
+          "alibaba-cn",
+          "alibaba-coding-plan",
+          "alibaba-coding-plan-cn",
+          "alibaba-token-plan",
+          "alibaba-token-plan-cn",
+          "aliyun",
+          "Aliyun DashScope",
+          "Aliyun DashScope 通义千问",
+          "bailian",
+          "DashScope",
+          "qwen",
+          "Qwen (DashScope)",
+          "Qwen / DashScope",
+          "Qwen Coder",
+          "qwen-code",
+          "tongyi",
+          "阿里百炼 Bailian",
+          "阿里通义千问",
+          "通义 DashScope"
+        ]
+      }
     },
     {
       "id": "alibaba_token_plan_cn",
       "display_name": "Alibaba Token Plan (China)",
-      "aliases": [],
+      "aliases": [
+        "Aliyun DashScope",
+        "Aliyun DashScope 通义千问",
+        "DashScope",
+        "Qwen (DashScope)",
+        "Qwen / DashScope",
+        "Qwen Coder",
+        "alibaba",
+        "alibaba-cn",
+        "alibaba-coding-plan",
+        "alibaba-coding-plan-cn",
+        "alibaba-token-plan",
+        "aliyun",
+        "bailian",
+        "qwen",
+        "qwen-code",
+        "tongyi",
+        "通义 DashScope",
+        "阿里百炼 Bailian",
+        "阿里通义千问"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -2416,7 +3128,75 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 46,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "cc-switch",
+          "chats",
+          "cline",
+          "eino",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain4j",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "portkey-gateway",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide"
+        ],
+        "access": {
+          "openai_compat": 35,
+          "special": 6,
+          "native": 3,
+          "none": 2
+        },
+        "special_entries": 6,
+        "spellings": [
+          "alibaba",
+          "alibaba-cn",
+          "alibaba-coding-plan",
+          "alibaba-coding-plan-cn",
+          "alibaba-token-plan",
+          "alibaba-token-plan-cn",
+          "aliyun",
+          "Aliyun DashScope",
+          "Aliyun DashScope 通义千问",
+          "bailian",
+          "DashScope",
+          "qwen",
+          "Qwen (DashScope)",
+          "Qwen / DashScope",
+          "Qwen Coder",
+          "qwen-code",
+          "tongyi",
+          "阿里百炼 Bailian",
+          "阿里通义千问",
+          "通义 DashScope"
+        ]
+      }
     },
     {
       "id": "ambient",
@@ -2514,12 +3294,37 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "ambient"
+        ]
+      }
     },
     {
       "id": "anthropic",
       "display_name": "Anthropic",
-      "aliases": [],
+      "aliases": [
+        "Anthropic / Claude",
+        "Anthropic Claude",
+        "anthropic (claude)",
+        "anthropic-aws",
+        "anthropic_aws",
+        "claude",
+        "google-vertex-anthropic",
+        "vertex-anthropic"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L1",
@@ -2774,7 +3579,111 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 85,
+        "projects": [
+          "agent-of-empires",
+          "agentsdk",
+          "ai",
+          "ai.rs",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "async-anthropic",
+          "autogen",
+          "AutoGPT",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "chats",
+          "claude-code-router",
+          "cline",
+          "coai",
+          "continue",
+          "crewAI",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "kalosm",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchainjs",
+          "langchain-rust",
+          "litellm",
+          "litellm-rust",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "multi-llm",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "pi",
+          "pinchbench",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust_ai_sdk",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "traceloop-hub",
+          "unia",
+          "uni-api"
+        ],
+        "access": {
+          "native": 71,
+          "special": 10,
+          "none": 3,
+          "openai_compat": 1
+        },
+        "special_entries": 28,
+        "spellings": [
+          "anthropic",
+          "anthropic (claude)",
+          "Anthropic / Claude",
+          "Anthropic Claude",
+          "anthropic_aws",
+          "anthropic-aws",
+          "claude",
+          "google-vertex-anthropic",
+          "vertex-anthropic"
+        ]
+      }
     },
     {
       "id": "anthropic_text",
@@ -2820,7 +3729,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "native": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "anthropic_text"
+        ]
+      }
     },
     {
       "id": "anyapi",
@@ -2973,13 +3897,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "anyapi"
+        ]
+      }
     },
     {
       "id": "anyscale",
       "display_name": "Anyscale",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -3060,7 +4000,27 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "dspy",
+          "instructor",
+          "litellm",
+          "llama_index",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 4,
+          "none": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "anyscale"
+        ]
+      }
     },
     {
       "id": "apertis",
@@ -3103,7 +4063,23 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "litellm",
+          "llama_index"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "apertis"
+        ]
+      }
     },
     {
       "id": "api2gpt",
@@ -3162,7 +4138,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "API2GPT"
+        ]
+      }
     },
     {
       "id": "apiserpent",
@@ -3215,7 +4206,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "apiserpent"
+        ]
+      }
     },
     {
       "id": "assemblyai",
@@ -3315,7 +4321,26 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "awaken",
+          "axonhub",
+          "llmgateway",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 3,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "atlascloud"
+        ]
+      }
     },
     {
       "id": "atomic_chat",
@@ -3409,7 +4434,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "atomic-chat"
+        ]
+      }
     },
     {
       "id": "auriko",
@@ -3532,12 +4573,43 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "auriko"
+        ]
+      }
     },
     {
       "id": "aws",
       "display_name": "AWS",
-      "aliases": [],
+      "aliases": [
+        "AWS Bedrock",
+        "Amazon Bedrock",
+        "amazon-bedrock",
+        "amazon_bedrock",
+        "amazon_nova",
+        "aws-bedrock",
+        "aws_bedrock",
+        "bedrock",
+        "bedrock (Converse)",
+        "bedrock-converse",
+        "bedrock-mantle",
+        "bedrock_api",
+        "bedrock_mantle",
+        "bedrock_sigv4"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -3578,7 +4650,92 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 62,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "bifrost",
+          "cc-switch",
+          "claude-code",
+          "cline",
+          "codex",
+          "continue",
+          "crewAI",
+          "edgequake-llm",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "traceloop-hub",
+          "uni-api"
+        ],
+        "access": {
+          "special": 58,
+          "native": 2,
+          "openai_compat": 1,
+          "none": 1
+        },
+        "special_entries": 58,
+        "spellings": [
+          "Amazon Bedrock",
+          "amazon_bedrock",
+          "amazon_nova",
+          "amazon-bedrock",
+          "aws",
+          "AWS Bedrock",
+          "aws_bedrock",
+          "aws-bedrock",
+          "bedrock",
+          "bedrock (Converse)",
+          "bedrock_api",
+          "bedrock_mantle",
+          "bedrock_sigv4",
+          "bedrock-converse",
+          "bedrock-mantle"
+        ]
+      }
     },
     {
       "id": "aws_polly",
@@ -3635,12 +4792,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "aws_polly"
+        ]
+      }
     },
     {
       "id": "azure",
       "display_name": "Azure",
-      "aliases": [],
+      "aliases": [
+        "Azure OpenAI",
+        "azure-openai",
+        "azure_openai"
+      ],
       "provider_kind": "cloud_platform",
       "compatibility": {
         "tier": "L1",
@@ -3822,7 +4998,81 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 55,
+        "projects": [
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "autogen",
+          "bifrost",
+          "cc-switch",
+          "coai",
+          "codex",
+          "continue",
+          "crewAI",
+          "dotnet-extensions",
+          "dspy",
+          "edgequake-llm",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "guidance",
+          "haystack",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchainjs",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmgateway",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "plano",
+          "portkey-gateway",
+          "rig",
+          "rllm",
+          "semantic-kernel",
+          "semantic-kernel-java",
+          "simple-one-api",
+          "smg",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "traceloop-hub",
+          "uni-api"
+        ],
+        "access": {
+          "special": 33,
+          "openai_compat": 16,
+          "native": 4,
+          "none": 2
+        },
+        "special_entries": 39,
+        "spellings": [
+          "azure",
+          "Azure OpenAI",
+          "azure_openai",
+          "azure-openai"
+        ]
+      }
     },
     {
       "id": "azure_ai",
@@ -3947,7 +5197,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "langchain",
+          "litellm",
+          "portkey-gateway"
+        ],
+        "access": {
+          "special": 2,
+          "openai_compat": 1
+        },
+        "special_entries": 3,
+        "spellings": [
+          "azure_ai",
+          "azure-ai"
+        ]
+      }
     },
     {
       "id": "azure_cognitive_services",
@@ -4049,7 +5318,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "opencode"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "azure-cognitive-services"
+        ]
+      }
     },
     {
       "id": "azure_text",
@@ -4125,7 +5409,15 @@
     {
       "id": "baidu",
       "display_name": "Baidu",
-      "aliases": [],
+      "aliases": [
+        "Baidu 文心(旧)",
+        "BaiduV2 千帆",
+        "baiduv2",
+        "ernie(百度千帆)",
+        "qianfan",
+        "百度千帆 qianfan",
+        "百度文心"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -4194,12 +5486,50 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 16,
+        "projects": [
+          "aiproxy",
+          "awaken",
+          "eino",
+          "higress",
+          "langchain4j",
+          "langchaingo",
+          "langchain-swift",
+          "llama_index",
+          "one-api",
+          "one-hub",
+          "opencodex",
+          "rust-genai",
+          "simple-one-api"
+        ],
+        "access": {
+          "special": 12,
+          "openai_compat": 3,
+          "native": 1
+        },
+        "special_entries": 13,
+        "spellings": [
+          "baidu",
+          "Baidu 文心(旧)",
+          "baiduv2",
+          "BaiduV2 千帆",
+          "ernie(百度千帆)",
+          "qianfan",
+          "百度千帆 qianfan",
+          "百度文心"
+        ]
+      }
     },
     {
       "id": "baidu_v2",
       "display_name": "BaiduV2",
-      "aliases": [],
+      "aliases": [
+        "Baidu 千帆 v2"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -4251,7 +5581,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "new-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "Baidu 千帆 v2"
+        ]
+      }
     },
     {
       "id": "bailing",
@@ -4335,13 +5680,30 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "cc-switch",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "BaiLing"
+        ]
+      }
     },
     {
       "id": "baseten",
       "display_name": "Baseten",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -4508,16 +5870,50 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 8,
+        "projects": [
+          "ai",
+          "cline",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "mastra",
+          "opencode",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 7,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "baseten"
+        ]
+      }
     },
     {
       "id": "bedrock",
       "display_name": "Amazon Bedrock",
       "aliases": [
+        "AWS Bedrock",
+        "Amazon Bedrock",
         "amazon-bedrock",
+        "amazon_bedrock",
         "amazon_nova",
+        "aws",
+        "aws-bedrock",
+        "aws_bedrock",
+        "bedrock (Converse)",
+        "bedrock-converse",
+        "bedrock-mantle",
         "bedrock_api",
-        "bedrock_converse"
+        "bedrock_converse",
+        "bedrock_mantle",
+        "bedrock_sigv4"
       ],
       "provider_kind": "cloud_platform",
       "compatibility": {
@@ -4810,12 +6206,111 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 62,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "bifrost",
+          "cc-switch",
+          "claude-code",
+          "cline",
+          "codex",
+          "continue",
+          "crewAI",
+          "edgequake-llm",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "traceloop-hub",
+          "uni-api"
+        ],
+        "access": {
+          "special": 58,
+          "native": 2,
+          "openai_compat": 1,
+          "none": 1
+        },
+        "special_entries": 58,
+        "spellings": [
+          "Amazon Bedrock",
+          "amazon_bedrock",
+          "amazon_nova",
+          "amazon-bedrock",
+          "aws",
+          "AWS Bedrock",
+          "aws_bedrock",
+          "aws-bedrock",
+          "bedrock",
+          "bedrock (Converse)",
+          "bedrock_api",
+          "bedrock_mantle",
+          "bedrock_sigv4",
+          "bedrock-converse",
+          "bedrock-mantle"
+        ]
+      }
     },
     {
       "id": "bedrock_mantle",
       "display_name": "Bedrock Mantle",
-      "aliases": [],
+      "aliases": [
+        "AWS Bedrock",
+        "Amazon Bedrock",
+        "amazon-bedrock",
+        "amazon_bedrock",
+        "amazon_nova",
+        "aws",
+        "aws-bedrock",
+        "aws_bedrock",
+        "bedrock",
+        "bedrock (Converse)",
+        "bedrock-converse",
+        "bedrock_api",
+        "bedrock_sigv4"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -4925,7 +6420,92 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 62,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "bifrost",
+          "cc-switch",
+          "claude-code",
+          "cline",
+          "codex",
+          "continue",
+          "crewAI",
+          "edgequake-llm",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "traceloop-hub",
+          "uni-api"
+        ],
+        "access": {
+          "special": 58,
+          "native": 2,
+          "openai_compat": 1,
+          "none": 1
+        },
+        "special_entries": 58,
+        "spellings": [
+          "Amazon Bedrock",
+          "amazon_bedrock",
+          "amazon_nova",
+          "amazon-bedrock",
+          "aws",
+          "AWS Bedrock",
+          "aws_bedrock",
+          "aws-bedrock",
+          "bedrock",
+          "bedrock (Converse)",
+          "bedrock_api",
+          "bedrock_mantle",
+          "bedrock_sigv4",
+          "bedrock-converse",
+          "bedrock-mantle"
+        ]
+      }
     },
     {
       "id": "berget",
@@ -5026,14 +6606,39 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "berget"
+        ]
+      }
     },
     {
       "id": "bigmodel",
       "display_name": "Zhipu AI",
       "aliases": [
         "Zhipu",
-        "zhipuai"
+        "Zhipu AI",
+        "Zhipu 智谱",
+        "chatglm",
+        "glm",
+        "zhipu",
+        "zhipu_ai",
+        "zhipuai",
+        "zhipuai-coding-plan",
+        "智谱",
+        "智谱 GLM"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -5185,7 +6790,51 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 22,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "chats",
+          "higress",
+          "langchain4j",
+          "langchain-swift",
+          "llama_index",
+          "mastra",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "OpenHands",
+          "plano",
+          "portkey-gateway",
+          "rust-genai",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 16,
+          "special": 5,
+          "native": 1
+        },
+        "special_entries": 8,
+        "spellings": [
+          "bigmodel",
+          "chatglm",
+          "glm",
+          "zhipu",
+          "Zhipu AI",
+          "Zhipu 智谱",
+          "zhipu_ai",
+          "zhipuai",
+          "zhipuai-coding-plan",
+          "智谱",
+          "智谱 GLM"
+        ]
+      }
     },
     {
       "id": "black_forest_labs",
@@ -5252,7 +6901,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "black_forest_labs"
+        ]
+      }
     },
     {
       "id": "blueclaw",
@@ -5317,7 +6981,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "blueclaw"
+        ]
+      }
     },
     {
       "id": "burncloud",
@@ -5422,7 +7102,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "axonhub"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "burncloud"
+        ]
+      }
     },
     {
       "id": "bytedance",
@@ -5515,7 +7210,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "llmgateway"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "bytedance"
+        ]
+      }
     },
     {
       "id": "bytez",
@@ -5561,13 +7271,30 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "litellm",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 1,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "bytez"
+        ]
+      }
     },
     {
       "id": "cerebras",
       "display_name": "Cerebras",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -5703,7 +7430,48 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 25,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aisuite",
+          "axonhub",
+          "bifrost",
+          "cline",
+          "continue",
+          "crewAI",
+          "ferro-ai-gateway",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "oh-my-opencode-slim",
+          "opencode",
+          "opencodex",
+          "otari",
+          "pi",
+          "portkey-gateway",
+          "pydantic-ai",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 22,
+          "none": 2,
+          "native": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "cerebras"
+        ]
+      }
     },
     {
       "id": "chat_gpt_subscription_codex",
@@ -5765,7 +7533,9 @@
     {
       "id": "chatgpt",
       "display_name": "Chatgpt",
-      "aliases": [],
+      "aliases": [
+        "ChatGPT 订阅"
+      ],
       "provider_kind": "subscription_proxy",
       "compatibility": {
         "tier": "L2",
@@ -5846,7 +7616,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "litellm",
+          "plano",
+          "rig"
+        ],
+        "access": {
+          "special": 3
+        },
+        "special_entries": 3,
+        "spellings": [
+          "chatgpt",
+          "ChatGPT 订阅"
+        ]
+      }
     },
     {
       "id": "cherryin",
@@ -6109,7 +7897,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "litellm",
+          "mastra",
+          "opencode",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 3,
+          "none": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "chutes"
+        ]
+      }
     },
     {
       "id": "clarifai",
@@ -6239,7 +8046,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "litellm",
+          "llama_index",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3,
+          "native": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "clarifai"
+        ]
+      }
     },
     {
       "id": "claudinio",
@@ -6322,7 +8148,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "claudinio"
+        ]
+      }
     },
     {
       "id": "cline_pass",
@@ -6405,7 +8247,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "cline",
+          "manifest",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 4
+        },
+        "special_entries": 1,
+        "spellings": [
+          "cline-pass"
+        ]
+      }
     },
     {
       "id": "cloudferro_sherlock",
@@ -6498,12 +8358,35 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "cloudferro-sherlock"
+        ]
+      }
     },
     {
       "id": "cloudflare",
       "display_name": "Cloudflare",
-      "aliases": [],
+      "aliases": [
+        "Cloudflare Workers AI",
+        "cloudflare(Workers AI)",
+        "cloudflare-workers-ai",
+        "cloudflare_workers_ai",
+        "workers-ai",
+        "workers_ai"
+      ],
       "provider_kind": "cloud_platform",
       "compatibility": {
         "tier": "unknown",
@@ -6638,7 +8521,46 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 17,
+        "projects": [
+          "aiproxy",
+          "continue",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "mastra",
+          "one-api",
+          "opencode",
+          "opencodex",
+          "pi",
+          "portkey-gateway",
+          "simple-one-api",
+          "uni-api"
+        ],
+        "access": {
+          "special": 8,
+          "openai_compat": 6,
+          "native": 3
+        },
+        "special_entries": 10,
+        "spellings": [
+          "cloudflare",
+          "Cloudflare Workers AI",
+          "cloudflare(Workers AI)",
+          "cloudflare_workers_ai",
+          "cloudflare-workers-ai",
+          "workers_ai",
+          "workers-ai"
+        ]
+      }
     },
     {
       "id": "cloudflare_ai_gateway",
@@ -6742,12 +8664,40 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "agentsdk",
+          "llama_index",
+          "mastra",
+          "new-api",
+          "opencode",
+          "opencodex",
+          "pi"
+        ],
+        "access": {
+          "special": 4,
+          "native": 2,
+          "openai_compat": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "Cloudflare AI Gateway",
+          "cloudflare-ai-gateway"
+        ]
+      }
     },
     {
       "id": "cloudflare_workers_ai",
       "display_name": "Cloudflare Workers AI",
-      "aliases": [],
+      "aliases": [
+        "cloudflare",
+        "workers-ai",
+        "workers_ai"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -6885,7 +8835,46 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 17,
+        "projects": [
+          "aiproxy",
+          "continue",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "mastra",
+          "one-api",
+          "opencode",
+          "opencodex",
+          "pi",
+          "portkey-gateway",
+          "simple-one-api",
+          "uni-api"
+        ],
+        "access": {
+          "special": 8,
+          "openai_compat": 6,
+          "native": 3
+        },
+        "special_entries": 10,
+        "spellings": [
+          "cloudflare",
+          "Cloudflare Workers AI",
+          "cloudflare(Workers AI)",
+          "cloudflare_workers_ai",
+          "cloudflare-workers-ai",
+          "workers_ai",
+          "workers-ai"
+        ]
+      }
     },
     {
       "id": "codestral",
@@ -6954,7 +8943,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "codestral"
+        ]
+      }
     },
     {
       "id": "cohere",
@@ -7158,7 +9162,59 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 36,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "bifrost",
+          "continue",
+          "edgequake-llm",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "langchain",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "otari",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "rust-genai",
+          "textgrad",
+          "uni-api"
+        ],
+        "access": {
+          "native": 26,
+          "special": 6,
+          "openai_compat": 4
+        },
+        "special_entries": 11,
+        "spellings": [
+          "cohere"
+        ]
+      }
     },
     {
       "id": "cohere_chat",
@@ -7236,7 +9292,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "native": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "cohere_chat"
+        ]
+      }
     },
     {
       "id": "cometapi",
@@ -7283,7 +9354,26 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "continue",
+          "haystack",
+          "litellm",
+          "llama_index",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 5
+        },
+        "special_entries": 0,
+        "spellings": [
+          "cometapi"
+        ]
+      }
     },
     {
       "id": "copilot",
@@ -7473,7 +9563,40 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 15,
+        "projects": [
+          "agent-of-empires",
+          "agentsdk",
+          "ai.rs",
+          "aider",
+          "awaken",
+          "axonhub",
+          "litellm",
+          "manifest",
+          "oh-my-opencode-slim",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "pi",
+          "rig",
+          "rust-genai"
+        ],
+        "access": {
+          "special": 10,
+          "openai_compat": 3,
+          "none": 2
+        },
+        "special_entries": 11,
+        "spellings": [
+          "copilot",
+          "github_copilot",
+          "github-copilot"
+        ]
+      }
     },
     {
       "id": "cortecs",
@@ -7626,13 +9749,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "cortecs"
+        ]
+      }
     },
     {
       "id": "coze",
       "display_name": "Coze",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "gateway_aggregator",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -7683,7 +9822,27 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "aiproxy",
+          "coai",
+          "higress",
+          "new-api",
+          "one-api",
+          "one-hub"
+        ],
+        "access": {
+          "special": 6
+        },
+        "special_entries": 6,
+        "spellings": [
+          "coze"
+        ]
+      }
     },
     {
       "id": "crof",
@@ -7831,7 +9990,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "crof"
+        ]
+      }
     },
     {
       "id": "crossmodel",
@@ -7942,7 +10117,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "crossmodel"
+        ]
+      }
     },
     {
       "id": "crusoe",
@@ -8005,12 +10196,35 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "aisuite",
+          "langchain"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "crusoe"
+        ]
+      }
     },
     {
       "id": "custom_provider",
       "display_name": "custom provider",
-      "aliases": [],
+      "aliases": [
+        "Custom(自定义渠道)",
+        "custom",
+        "custom (genai_n)",
+        "custom_genai_n",
+        "自定义(任意名称)",
+        "自定义端点 (custom)"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -8104,7 +10318,37 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 10,
+        "projects": [
+          "awaken",
+          "claude-code-router",
+          "litellm",
+          "litellm-rust",
+          "llmgateway",
+          "manifest",
+          "one-api",
+          "one-hub",
+          "rust-genai",
+          "smg"
+        ],
+        "access": {
+          "openai_compat": 8,
+          "special": 2
+        },
+        "special_entries": 3,
+        "spellings": [
+          "custom",
+          "custom (genai_n)",
+          "Custom(自定义渠道)",
+          "custom_genai_n",
+          "自定义(任意名称)",
+          "自定义端点 (custom)"
+        ]
+      }
     },
     {
       "id": "daoxe",
@@ -8183,7 +10427,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "daoxe"
+        ]
+      }
     },
     {
       "id": "darkbloom",
@@ -8250,12 +10510,30 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "darkbloom"
+        ]
+      }
     },
     {
       "id": "databricks",
       "display_name": "Databricks",
-      "aliases": [],
+      "aliases": [
+        "Azure Databricks",
+        "azure-databricks"
+      ],
       "provider_kind": "cloud_platform",
       "compatibility": {
         "tier": "unknown",
@@ -8461,7 +10739,36 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 12,
+        "projects": [
+          "bifrost",
+          "dspy",
+          "ferro-ai-gateway",
+          "instructor",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "mastra",
+          "one-hub",
+          "opencode",
+          "otari",
+          "uni-api"
+        ],
+        "access": {
+          "openai_compat": 10,
+          "special": 2
+        },
+        "special_entries": 4,
+        "spellings": [
+          "Azure Databricks",
+          "azure-databricks",
+          "databricks"
+        ]
+      }
     },
     {
       "id": "dataforseo",
@@ -8512,7 +10819,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "dataforseo"
+        ]
+      }
     },
     {
       "id": "datarobot",
@@ -8558,13 +10880,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "datarobot"
+        ]
+      }
     },
     {
       "id": "deepgram",
       "display_name": "Deepgram",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "modal_service",
       "compatibility": {
         "tier": "L3",
         "protocol": "unknown",
@@ -8657,13 +10994,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "aisuite",
+          "litellm"
+        ],
+        "access": {
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "deepgram"
+        ]
+      }
     },
     {
       "id": "deepinfra",
       "display_name": "Deep Infra",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -8855,7 +11208,38 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 15,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "axonhub",
+          "continue",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "mastra",
+          "opencode",
+          "otari",
+          "portkey-gateway",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 13,
+          "native": 1,
+          "none": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "deepinfra"
+        ]
+      }
     },
     {
       "id": "deepseek",
@@ -9050,13 +11434,82 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 54,
+        "projects": [
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "ccs-nicremo",
+          "cc-switch",
+          "ccswitch-deepseek",
+          "chats",
+          "claude-code-router",
+          "cline",
+          "coai",
+          "continue",
+          "crewAI",
+          "eino",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "langchain-rust",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "spring-ai",
+          "tensorzero",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 52,
+          "native": 2
+        },
+        "special_entries": 7,
+        "spellings": [
+          "deepseek"
+        ]
+      }
     },
     {
       "id": "dify",
       "display_name": "Dify",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "gateway_aggregator",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -9107,7 +11560,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "cline",
+          "coai",
+          "higress",
+          "new-api",
+          "simple-one-api"
+        ],
+        "access": {
+          "special": 5
+        },
+        "special_entries": 5,
+        "spellings": [
+          "dify"
+        ]
+      }
     },
     {
       "id": "digitalocean",
@@ -9264,7 +11736,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "mastra",
+          "opencode",
+          "plano"
+        ],
+        "access": {
+          "openai_compat": 2,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "digitalocean"
+        ]
+      }
     },
     {
       "id": "dinference",
@@ -9359,7 +11849,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "dinference"
+        ]
+      }
     },
     {
       "id": "docker_model_runner",
@@ -9406,12 +11912,34 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "docker_model_runner"
+        ]
+      }
     },
     {
       "id": "doubao",
       "display_name": "Doubao",
-      "aliases": [],
+      "aliases": [
+        "Doubao 豆包(火山方舟)",
+        "ark",
+        "arkbot",
+        "volcengine",
+        "火山引擎豆包 Volcengine",
+        "火山方舟 Ark"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -9512,7 +12040,41 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 13,
+        "projects": [
+          "aiproxy",
+          "axonhub",
+          "chats",
+          "cline",
+          "eino",
+          "higress",
+          "litellm",
+          "new-api",
+          "one-api",
+          "Roo-Code",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 9,
+          "native": 2,
+          "special": 1,
+          "none": 1
+        },
+        "special_entries": 3,
+        "spellings": [
+          "ark",
+          "arkbot",
+          "doubao",
+          "Doubao 豆包(火山方舟)",
+          "volcengine",
+          "火山方舟 Ark",
+          "火山引擎豆包 Volcengine"
+        ]
+      }
     },
     {
       "id": "doubao_video",
@@ -9656,7 +12218,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "drun"
+        ]
+      }
     },
     {
       "id": "duckduckgo",
@@ -9707,7 +12285,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "duckduckgo"
+        ]
+      }
     },
     {
       "id": "ebcloud",
@@ -9776,13 +12369,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "ebcloud"
+        ]
+      }
     },
     {
       "id": "elevenlabs",
       "display_name": "Elevenlabs",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "modal_service",
       "compatibility": {
         "tier": "L3",
         "protocol": "unknown",
@@ -9835,7 +12444,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "bifrost",
+          "graniet-llm",
+          "litellm",
+          "llmgateway",
+          "rllm",
+          "spring-ai"
+        ],
+        "access": {
+          "special": 4,
+          "native": 2
+        },
+        "special_entries": 4,
+        "spellings": [
+          "elevenlabs"
+        ]
+      }
     },
     {
       "id": "empiriolabs",
@@ -9946,7 +12576,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "langchain",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "empiriolabs"
+        ]
+      }
     },
     {
       "id": "empower",
@@ -9993,7 +12640,22 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "empower"
+        ]
+      }
     },
     {
       "id": "evroc",
@@ -10123,7 +12785,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "evroc"
+        ]
+      }
     },
     {
       "id": "exa_ai",
@@ -10174,7 +12852,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "exa_ai"
+        ]
+      }
     },
     {
       "id": "fal",
@@ -10253,7 +12946,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "edgequake-llm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "fal"
+        ]
+      }
     },
     {
       "id": "fastgpt",
@@ -10312,7 +13020,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "FastGPT"
+        ]
+      }
     },
     {
       "id": "fastrouter",
@@ -10467,7 +13190,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "fastrouter"
+        ]
+      }
     },
     {
       "id": "featherless_ai",
@@ -10536,7 +13275,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "langchain",
+          "litellm",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "featherless_ai",
+          "featherless-ai"
+        ]
+      }
     },
     {
       "id": "firecrawl",
@@ -10587,7 +13344,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "firecrawl"
+        ]
+      }
     },
     {
       "id": "firepass",
@@ -10650,7 +13422,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "opencodex"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "firepass"
+        ]
+      }
     },
     {
       "id": "fireworks",
@@ -10660,7 +13447,7 @@
         "fireworks_ai",
         "fireworks_ai-embedding-models"
       ],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -10890,7 +13677,53 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 29,
+        "projects": [
+          "ai",
+          "aisuite",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "continue",
+          "ferro-ai-gateway",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "oh-my-opencode-slim",
+          "opencode",
+          "opencodex",
+          "otari",
+          "pi",
+          "portkey-gateway",
+          "pydantic-ai",
+          "Roo-Code",
+          "rust-genai",
+          "tensorzero",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 28,
+          "none": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "fireworks",
+          "fireworks_ai",
+          "fireworks-ai"
+        ]
+      }
     },
     {
       "id": "freemodel",
@@ -10998,7 +13831,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "special": 1,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "freemodel"
+        ]
+      }
     },
     {
       "id": "friendliai",
@@ -11135,7 +13985,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "friendliai"
+        ]
+      }
     },
     {
       "id": "frogbot",
@@ -11288,7 +14153,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "frogbot"
+        ]
+      }
     },
     {
       "id": "galadriel",
@@ -11335,7 +14216,22 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "galadriel"
+        ]
+      }
     },
     {
       "id": "gdc",
@@ -11381,7 +14277,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "gdc"
+        ]
+      }
     },
     {
       "id": "gigachat",
@@ -11459,13 +14370,33 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "litellm",
+          "llama_index"
+        ],
+        "access": {
+          "openai_compat": 1,
+          "native": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "gigachat"
+        ]
+      }
     },
     {
       "id": "github",
       "display_name": "GitHub Models",
       "aliases": [
-        "github-models"
+        "GitHub (Models)",
+        "Github Models",
+        "github-models",
+        "github_models"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -11630,13 +14561,41 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 10,
+        "projects": [
+          "axonhub",
+          "chats",
+          "higress",
+          "langchain4j",
+          "litellm",
+          "mastra",
+          "one-hub",
+          "opencode",
+          "plano",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 10
+        },
+        "special_entries": 0,
+        "spellings": [
+          "github",
+          "GitHub (Models)",
+          "Github Models",
+          "github_models",
+          "github-models"
+        ]
+      }
     },
     {
       "id": "gitlab",
       "display_name": "GitLab Duo",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "cloud_platform",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -11716,12 +14675,30 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "agentsdk",
+          "opencode"
+        ],
+        "access": {
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "gitlab"
+        ]
+      }
     },
     {
       "id": "gmi",
       "display_name": "GMI",
-      "aliases": [],
+      "aliases": [
+        "gmicloud"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -11799,7 +14776,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "gmicloud"
+        ]
+      }
     },
     {
       "id": "gmicloud",
@@ -11911,14 +14904,38 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "gmicloud"
+        ]
+      }
     },
     {
       "id": "google",
       "display_name": "Google",
       "aliases": [
         "Gemini",
-        "gemini"
+        "Google AI",
+        "Google Gemini",
+        "gemini",
+        "google (gemini)",
+        "google / gemini",
+        "google-genai",
+        "google_ai",
+        "google_gemini",
+        "google_genai"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -12199,7 +15216,102 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 73,
+        "projects": [
+          "agent-of-empires",
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "async-openai",
+          "autogen",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "CCSwitcher",
+          "chats",
+          "claude-code-router",
+          "claude-worker-proxy",
+          "cline",
+          "continue",
+          "crewAI",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchainjs",
+          "langchain-swift",
+          "litellm",
+          "litellm-rust",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust_ai_sdk",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "textgrad",
+          "unia",
+          "uni-api"
+        ],
+        "access": {
+          "native": 58,
+          "openai_compat": 6,
+          "special": 5,
+          "none": 4
+        },
+        "special_entries": 20,
+        "spellings": [
+          "gemini",
+          "google",
+          "google (gemini)",
+          "google / gemini",
+          "Google AI",
+          "Google Gemini",
+          "google_ai",
+          "google_gemini",
+          "google_genai",
+          "google-genai"
+        ]
+      }
     },
     {
       "id": "google_pse",
@@ -12250,12 +15362,36 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "google_pse"
+        ]
+      }
     },
     {
       "id": "google_vertex",
       "display_name": "Vertex",
-      "aliases": [],
+      "aliases": [
+        "Google Vertex AI",
+        "Vertex AI",
+        "google-vertexai",
+        "google_vertexai",
+        "vertex",
+        "vertex-ai",
+        "vertex_ai",
+        "vertexai"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -12352,12 +15488,85 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 39,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "bifrost",
+          "cc-switch",
+          "cline",
+          "continue",
+          "dspy",
+          "edgequake-llm",
+          "ferro-ai-gateway",
+          "haystack",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "llmgateway",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "portkey-gateway",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "traceloop-hub"
+        ],
+        "access": {
+          "special": 31,
+          "native": 7,
+          "none": 1
+        },
+        "special_entries": 33,
+        "spellings": [
+          "Google Vertex AI",
+          "google_vertex",
+          "google_vertexai",
+          "google-vertex",
+          "google-vertexai",
+          "vertex",
+          "Vertex AI",
+          "vertex_ai",
+          "vertexai",
+          "vertex-ai"
+        ]
+      }
     },
     {
       "id": "google_vertex_anthropic",
       "display_name": "Vertex (Anthropic)",
-      "aliases": [],
+      "aliases": [
+        "Anthropic / Claude",
+        "Anthropic Claude",
+        "anthropic",
+        "anthropic (claude)",
+        "anthropic-aws",
+        "anthropic_aws",
+        "claude",
+        "vertex-anthropic"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -12424,7 +15633,111 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 85,
+        "projects": [
+          "agent-of-empires",
+          "agentsdk",
+          "ai",
+          "ai.rs",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "async-anthropic",
+          "autogen",
+          "AutoGPT",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "chats",
+          "claude-code-router",
+          "cline",
+          "coai",
+          "continue",
+          "crewAI",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "kalosm",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchainjs",
+          "langchain-rust",
+          "litellm",
+          "litellm-rust",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "multi-llm",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "pi",
+          "pinchbench",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust_ai_sdk",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "traceloop-hub",
+          "unia",
+          "uni-api"
+        ],
+        "access": {
+          "native": 71,
+          "special": 10,
+          "none": 3,
+          "openai_compat": 1
+        },
+        "special_entries": 28,
+        "spellings": [
+          "anthropic",
+          "anthropic (claude)",
+          "Anthropic / Claude",
+          "Anthropic Claude",
+          "anthropic_aws",
+          "anthropic-aws",
+          "claude",
+          "google-vertex-anthropic",
+          "vertex-anthropic"
+        ]
+      }
     },
     {
       "id": "gradient_ai",
@@ -12514,7 +15827,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "gradient_ai"
+        ]
+      }
     },
     {
       "id": "groq",
@@ -12740,7 +16068,69 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 46,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "AutoGPT",
+          "awaken",
+          "bifrost",
+          "cline",
+          "coai",
+          "continue",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 42,
+          "native": 3,
+          "none": 1
+        },
+        "special_entries": 2,
+        "spellings": [
+          "groq"
+        ]
+      }
     },
     {
       "id": "helicone",
@@ -12909,7 +16299,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "litellm",
+          "llama_index",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 4
+        },
+        "special_entries": 0,
+        "spellings": [
+          "helicone"
+        ]
+      }
     },
     {
       "id": "heroku",
@@ -13041,7 +16449,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "litellm",
+          "llama_index",
+          "pydantic-ai"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "heroku"
+        ]
+      }
     },
     {
       "id": "hetzner",
@@ -13104,7 +16529,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "hetzner"
+        ]
+      }
     },
     {
       "id": "hosted_vllm",
@@ -13151,7 +16592,22 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "hosted_vllm"
+        ]
+      }
     },
     {
       "id": "hpc_ai",
@@ -13250,12 +16706,34 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "hpc-ai"
+        ]
+      }
     },
     {
       "id": "huggingface",
       "display_name": "Hugging Face",
-      "aliases": [],
+      "aliases": [
+        "hugging_face",
+        "huggingface-api",
+        "huggingface-tei",
+        "huggingface_api",
+        "huggingface_tei"
+      ],
       "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "unknown",
@@ -13443,7 +16921,59 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 32,
+        "projects": [
+          "ai",
+          "aisuite",
+          "bifrost",
+          "cline",
+          "continue",
+          "edgequake-llm",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchain-swift",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "manifest",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "otari",
+          "pi",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "semantic-kernel",
+          "semantic-kernel-java"
+        ],
+        "access": {
+          "openai_compat": 15,
+          "special": 11,
+          "native": 5,
+          "none": 1
+        },
+        "special_entries": 12,
+        "spellings": [
+          "hugging_face",
+          "huggingface",
+          "huggingface_api",
+          "huggingface_tei",
+          "huggingface-api",
+          "huggingface-tei"
+        ]
+      }
     },
     {
       "id": "hyper",
@@ -13544,13 +17074,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "hyper"
+        ]
+      }
     },
     {
       "id": "hyperbolic",
       "display_name": "Hyperbolic",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -13639,7 +17185,27 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "helicone-ai-gateway",
+          "litellm",
+          "portkey-gateway",
+          "rig",
+          "tensorzero",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 6
+        },
+        "special_entries": 0,
+        "spellings": [
+          "hyperbolic"
+        ]
+      }
     },
     {
       "id": "iflowcn",
@@ -13759,7 +17325,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "iflowcn"
+        ]
+      }
     },
     {
       "id": "inception",
@@ -13877,7 +17459,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "aisuite",
+          "continue",
+          "litellm",
+          "mastra",
+          "opencode",
+          "otari"
+        ],
+        "access": {
+          "openai_compat": 5,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "inception"
+        ]
+      }
     },
     {
       "id": "inceptron",
@@ -13972,7 +17575,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "inceptron"
+        ]
+      }
     },
     {
       "id": "inference_net",
@@ -14081,7 +17700,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "llmgateway",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "inference.net",
+          "inference-net"
+        ]
+      }
     },
     {
       "id": "inferx",
@@ -14154,7 +17790,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "inferx"
+        ]
+      }
     },
     {
       "id": "io_net",
@@ -14283,7 +17935,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "io-net"
+        ]
+      }
     },
     {
       "id": "jiekou",
@@ -14435,12 +18103,30 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "jiekou"
+        ]
+      }
     },
     {
       "id": "jimeng",
       "display_name": "Jimeng",
-      "aliases": [],
+      "aliases": [
+        "Jimeng 即梦(图像)"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -14492,13 +18178,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "new-api"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "Jimeng 即梦(图像)"
+        ]
+      }
     },
     {
       "id": "jina",
       "display_name": "Jina",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "embedding",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -14549,7 +18250,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "aiproxy",
+          "axonhub",
+          "edgequake-llm",
+          "haystack",
+          "new-api",
+          "one-hub",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 5,
+          "native": 2
+        },
+        "special_entries": 3,
+        "spellings": [
+          "jina"
+        ]
+      }
     },
     {
       "id": "jina_ai",
@@ -14600,7 +18323,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "jina_ai"
+        ]
+      }
     },
     {
       "id": "kenari",
@@ -14711,7 +18449,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "kenari"
+        ]
+      }
     },
     {
       "id": "kilo",
@@ -14866,12 +18620,40 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "cline",
+          "manifest",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "pinchbench"
+        ],
+        "access": {
+          "openai_compat": 6
+        },
+        "special_entries": 0,
+        "spellings": [
+          "kilo"
+        ]
+      }
     },
     {
       "id": "kimi",
       "display_name": "Kimi",
-      "aliases": [],
+      "aliases": [
+        "Moonshot (Kimi)",
+        "Moonshot AI",
+        "Moonshot Kimi",
+        "kimi-for-coding",
+        "moonshot",
+        "moonshotai",
+        "moonshotai-cn"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -14912,12 +18694,79 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 43,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "chats",
+          "cline",
+          "coai",
+          "continue",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain",
+          "litellm",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 36,
+          "special": 4,
+          "none": 2,
+          "native": 1
+        },
+        "special_entries": 7,
+        "spellings": [
+          "kimi",
+          "kimi-for-coding",
+          "moonshot",
+          "Moonshot (Kimi)",
+          "Moonshot AI",
+          "Moonshot Kimi",
+          "moonshotai",
+          "moonshotai-cn"
+        ]
+      }
     },
     {
       "id": "kimi_for_coding",
       "display_name": "Kimi For Coding",
-      "aliases": [],
+      "aliases": [
+        "Moonshot (Kimi)",
+        "Moonshot AI",
+        "Moonshot Kimi",
+        "kimi",
+        "moonshot",
+        "moonshotai",
+        "moonshotai-cn"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -15002,12 +18851,74 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 43,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "chats",
+          "cline",
+          "coai",
+          "continue",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain",
+          "litellm",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 36,
+          "special": 4,
+          "none": 2,
+          "native": 1
+        },
+        "special_entries": 7,
+        "spellings": [
+          "kimi",
+          "kimi-for-coding",
+          "moonshot",
+          "Moonshot (Kimi)",
+          "Moonshot AI",
+          "Moonshot Kimi",
+          "moonshotai",
+          "moonshotai-cn"
+        ]
+      }
     },
     {
       "id": "kling",
       "display_name": "Kling",
-      "aliases": [],
+      "aliases": [
+        "Kling 可灵",
+        "Kling 可灵(视频)"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -15059,7 +18970,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "new-api",
+          "one-hub"
+        ],
+        "access": {
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "Kling 可灵",
+          "Kling 可灵(视频)"
+        ]
+      }
     },
     {
       "id": "kuae_cloud_coding_plan",
@@ -15140,7 +19068,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "kuae-cloud-coding-plan"
+        ]
+      }
     },
     {
       "id": "lambda_ai",
@@ -15245,7 +19189,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "lambda_ai"
+        ]
+      }
     },
     {
       "id": "lemonade",
@@ -15319,7 +19278,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "continue",
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "lemonade"
+        ]
+      }
     },
     {
       "id": "libertai",
@@ -15408,7 +19384,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "libertai"
+        ]
+      }
     },
     {
       "id": "lilac",
@@ -15500,13 +19491,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "lilac"
+        ]
+      }
     },
     {
       "id": "lingyiwanwu",
       "display_name": "LingYiWanWu",
       "aliases": [
-        "LingYiWanWu"
+        "LingYiWanWu",
+        "LingYiWanWu 零一万物",
+        "零一万物 LingYiWanWu"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -15559,7 +19568,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "aiproxy",
+          "new-api",
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "lingyiwanwu",
+          "LingYiWanWu 零一万物",
+          "零一万物 LingYiWanWu"
+        ]
+      }
     },
     {
       "id": "linkup",
@@ -15612,12 +19640,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "linkup"
+        ]
+      }
     },
     {
       "id": "litellm_proxy",
       "display_name": "Litellm Proxy",
-      "aliases": [],
+      "aliases": [
+        "litellm"
+      ],
       "provider_kind": "gateway_aggregator",
       "compatibility": {
         "tier": "L4",
@@ -15659,7 +19704,34 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 11,
+        "projects": [
+          "cline",
+          "haystack",
+          "instructor",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "opencodex",
+          "OpenHands",
+          "pydantic-ai",
+          "Roo-Code",
+          "textgrad"
+        ],
+        "access": {
+          "openai_compat": 7,
+          "special": 4
+        },
+        "special_entries": 6,
+        "spellings": [
+          "litellm",
+          "litellm_proxy"
+        ]
+      }
     },
     {
       "id": "llama",
@@ -15758,7 +19830,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "llama"
+        ]
+      }
     },
     {
       "id": "llamafile",
@@ -15805,7 +19893,29 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "continue",
+          "langchaingo",
+          "litellm",
+          "llama_index",
+          "otari",
+          "rig"
+        ],
+        "access": {
+          "openai_compat": 4,
+          "native": 1,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "llamafile"
+        ]
+      }
     },
     {
       "id": "llamagate",
@@ -15894,7 +20004,7 @@
       "id": "llmgateway",
       "display_name": "LLM Gateway",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "gateway_aggregator",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -16041,7 +20151,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "llmgateway",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2,
+          "none": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "llmgateway"
+        ]
+      }
     },
     {
       "id": "llmtr",
@@ -16137,12 +20265,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "llmtr"
+        ]
+      }
     },
     {
       "id": "lmstudio",
       "display_name": "LMStudio",
       "aliases": [
+        "lm-studio",
         "lm_studio"
       ],
       "provider_kind": "local_runtime",
@@ -16243,7 +20388,42 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 18,
+        "projects": [
+          "aider",
+          "aisuite",
+          "APIPark",
+          "cline",
+          "codex",
+          "continue",
+          "edgequake-llm",
+          "langchain-swift",
+          "litellm",
+          "llama_index",
+          "manifest",
+          "mastra",
+          "multi-llm",
+          "opencode",
+          "opencodex",
+          "otari",
+          "outlines",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 17,
+          "special": 1
+        },
+        "special_entries": 2,
+        "spellings": [
+          "lm_studio",
+          "lmstudio",
+          "lm-studio"
+        ]
+      }
     },
     {
       "id": "longcat",
@@ -16306,7 +20486,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "axonhub",
+          "cc-switch",
+          "llm-connector",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 5
+        },
+        "special_entries": 1,
+        "spellings": [
+          "longcat"
+        ]
+      }
     },
     {
       "id": "lucidquery",
@@ -16402,7 +20601,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "lucidquery"
+        ]
+      }
     },
     {
       "id": "lynkr",
@@ -16466,7 +20681,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "lynkr"
+        ]
+      }
     },
     {
       "id": "maritalk",
@@ -16512,7 +20743,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "litellm",
+          "llama_index"
+        ],
+        "access": {
+          "special": 1,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "maritalk"
+        ]
+      }
     },
     {
       "id": "meganova",
@@ -16647,7 +20895,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "meganova"
+        ]
+      }
     },
     {
       "id": "merge_gateway",
@@ -16747,12 +21011,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "merge-gateway"
+        ]
+      }
     },
     {
       "id": "meta",
       "display_name": "Meta",
-      "aliases": [],
+      "aliases": [
+        "meta_llama"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -16842,12 +21123,38 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 9,
+        "projects": [
+          "haystack",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "llmgateway",
+          "mastra",
+          "opencode",
+          "plano"
+        ],
+        "access": {
+          "openai_compat": 7,
+          "native": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "meta",
+          "meta_llama"
+        ]
+      }
     },
     {
       "id": "meta_llama",
       "display_name": "Meta Llama",
-      "aliases": [],
+      "aliases": [
+        "meta"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -16915,13 +21222,37 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 9,
+        "projects": [
+          "haystack",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "llmgateway",
+          "mastra",
+          "opencode",
+          "plano"
+        ],
+        "access": {
+          "openai_compat": 7,
+          "native": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "meta",
+          "meta_llama"
+        ]
+      }
     },
     {
       "id": "midjourney",
       "display_name": "Midjourney",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "modal_service",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -16972,7 +21303,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "coai",
+          "one-hub"
+        ],
+        "access": {
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "Midjourney"
+        ]
+      }
     },
     {
       "id": "midjourney_plus",
@@ -17075,13 +21422,33 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "awaken",
+          "continue",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "mimo"
+        ]
+      }
     },
     {
       "id": "minimax",
       "display_name": "MiniMax (minimax.io)",
       "aliases": [
-        "MiniMax"
+        "MiniMax",
+        "minimax-cn",
+        "minimax-cn-coding-plan",
+        "minimax-coding-plan"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -17253,12 +21620,64 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 37,
+        "projects": [
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "chats",
+          "cline",
+          "continue",
+          "higress",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 18,
+          "special": 12,
+          "native": 7
+        },
+        "special_entries": 15,
+        "spellings": [
+          "minimax",
+          "minimax-cn",
+          "minimax-cn-coding-plan",
+          "minimax-coding-plan"
+        ]
+      }
     },
     {
       "id": "minimax_cn",
       "display_name": "MiniMax (minimaxi.com)",
-      "aliases": [],
+      "aliases": [
+        "minimax",
+        "minimax-cn-coding-plan",
+        "minimax-coding-plan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -17352,12 +21771,64 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 37,
+        "projects": [
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "chats",
+          "cline",
+          "continue",
+          "higress",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 18,
+          "special": 12,
+          "native": 7
+        },
+        "special_entries": 15,
+        "spellings": [
+          "minimax",
+          "minimax-cn",
+          "minimax-cn-coding-plan",
+          "minimax-coding-plan"
+        ]
+      }
     },
     {
       "id": "minimax_cn_coding_plan",
       "display_name": "MiniMax Token Plan (minimaxi.com)",
-      "aliases": [],
+      "aliases": [
+        "minimax",
+        "minimax-cn",
+        "minimax-coding-plan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -17451,12 +21922,64 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 37,
+        "projects": [
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "chats",
+          "cline",
+          "continue",
+          "higress",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 18,
+          "special": 12,
+          "native": 7
+        },
+        "special_entries": 15,
+        "spellings": [
+          "minimax",
+          "minimax-cn",
+          "minimax-cn-coding-plan",
+          "minimax-coding-plan"
+        ]
+      }
     },
     {
       "id": "minimax_coding_plan",
       "display_name": "MiniMax Token Plan (minimax.io)",
-      "aliases": [],
+      "aliases": [
+        "minimax",
+        "minimax-cn",
+        "minimax-cn-coding-plan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -17550,12 +22073,64 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 37,
+        "projects": [
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "ccs-nicremo",
+          "chats",
+          "cline",
+          "continue",
+          "higress",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 18,
+          "special": 12,
+          "native": 7
+        },
+        "special_entries": 15,
+        "spellings": [
+          "minimax",
+          "minimax-cn",
+          "minimax-cn-coding-plan",
+          "minimax-coding-plan"
+        ]
+      }
     },
     {
       "id": "mistral",
       "display_name": "Mistral",
-      "aliases": [],
+      "aliases": [
+        "mistral-ai",
+        "mistral_ai",
+        "mistralai"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L1",
@@ -17807,7 +22382,74 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 48,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "bifrost",
+          "claude-code-router",
+          "cline",
+          "continue",
+          "edgequake-llm",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenGateLLM",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "semantic-kernel",
+          "spring-ai",
+          "tensorzero",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 28,
+          "native": 17,
+          "special": 3
+        },
+        "special_entries": 4,
+        "spellings": [
+          "mistral",
+          "mistral_ai",
+          "mistralai",
+          "mistral-ai"
+        ]
+      }
     },
     {
       "id": "mixlayer",
@@ -17900,7 +22542,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "mixlayer"
+        ]
+      }
     },
     {
       "id": "moark",
@@ -17984,7 +22642,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "moark"
+        ]
+      }
     },
     {
       "id": "model_oracle_ai",
@@ -18075,7 +22749,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "model-oracle-ai"
+        ]
+      }
     },
     {
       "id": "modelscope",
@@ -18190,7 +22880,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "axonhub",
+          "cc-switch",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 6,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "modelscope"
+        ]
+      }
     },
     {
       "id": "moka_ai",
@@ -18254,8 +22966,14 @@
       "display_name": "Moonshot AI",
       "aliases": [
         "Moonshot",
+        "Moonshot (Kimi)",
+        "Moonshot AI",
+        "Moonshot Kimi",
+        "kimi",
+        "kimi-for-coding",
         "moonshot",
-        "moonshot-ai"
+        "moonshot-ai",
+        "moonshotai-cn"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -18537,12 +23255,79 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 43,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "chats",
+          "cline",
+          "coai",
+          "continue",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain",
+          "litellm",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 36,
+          "special": 4,
+          "none": 2,
+          "native": 1
+        },
+        "special_entries": 7,
+        "spellings": [
+          "kimi",
+          "kimi-for-coding",
+          "moonshot",
+          "Moonshot (Kimi)",
+          "Moonshot AI",
+          "Moonshot Kimi",
+          "moonshotai",
+          "moonshotai-cn"
+        ]
+      }
     },
     {
       "id": "moonshotai_cn",
       "display_name": "Moonshot AI (China)",
-      "aliases": [],
+      "aliases": [
+        "Moonshot (Kimi)",
+        "Moonshot AI",
+        "Moonshot Kimi",
+        "kimi",
+        "kimi-for-coding",
+        "moonshot",
+        "moonshotai"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -18618,7 +23403,66 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 43,
+        "projects": [
+          "agent-of-empires",
+          "ai",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "chats",
+          "cline",
+          "coai",
+          "continue",
+          "ferro-ai-gateway",
+          "higress",
+          "langchain",
+          "litellm",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 36,
+          "special": 4,
+          "none": 2,
+          "native": 1
+        },
+        "special_entries": 7,
+        "spellings": [
+          "kimi",
+          "kimi-for-coding",
+          "moonshot",
+          "Moonshot (Kimi)",
+          "Moonshot AI",
+          "Moonshot Kimi",
+          "moonshotai",
+          "moonshotai-cn"
+        ]
+      }
     },
     {
       "id": "morph",
@@ -18741,7 +23585,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "litellm",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "morph"
+        ]
+      }
     },
     {
       "id": "nanogpt",
@@ -18912,7 +23773,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "axonhub",
+          "litellm",
+          "llmgateway",
+          "mastra",
+          "opencode",
+          "opencodex"
+        ],
+        "access": {
+          "openai_compat": 6
+        },
+        "special_entries": 0,
+        "spellings": [
+          "nanogpt",
+          "nano-gpt"
+        ]
+      }
     },
     {
       "id": "nearai",
@@ -19069,13 +23951,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "nearai"
+        ]
+      }
     },
     {
       "id": "nebius",
       "display_name": "Nebius Token Factory",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -19297,7 +24195,36 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 15,
+        "projects": [
+          "aisuite",
+          "awaken",
+          "bifrost",
+          "cline",
+          "continue",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "llmgateway",
+          "mastra",
+          "opencode",
+          "otari",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 15
+        },
+        "special_entries": 0,
+        "spellings": [
+          "nebius"
+        ]
+      }
     },
     {
       "id": "neon",
@@ -19438,7 +24365,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 1,
+        "spellings": [
+          "neon"
+        ]
+      }
     },
     {
       "id": "netlify",
@@ -19538,7 +24481,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "mastra"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "netlify"
+        ]
+      }
     },
     {
       "id": "neuralwatt",
@@ -19672,13 +24630,34 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "langchain",
+          "mastra",
+          "opencode",
+          "opencodex"
+        ],
+        "access": {
+          "openai_compat": 3,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "neuralwatt"
+        ]
+      }
     },
     {
       "id": "new_api",
       "display_name": "New API",
-      "aliases": [],
-      "provider_kind": "model_vendor",
+      "aliases": [
+        "New API 实例互连"
+      ],
+      "provider_kind": "gateway_aggregator",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -19718,7 +24697,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "new-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "New API 实例互连"
+        ]
+      }
     },
     {
       "id": "nlp_cloud",
@@ -19788,7 +24782,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "nlp_cloud"
+        ]
+      }
     },
     {
       "id": "nova",
@@ -19872,12 +24881,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "nova"
+        ]
+      }
     },
     {
       "id": "novita",
       "display_name": "NovitaAI",
       "aliases": [
+        "Novita AI",
         "novita-ai"
       ],
       "provider_kind": "model_vendor",
@@ -20088,7 +25114,36 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 13,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "cc-switch",
+          "chats",
+          "continue",
+          "ferro-ai-gateway",
+          "litellm",
+          "llama_index",
+          "llmgateway",
+          "mastra",
+          "one-api",
+          "opencode",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 13
+        },
+        "special_entries": 0,
+        "spellings": [
+          "novita",
+          "Novita AI",
+          "novita-ai"
+        ]
+      }
     },
     {
       "id": "nscale",
@@ -20187,7 +25242,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "litellm",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "nscale"
+        ]
+      }
     },
     {
       "id": "nvidia_nim",
@@ -20382,7 +25453,44 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "APIPark",
+          "AutoGPT",
+          "cc-switch",
+          "claude-code-router",
+          "continue",
+          "edgequake-llm",
+          "ferro-ai-gateway",
+          "haystack",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "manifest",
+          "mastra",
+          "oh-my-opencode-slim",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "pi",
+          "semantic-kernel",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 18,
+          "none": 2
+        },
+        "special_entries": 1,
+        "spellings": [
+          "nvidia",
+          "Nvidia NIM",
+          "nvidia_nim"
+        ]
+      }
     },
     {
       "id": "oci",
@@ -20498,7 +25606,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "oci"
+        ]
+      }
     },
     {
       "id": "ofox",
@@ -20585,7 +25708,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "ofox"
+        ]
+      }
     },
     {
       "id": "ohmygpt",
@@ -20644,12 +25783,32 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "OhMyGPT"
+        ]
+      }
     },
     {
       "id": "ollama",
       "display_name": "Ollama Cloud",
-      "aliases": [],
+      "aliases": [
+        "ollama / 本地模型",
+        "ollama-cloud",
+        "ollama_chat",
+        "ollama_cloud"
+      ],
       "provider_kind": "local_runtime",
       "compatibility": {
         "tier": "L2",
@@ -20856,12 +26015,104 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 73,
+        "projects": [
+          "agentsdk",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "async-openai",
+          "autogen",
+          "AutoGPT",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "chats",
+          "cline",
+          "codex",
+          "continue",
+          "crewAI",
+          "dotnet-extensions",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchainjs",
+          "langchain-rust",
+          "langchain-swift",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "multi-llm",
+          "new-api",
+          "ollama-rs",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "textgrad",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 31,
+          "native": 27,
+          "special": 14,
+          "none": 1
+        },
+        "special_entries": 17,
+        "spellings": [
+          "ollama",
+          "ollama / 本地模型",
+          "ollama_chat",
+          "ollama_cloud",
+          "ollama-cloud"
+        ]
+      }
     },
     {
       "id": "ollama_chat",
       "display_name": "Ollama Chat",
-      "aliases": [],
+      "aliases": [
+        "ollama",
+        "ollama / 本地模型",
+        "ollama-cloud",
+        "ollama_cloud"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -20902,12 +26153,103 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 73,
+        "projects": [
+          "agentsdk",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "async-openai",
+          "autogen",
+          "AutoGPT",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "chats",
+          "cline",
+          "codex",
+          "continue",
+          "crewAI",
+          "dotnet-extensions",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchainjs",
+          "langchain-rust",
+          "langchain-swift",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "multi-llm",
+          "new-api",
+          "ollama-rs",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "textgrad",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 31,
+          "native": 27,
+          "special": 14,
+          "none": 1
+        },
+        "special_entries": 17,
+        "spellings": [
+          "ollama",
+          "ollama / 本地模型",
+          "ollama_chat",
+          "ollama_cloud",
+          "ollama-cloud"
+        ]
+      }
     },
     {
       "id": "ollama_cloud",
       "display_name": "Ollama Cloud",
-      "aliases": [],
+      "aliases": [
+        "ollama",
+        "ollama / 本地模型",
+        "ollama_chat"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -21017,7 +26359,94 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 73,
+        "projects": [
+          "agentsdk",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "async-openai",
+          "autogen",
+          "AutoGPT",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "chats",
+          "cline",
+          "codex",
+          "continue",
+          "crewAI",
+          "dotnet-extensions",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchainjs",
+          "langchain-rust",
+          "langchain-swift",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-connector",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "multi-llm",
+          "new-api",
+          "ollama-rs",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "textgrad",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 31,
+          "native": 27,
+          "special": 14,
+          "none": 1
+        },
+        "special_entries": 17,
+        "spellings": [
+          "ollama",
+          "ollama / 本地模型",
+          "ollama_chat",
+          "ollama_cloud",
+          "ollama-cloud"
+        ]
+      }
     },
     {
       "id": "omlx",
@@ -21064,7 +26493,24 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "awaken",
+          "edgequake-llm",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 1,
+        "spellings": [
+          "omlx"
+        ]
+      }
     },
     {
       "id": "oobabooga",
@@ -21110,7 +26556,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "oobabooga"
+        ]
+      }
     },
     {
       "id": "openai",
@@ -21118,7 +26579,12 @@
       "aliases": [
         "OpenAI",
         "openai-chat",
-        "openai_resp"
+        "openai-native",
+        "openai-responses",
+        "openai:responses",
+        "openai_resp",
+        "openai_responses",
+        "任意 OpenAI 兼容服务"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -21468,7 +26934,114 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 92,
+        "projects": [
+          "ai",
+          "ai.rs",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "async-openai",
+          "autogen",
+          "AutoGPT",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "chats",
+          "claude-code-router",
+          "claude-worker-proxy",
+          "cline",
+          "coai",
+          "codex",
+          "continue",
+          "crewAI",
+          "dotnet-extensions",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "guidance",
+          "haystack",
+          "helicone-ai-gateway",
+          "higress",
+          "instructor",
+          "instructor-go",
+          "kalosm",
+          "langchain",
+          "langchain4j",
+          "LangChain-csharp",
+          "langchaingo",
+          "langchainjs",
+          "langchain-rust",
+          "langchain-swift",
+          "litellm",
+          "litellm-rust",
+          "llama_index",
+          "LlamaIndexTS",
+          "llm-chain",
+          "llm-connector",
+          "llmgateway",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "multi-llm",
+          "new-api",
+          "oh-my-opencode-slim",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenGateLLM",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "pi",
+          "pinchbench",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust_ai_sdk",
+          "rust-genai",
+          "semantic-kernel",
+          "semantic-kernel-java",
+          "simple-one-api",
+          "smg",
+          "spring-ai",
+          "swiftide",
+          "tensorzero",
+          "textgrad",
+          "traceloop-hub",
+          "unia"
+        ],
+        "access": {
+          "native": 74,
+          "openai_compat": 15,
+          "special": 2,
+          "none": 1
+        },
+        "special_entries": 11,
+        "spellings": [
+          "openai",
+          "openai:responses",
+          "openai_resp",
+          "openai_responses",
+          "openai-native",
+          "openai-responses",
+          "任意 OpenAI 兼容服务"
+        ]
+      }
     },
     {
       "id": "openaimax",
@@ -21527,12 +27100,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "one-api"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "OpenAIMax"
+        ]
+      }
     },
     {
       "id": "opencode",
       "display_name": "OpenCode Zen",
-      "aliases": [],
+      "aliases": [
+        "OpenCode (本机配置导入)"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -21680,7 +27270,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "agent-of-empires",
+          "bifrost",
+          "claude-code-router",
+          "cline",
+          "mastra",
+          "opencode",
+          "pi"
+        ],
+        "access": {
+          "openai_compat": 3,
+          "special": 3,
+          "none": 1
+        },
+        "special_entries": 3,
+        "spellings": [
+          "opencode",
+          "OpenCode (本机配置导入)"
+        ]
+      }
     },
     {
       "id": "opencode_go",
@@ -21835,7 +27449,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 8,
+        "projects": [
+          "awaken",
+          "axonhub",
+          "manifest",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "pi",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 5,
+          "special": 3
+        },
+        "special_entries": 4,
+        "spellings": [
+          "opencode_go",
+          "opencode-go"
+        ]
+      }
     },
     {
       "id": "openrouter",
@@ -22090,7 +27728,84 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 59,
+        "projects": [
+          "agentsdk",
+          "ai.rs",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "APIPark",
+          "AutoGPT",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "cc-switch",
+          "chats",
+          "claude-code-router",
+          "cline",
+          "continue",
+          "crewAI",
+          "dspy",
+          "edgequake-llm",
+          "eino",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "haystack",
+          "higress",
+          "instructor",
+          "kalosm",
+          "langchain",
+          "LangChain-csharp",
+          "langchainjs",
+          "litellm",
+          "litellm-rust",
+          "llama_index",
+          "llm-connector",
+          "llmrust",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "outlines",
+          "pi",
+          "pinchbench",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "simple-one-api",
+          "swiftide",
+          "tensorzero",
+          "unia",
+          "uni-api"
+        ],
+        "access": {
+          "openai_compat": 54,
+          "special": 3,
+          "none": 1,
+          "native": 1
+        },
+        "special_entries": 11,
+        "spellings": [
+          "open_router",
+          "openrouter"
+        ]
+      }
     },
     {
       "id": "orcarouter",
@@ -22243,7 +27958,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "haystack",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "outlines"
+        ],
+        "access": {
+          "openai_compat": 5
+        },
+        "special_entries": 0,
+        "spellings": [
+          "orcarouter"
+        ]
+      }
     },
     {
       "id": "ovhcloud",
@@ -22421,7 +28155,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 8,
+        "projects": [
+          "continue",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "mastra",
+          "opencode",
+          "portkey-gateway",
+          "pydantic-ai"
+        ],
+        "access": {
+          "openai_compat": 8
+        },
+        "special_entries": 0,
+        "spellings": [
+          "ovhcloud"
+        ]
+      }
     },
     {
       "id": "pa_lm",
@@ -22530,7 +28286,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "litellm",
+          "llama_index",
+          "one-api",
+          "one-hub",
+          "portkey-gateway"
+        ],
+        "access": {
+          "native": 3,
+          "none": 1,
+          "special": 1
+        },
+        "special_entries": 2,
+        "spellings": [
+          "palm"
+        ]
+      }
     },
     {
       "id": "parallel_ai",
@@ -22626,12 +28403,30 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "bifrost",
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "parasail"
+        ]
+      }
     },
     {
       "id": "perplexity",
       "display_name": "Perplexity",
-      "aliases": [],
+      "aliases": [
+        "perplexity-agent"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -22814,12 +28609,48 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "bifrost",
+          "ferro-ai-gateway",
+          "haystack",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "mastra",
+          "new-api",
+          "opencode",
+          "otari",
+          "rig",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 17,
+          "native": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "perplexity",
+          "perplexity-agent"
+        ]
+      }
     },
     {
       "id": "perplexity_agent",
       "display_name": "Perplexity Agent",
-      "aliases": [],
+      "aliases": [
+        "perplexity"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -22946,7 +28777,41 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "bifrost",
+          "ferro-ai-gateway",
+          "haystack",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "mastra",
+          "new-api",
+          "opencode",
+          "otari",
+          "rig",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 17,
+          "native": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "perplexity",
+          "perplexity-agent"
+        ]
+      }
     },
     {
       "id": "petals",
@@ -22992,7 +28857,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "petals"
+        ]
+      }
     },
     {
       "id": "pinstripes",
@@ -23067,7 +28947,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "pinstripes"
+        ]
+      }
     },
     {
       "id": "pioneer",
@@ -23178,7 +29073,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "manifest",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "pioneer"
+        ]
+      }
     },
     {
       "id": "poe",
@@ -23347,7 +29259,26 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "litellm",
+          "mastra",
+          "opencode",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 3,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "poe"
+        ]
+      }
     },
     {
       "id": "poolside",
@@ -23434,7 +29365,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "cline",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "poolside"
+        ]
+      }
     },
     {
       "id": "ppinfra",
@@ -23579,7 +29527,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "litellm",
+          "llama_index",
+          "portkey-gateway"
+        ],
+        "access": {
+          "special": 2,
+          "openai_compat": 1
+        },
+        "special_entries": 2,
+        "spellings": [
+          "predibase"
+        ]
+      }
     },
     {
       "id": "privatemode_ai",
@@ -23677,7 +29643,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "privatemode-ai"
+        ]
+      }
     },
     {
       "id": "publicai",
@@ -23760,7 +29742,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "publicai"
+        ]
+      }
     },
     {
       "id": "qihang_ai",
@@ -23865,7 +29862,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "qihang-ai"
+        ]
+      }
     },
     {
       "id": "qihoo360",
@@ -24079,7 +30092,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "qiniu-ai"
+        ]
+      }
     },
     {
       "id": "ragflow",
@@ -24122,7 +30151,22 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "ragflow"
+        ]
+      }
     },
     {
       "id": "recraft",
@@ -24175,7 +30219,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "litellm",
+          "one-hub"
+        ],
+        "access": {
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "recraft"
+        ]
+      }
     },
     {
       "id": "reducto",
@@ -24228,7 +30288,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "reducto"
+        ]
+      }
     },
     {
       "id": "regolo_ai",
@@ -24351,13 +30426,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "regolo-ai"
+        ]
+      }
     },
     {
       "id": "replicate",
       "display_name": "Replicate",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -24491,7 +30582,32 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 10,
+        "projects": [
+          "bifrost",
+          "continue",
+          "ferro-ai-gateway",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "portkey-gateway"
+        ],
+        "access": {
+          "special": 9,
+          "native": 1
+        },
+        "special_entries": 9,
+        "spellings": [
+          "replicate"
+        ]
+      }
     },
     {
       "id": "requesty",
@@ -24644,7 +30760,27 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "aisuite",
+          "cline",
+          "mastra",
+          "opencode",
+          "outlines",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 6
+        },
+        "special_entries": 1,
+        "spellings": [
+          "requesty"
+        ]
+      }
     },
     {
       "id": "routing_run",
@@ -24795,7 +30931,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "routing-run"
+        ]
+      }
     },
     {
       "id": "runwayml",
@@ -24860,12 +31012,30 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "runwayml"
+        ]
+      }
     },
     {
       "id": "sagemaker",
       "display_name": "Sagemaker",
-      "aliases": [],
+      "aliases": [
+        "sagemaker-endpoint",
+        "sagemaker_endpoint"
+      ],
       "provider_kind": "cloud_platform",
       "compatibility": {
         "tier": "unknown",
@@ -24938,7 +31108,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "continue",
+          "dspy",
+          "litellm",
+          "llama_index",
+          "llm-chain",
+          "otari",
+          "portkey-gateway"
+        ],
+        "access": {
+          "special": 6,
+          "none": 1
+        },
+        "special_entries": 6,
+        "spellings": [
+          "sagemaker",
+          "sagemaker_endpoint",
+          "sagemaker-endpoint"
+        ]
+      }
     },
     {
       "id": "sagemaker_chat",
@@ -24984,7 +31178,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "sagemaker_chat"
+        ]
+      }
     },
     {
       "id": "sagemaker_nova",
@@ -25030,7 +31239,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "sagemaker_nova"
+        ]
+      }
     },
     {
       "id": "sakana",
@@ -25097,13 +31321,30 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "llmgateway",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "sakana"
+        ]
+      }
     },
     {
       "id": "sambanova",
       "display_name": "Sambanova",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "deployment_platform",
       "compatibility": {
         "tier": "L2",
         "protocol": "openai",
@@ -25200,7 +31441,34 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 12,
+        "projects": [
+          "aisuite",
+          "cline",
+          "continue",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "instructor",
+          "langchain",
+          "litellm",
+          "otari",
+          "portkey-gateway",
+          "pydantic-ai",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 11,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "sambanova"
+        ]
+      }
     },
     {
       "id": "sap_ai_core",
@@ -25300,7 +31568,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "agentsdk",
+          "opencode"
+        ],
+        "access": {
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "sap-ai-core"
+        ]
+      }
     },
     {
       "id": "sarvam",
@@ -25402,7 +31686,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 5,
+        "projects": [
+          "bifrost",
+          "langchain",
+          "llama_index",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3,
+          "native": 1,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "sarvam"
+        ]
+      }
     },
     {
       "id": "scaleway",
@@ -25576,7 +31881,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "continue",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "scaleway"
+        ]
+      }
     },
     {
       "id": "searxng",
@@ -25627,13 +31949,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "searxng"
+        ]
+      }
     },
     {
       "id": "serper",
       "display_name": "Serper",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "search_provider",
       "compatibility": {
         "tier": "L3",
         "protocol": "unknown",
@@ -25678,15 +32015,32 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "serper"
+        ]
+      }
     },
     {
       "id": "siliconflow",
       "display_name": "SiliconFlow",
       "aliases": [
         "SiliconFlow",
+        "SiliconFlow 硅基流动",
         "siliconflow-cn",
-        "siliconflow-com"
+        "siliconflow-com",
+        "硅基流动 Siliconflow"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -25963,13 +32317,48 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 17,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "axonhub",
+          "chats",
+          "claude-code-router",
+          "continue",
+          "llama_index",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "portkey-gateway",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 17
+        },
+        "special_entries": 0,
+        "spellings": [
+          "siliconflow",
+          "SiliconFlow 硅基流动",
+          "siliconflow-cn",
+          "硅基流动 Siliconflow"
+        ]
+      }
     },
     {
       "id": "snowflake",
       "display_name": "Snowflake",
-      "aliases": [],
-      "provider_kind": "model_vendor",
+      "aliases": [
+        "Snowflake Cortex",
+        "snowflake-cortex"
+      ],
+      "provider_kind": "cloud_platform",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -26064,12 +32453,35 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "crewAI",
+          "litellm",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "special": 3,
+          "openai_compat": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "snowflake",
+          "Snowflake Cortex",
+          "snowflake-cortex"
+        ]
+      }
     },
     {
       "id": "snowflake_cortex",
       "display_name": "Snowflake Cortex",
-      "aliases": [],
+      "aliases": [
+        "snowflake"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -26202,7 +32614,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "crewAI",
+          "litellm",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "special": 3,
+          "openai_compat": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "snowflake",
+          "Snowflake Cortex",
+          "snowflake-cortex"
+        ]
+      }
     },
     {
       "id": "soniox",
@@ -26255,12 +32688,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "soniox"
+        ]
+      }
     },
     {
       "id": "sora",
       "display_name": "Sora",
-      "aliases": [],
+      "aliases": [
+        "Sora(视频)"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -26312,13 +32762,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "new-api"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "Sora(视频)"
+        ]
+      }
     },
     {
       "id": "stability",
       "display_name": "Stability",
-      "aliases": [],
-      "provider_kind": "model_vendor",
+      "aliases": [
+        "Stability AI",
+        "stability-ai"
+      ],
+      "provider_kind": "modal_service",
       "compatibility": {
         "tier": "L3",
         "protocol": "unknown",
@@ -26409,7 +32877,28 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "litellm",
+          "one-hub",
+          "portkey-gateway",
+          "spring-ai"
+        ],
+        "access": {
+          "special": 3,
+          "native": 1
+        },
+        "special_entries": 3,
+        "spellings": [
+          "stability",
+          "Stability AI",
+          "stability-ai"
+        ]
+      }
     },
     {
       "id": "stackit",
@@ -26513,13 +33002,33 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "haystack",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "stackit"
+        ]
+      }
     },
     {
       "id": "stepfun",
       "display_name": "StepFun (Global)",
       "aliases": [
-        "stepfun-ai"
+        "StepFun 阶跃星辰",
+        "stepfun-ai",
+        "stepfun-ai-step-plan",
+        "stepfun-step-plan"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -26673,12 +33182,43 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 14,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "cc-switch",
+          "higress",
+          "llama_index",
+          "mastra",
+          "one-api",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 14
+        },
+        "special_entries": 0,
+        "spellings": [
+          "stepfun",
+          "StepFun 阶跃星辰",
+          "stepfun-ai",
+          "stepfun-ai-step-plan",
+          "stepfun-step-plan"
+        ]
+      }
     },
     {
       "id": "stepfun_ai_step_plan",
       "display_name": "StepFun Step Plan (Global)",
-      "aliases": [],
+      "aliases": [
+        "StepFun 阶跃星辰",
+        "stepfun",
+        "stepfun-ai",
+        "stepfun-step-plan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -26740,12 +33280,43 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 14,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "cc-switch",
+          "higress",
+          "llama_index",
+          "mastra",
+          "one-api",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 14
+        },
+        "special_entries": 0,
+        "spellings": [
+          "stepfun",
+          "StepFun 阶跃星辰",
+          "stepfun-ai",
+          "stepfun-ai-step-plan",
+          "stepfun-step-plan"
+        ]
+      }
     },
     {
       "id": "stepfun_step_plan",
       "display_name": "StepFun Step Plan (China)",
-      "aliases": [],
+      "aliases": [
+        "StepFun 阶跃星辰",
+        "stepfun",
+        "stepfun-ai",
+        "stepfun-ai-step-plan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -26809,7 +33380,33 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 14,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "cc-switch",
+          "higress",
+          "llama_index",
+          "mastra",
+          "one-api",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 14
+        },
+        "special_entries": 0,
+        "spellings": [
+          "stepfun",
+          "StepFun 阶跃星辰",
+          "stepfun-ai",
+          "stepfun-ai-step-plan",
+          "stepfun-step-plan"
+        ]
+      }
     },
     {
       "id": "sub2_api",
@@ -26920,7 +33517,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "special": 1,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "subconscious"
+        ]
+      }
     },
     {
       "id": "submodel",
@@ -27049,12 +33663,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "mastra",
+          "new-api",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "submodel"
+        ]
+      }
     },
     {
       "id": "suno_api",
       "display_name": "SunoAPI",
-      "aliases": [],
+      "aliases": [
+        "Suno"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -27095,7 +33728,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "new-api",
+          "one-hub"
+        ],
+        "access": {
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "Suno"
+        ]
+      }
     },
     {
       "id": "synthetic",
@@ -27245,13 +33894,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "litellm",
+          "mastra",
+          "opencode",
+          "opencodex"
+        ],
+        "access": {
+          "openai_compat": 4
+        },
+        "special_entries": 0,
+        "spellings": [
+          "synthetic"
+        ]
+      }
     },
     {
       "id": "tavily",
       "display_name": "Tavily",
       "aliases": [],
-      "provider_kind": "model_vendor",
+      "provider_kind": "search_provider",
       "compatibility": {
         "tier": "L3",
         "protocol": "unknown",
@@ -27298,12 +33965,39 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "langchainjs",
+          "litellm"
+        ],
+        "access": {
+          "special": 1,
+          "none": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "tavily"
+        ]
+      }
     },
     {
       "id": "tencent",
       "display_name": "Tencent",
-      "aliases": [],
+      "aliases": [
+        "Tencent Hunyuan",
+        "Tencent 腾讯混元",
+        "hunyuan",
+        "tencent-coding-plan",
+        "tencent-token-plan",
+        "tencent-tokenhub",
+        "腾讯混元 Hunyuan(新版)",
+        "腾讯混元 Tencent",
+        "腾讯混元 hunyuan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -27393,12 +34087,61 @@
           "compatibility_hint": "openai"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 19,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "chats",
+          "cline",
+          "coai",
+          "higress",
+          "litellm",
+          "llm-connector",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 12,
+          "special": 7
+        },
+        "special_entries": 8,
+        "spellings": [
+          "hunyuan",
+          "tencent",
+          "Tencent Hunyuan",
+          "Tencent 腾讯混元",
+          "tencent-coding-plan",
+          "tencent-tokenhub",
+          "tencent-token-plan",
+          "腾讯混元 hunyuan",
+          "腾讯混元 Hunyuan(新版)",
+          "腾讯混元 Tencent"
+        ]
+      }
     },
     {
       "id": "tencent_coding_plan",
       "display_name": "Tencent Coding Plan (China)",
-      "aliases": [],
+      "aliases": [
+        "Tencent Hunyuan",
+        "Tencent 腾讯混元",
+        "hunyuan",
+        "tencent",
+        "tencent-token-plan",
+        "tencent-tokenhub",
+        "腾讯混元 Hunyuan(新版)",
+        "腾讯混元 Tencent",
+        "腾讯混元 hunyuan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -27495,12 +34238,61 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 19,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "chats",
+          "cline",
+          "coai",
+          "higress",
+          "litellm",
+          "llm-connector",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 12,
+          "special": 7
+        },
+        "special_entries": 8,
+        "spellings": [
+          "hunyuan",
+          "tencent",
+          "Tencent Hunyuan",
+          "Tencent 腾讯混元",
+          "tencent-coding-plan",
+          "tencent-tokenhub",
+          "tencent-token-plan",
+          "腾讯混元 hunyuan",
+          "腾讯混元 Hunyuan(新版)",
+          "腾讯混元 Tencent"
+        ]
+      }
     },
     {
       "id": "tencent_token_plan",
       "display_name": "Tencent Token Plan",
-      "aliases": [],
+      "aliases": [
+        "Tencent Hunyuan",
+        "Tencent 腾讯混元",
+        "hunyuan",
+        "tencent",
+        "tencent-coding-plan",
+        "tencent-tokenhub",
+        "腾讯混元 Hunyuan(新版)",
+        "腾讯混元 Tencent",
+        "腾讯混元 hunyuan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -27558,7 +34350,46 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 19,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "chats",
+          "cline",
+          "coai",
+          "higress",
+          "litellm",
+          "llm-connector",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 12,
+          "special": 7
+        },
+        "special_entries": 8,
+        "spellings": [
+          "hunyuan",
+          "tencent",
+          "Tencent Hunyuan",
+          "Tencent 腾讯混元",
+          "tencent-coding-plan",
+          "tencent-tokenhub",
+          "tencent-token-plan",
+          "腾讯混元 hunyuan",
+          "腾讯混元 Hunyuan(新版)",
+          "腾讯混元 Tencent"
+        ]
+      }
     },
     {
       "id": "tencent_token_plan_enterprise_auto",
@@ -27861,7 +34692,17 @@
     {
       "id": "tencent_tokenhub",
       "display_name": "Tencent TokenHub",
-      "aliases": [],
+      "aliases": [
+        "Tencent Hunyuan",
+        "Tencent 腾讯混元",
+        "hunyuan",
+        "tencent",
+        "tencent-coding-plan",
+        "tencent-token-plan",
+        "腾讯混元 Hunyuan(新版)",
+        "腾讯混元 Tencent",
+        "腾讯混元 hunyuan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -27939,7 +34780,46 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 19,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "chats",
+          "cline",
+          "coai",
+          "higress",
+          "litellm",
+          "llm-connector",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencodex",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 12,
+          "special": 7
+        },
+        "special_entries": 8,
+        "spellings": [
+          "hunyuan",
+          "tencent",
+          "Tencent Hunyuan",
+          "Tencent 腾讯混元",
+          "tencent-coding-plan",
+          "tencent-tokenhub",
+          "tencent-token-plan",
+          "腾讯混元 hunyuan",
+          "腾讯混元 Hunyuan(新版)",
+          "腾讯混元 Tencent"
+        ]
+      }
     },
     {
       "id": "tensormesh",
@@ -28022,7 +34902,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "tensormesh"
+        ]
+      }
     },
     {
       "id": "text_completion_codestral",
@@ -28091,7 +34986,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "text-completion-codestral"
+        ]
+      }
     },
     {
       "id": "text_completion_inception",
@@ -28158,7 +35068,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "text-completion-inception"
+        ]
+      }
     },
     {
       "id": "the_grid_ai",
@@ -28263,7 +35188,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "the-grid-ai"
+        ]
+      }
     },
     {
       "id": "thinkingmachines",
@@ -28328,7 +35269,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "special": 1,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "thinkingmachines"
+        ]
+      }
     },
     {
       "id": "tinfoil",
@@ -28403,7 +35361,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "tinfoil"
+        ]
+      }
     },
     {
       "id": "tinyfish",
@@ -28460,7 +35434,9 @@
       "id": "togetherai",
       "display_name": "Together AI",
       "aliases": [
+        "Together AI",
         "together",
+        "together-ai",
         "together_ai"
       ],
       "provider_kind": "model_vendor",
@@ -28672,7 +35648,60 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 33,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aisuite",
+          "awaken",
+          "cline",
+          "continue",
+          "dspy",
+          "envoy-ai-gateway",
+          "ferro-ai-gateway",
+          "haystack",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "llmgateway",
+          "mastra",
+          "mirascope",
+          "one-api",
+          "opencode",
+          "opencodex",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rust-genai",
+          "tensorzero",
+          "textgrad",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 30,
+          "native": 2,
+          "none": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "together",
+          "Together AI",
+          "together_ai",
+          "togetherai",
+          "together-ai"
+        ]
+      }
     },
     {
       "id": "tokenflux",
@@ -28817,7 +35846,24 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "higress",
+          "litellm",
+          "portkey-gateway"
+        ],
+        "access": {
+          "special": 3
+        },
+        "special_entries": 3,
+        "spellings": [
+          "triton"
+        ]
+      }
     },
     {
       "id": "trustedrouter",
@@ -28892,7 +35938,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "trustedrouter"
+        ]
+      }
     },
     {
       "id": "umans_ai",
@@ -28986,7 +36048,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "umans-ai"
+        ]
+      }
     },
     {
       "id": "umans_ai_coding_plan",
@@ -29083,7 +36161,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "umans-ai-coding-plan"
+        ]
+      }
     },
     {
       "id": "unorouter",
@@ -29190,7 +36284,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "unorouter"
+        ]
+      }
     },
     {
       "id": "upstage",
@@ -29277,12 +36387,37 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "APIPark",
+          "langchain",
+          "llama_index",
+          "mastra",
+          "opencode",
+          "portkey-gateway"
+        ],
+        "access": {
+          "openai_compat": 6
+        },
+        "special_entries": 0,
+        "spellings": [
+          "upstage"
+        ]
+      }
     },
     {
       "id": "v0",
       "display_name": "v0",
-      "aliases": [],
+      "aliases": [
+        "vercel",
+        "vercel (AI Gateway)",
+        "vercel-ai-gateway",
+        "vercel_ai_gateway"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -29371,7 +36506,42 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 18,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "AutoGPT",
+          "axonhub",
+          "cline",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "pi",
+          "plano",
+          "pydantic-ai",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 15,
+          "native": 2,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "v0",
+          "vercel",
+          "vercel (AI Gateway)",
+          "vercel_ai_gateway",
+          "vercel-ai-gateway"
+        ]
+      }
     },
     {
       "id": "venice",
@@ -29471,12 +36641,32 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 3,
+        "projects": [
+          "continue",
+          "opencode",
+          "opencodex"
+        ],
+        "access": {
+          "openai_compat": 3
+        },
+        "special_entries": 0,
+        "spellings": [
+          "venice"
+        ]
+      }
     },
     {
       "id": "vercel",
       "display_name": "Vercel AI Gateway",
       "aliases": [
+        "v0",
+        "vercel (AI Gateway)",
+        "vercel-ai-gateway",
         "vercel_ai_gateway"
       ],
       "provider_kind": "gateway_aggregator",
@@ -29676,19 +36866,62 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 18,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "AutoGPT",
+          "axonhub",
+          "cline",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "pi",
+          "plano",
+          "pydantic-ai",
+          "Roo-Code"
+        ],
+        "access": {
+          "openai_compat": 15,
+          "native": 2,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "v0",
+          "vercel",
+          "vercel (AI Gateway)",
+          "vercel_ai_gateway",
+          "vercel-ai-gateway"
+        ]
+      }
     },
     {
       "id": "vertex",
       "display_name": "VertexAI",
       "aliases": [
+        "Google Vertex AI",
+        "Vertex AI",
         "VertexAI",
         "google-cloud",
+        "google-vertex",
+        "google-vertexai",
+        "google_vertex",
+        "google_vertexai",
+        "vertex-ai",
         "vertex_ai",
         "vertex_ai-embedding-models",
         "vertex_ai-image-models",
         "vertex_ai-video-models",
-        "vertex_ai_beta"
+        "vertex_ai_beta",
+        "vertexai"
       ],
       "provider_kind": "cloud_platform",
       "compatibility": {
@@ -29953,7 +37186,71 @@
           "compatibility_hint": "native"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 39,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "bifrost",
+          "cc-switch",
+          "cline",
+          "continue",
+          "dspy",
+          "edgequake-llm",
+          "ferro-ai-gateway",
+          "haystack",
+          "higress",
+          "instructor",
+          "langchain",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "llmgateway",
+          "mastra",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "OpenHands",
+          "otari",
+          "pi",
+          "portkey-gateway",
+          "rig",
+          "Roo-Code",
+          "rust-genai",
+          "semantic-kernel",
+          "simple-one-api",
+          "traceloop-hub"
+        ],
+        "access": {
+          "special": 31,
+          "native": 7,
+          "none": 1
+        },
+        "special_entries": 33,
+        "spellings": [
+          "Google Vertex AI",
+          "google_vertex",
+          "google_vertexai",
+          "google-vertex",
+          "google-vertexai",
+          "vertex",
+          "Vertex AI",
+          "vertex_ai",
+          "vertexai",
+          "vertex-ai"
+        ]
+      }
     },
     {
       "id": "vertex_ai_ai21_models",
@@ -30754,7 +38051,9 @@
     {
       "id": "vidu",
       "display_name": "Vidu",
-      "aliases": [],
+      "aliases": [
+        "Vidu(视频)"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -30806,7 +38105,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "new-api"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "Vidu(视频)"
+        ]
+      }
     },
     {
       "id": "vivgrid",
@@ -30931,12 +38245,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "special": 1,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "vivgrid"
+        ]
+      }
     },
     {
       "id": "vllm",
       "display_name": "Vllm",
-      "aliases": [],
+      "aliases": [
+        "vllm (服务端)"
+      ],
       "provider_kind": "local_runtime",
       "compatibility": {
         "tier": "L2",
@@ -30978,12 +38311,52 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 15,
+        "projects": [
+          "bifrost",
+          "continue",
+          "dynamo",
+          "haystack",
+          "langchain",
+          "litellm",
+          "llama_index",
+          "LlamaIndexTS",
+          "opencodex",
+          "OpenGateLLM",
+          "otari",
+          "outlines",
+          "smg",
+          "tensorzero",
+          "textgrad"
+        ],
+        "access": {
+          "openai_compat": 12,
+          "special": 2,
+          "native": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "vllm",
+          "vllm (服务端)"
+        ]
+      }
     },
     {
       "id": "volc_engine",
       "display_name": "VolcEngine",
-      "aliases": [],
+      "aliases": [
+        "Doubao 豆包(火山方舟)",
+        "ark",
+        "arkbot",
+        "doubao",
+        "volcengine",
+        "火山引擎豆包 Volcengine",
+        "火山方舟 Ark"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -31035,13 +38408,49 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 13,
+        "projects": [
+          "aiproxy",
+          "axonhub",
+          "chats",
+          "cline",
+          "eino",
+          "higress",
+          "litellm",
+          "new-api",
+          "one-api",
+          "Roo-Code",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 9,
+          "native": 2,
+          "special": 1,
+          "none": 1
+        },
+        "special_entries": 3,
+        "spellings": [
+          "ark",
+          "arkbot",
+          "doubao",
+          "Doubao 豆包(火山方舟)",
+          "volcengine",
+          "火山方舟 Ark",
+          "火山引擎豆包 Volcengine"
+        ]
+      }
     },
     {
       "id": "voyage",
       "display_name": "Voyage",
-      "aliases": [],
-      "provider_kind": "model_vendor",
+      "aliases": [
+        "voyageai"
+      ],
+      "provider_kind": "embedding",
       "compatibility": {
         "tier": "L3",
         "protocol": "voyage",
@@ -31125,7 +38534,31 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "continue",
+          "litellm",
+          "otari",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig"
+        ],
+        "access": {
+          "openai_compat": 2,
+          "native": 2,
+          "none": 1,
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "voyage",
+          "voyageai"
+        ]
+      }
     },
     {
       "id": "vultr",
@@ -31232,7 +38665,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "vultr"
+        ]
+      }
     },
     {
       "id": "wafer",
@@ -31334,7 +38783,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "bifrost"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "wafer"
+        ]
+      }
     },
     {
       "id": "wandb",
@@ -31528,13 +38992,33 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "cline",
+          "litellm",
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 4
+        },
+        "special_entries": 0,
+        "spellings": [
+          "wandb"
+        ]
+      }
     },
     {
       "id": "watsonx",
       "display_name": "Watsonx",
-      "aliases": [],
-      "provider_kind": "model_vendor",
+      "aliases": [
+        "ibm"
+      ],
+      "provider_kind": "cloud_platform",
       "compatibility": {
         "tier": "unknown",
         "protocol": "unknown",
@@ -31644,7 +39128,33 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 9,
+        "projects": [
+          "aisuite",
+          "continue",
+          "haystack",
+          "langchain4j",
+          "langchaingo",
+          "langchainjs",
+          "litellm",
+          "llama_index",
+          "otari"
+        ],
+        "access": {
+          "special": 4,
+          "native": 4,
+          "openai_compat": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "ibm",
+          "watsonx"
+        ]
+      }
     },
     {
       "id": "watsonx_text",
@@ -31690,13 +39200,32 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "watsonx_text"
+        ]
+      }
     },
     {
       "id": "xai",
       "display_name": "xAI",
       "aliases": [
-        "xAI"
+        "x-ai",
+        "x.ai",
+        "xAI",
+        "xAI Grok",
+        "xai (Grok)"
       ],
       "provider_kind": "model_vendor",
       "compatibility": {
@@ -31947,12 +39476,81 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 44,
+        "projects": [
+          "agentsdk",
+          "ai",
+          "aider",
+          "aiproxy",
+          "aisuite",
+          "awaken",
+          "axonhub",
+          "bifrost",
+          "cc-switch",
+          "chats",
+          "cline",
+          "continue",
+          "edgequake-llm",
+          "ferro-ai-gateway",
+          "graniet-llm",
+          "helicone-ai-gateway",
+          "instructor",
+          "langchain",
+          "langchainjs",
+          "litellm",
+          "litellm-rust",
+          "LlamaIndexTS",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "mirascope",
+          "new-api",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "opencode-ai",
+          "opencodex",
+          "otari",
+          "pi",
+          "plano",
+          "portkey-gateway",
+          "pydantic-ai",
+          "rig",
+          "rllm",
+          "Roo-Code",
+          "rust-genai",
+          "smg",
+          "tensorzero",
+          "unia"
+        ],
+        "access": {
+          "openai_compat": 41,
+          "special": 2,
+          "native": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "x.ai",
+          "xai",
+          "x-ai",
+          "xai (Grok)",
+          "xAI Grok"
+        ]
+      }
     },
     {
       "id": "xiaomi_token_plan_ams",
       "display_name": "Xiaomi Token Plan (Europe)",
-      "aliases": [],
+      "aliases": [
+        "Xiaomi Mimo",
+        "xiaomi",
+        "xiaomi-token-plan-cn",
+        "xiaomi-token-plan-sgp"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -32048,12 +39646,47 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "axonhub",
+          "chats",
+          "cline",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "pi",
+          "plano"
+        ],
+        "access": {
+          "openai_compat": 19,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "xiaomi",
+          "Xiaomi Mimo",
+          "xiaomi-token-plan-ams",
+          "xiaomi-token-plan-cn",
+          "xiaomi-token-plan-sgp"
+        ]
+      }
     },
     {
       "id": "xiaomi_token_plan_cn",
       "display_name": "Xiaomi Token Plan (China)",
-      "aliases": [],
+      "aliases": [
+        "Xiaomi Mimo",
+        "xiaomi",
+        "xiaomi-token-plan-ams",
+        "xiaomi-token-plan-sgp"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -32149,12 +39782,47 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "axonhub",
+          "chats",
+          "cline",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "pi",
+          "plano"
+        ],
+        "access": {
+          "openai_compat": 19,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "xiaomi",
+          "Xiaomi Mimo",
+          "xiaomi-token-plan-ams",
+          "xiaomi-token-plan-cn",
+          "xiaomi-token-plan-sgp"
+        ]
+      }
     },
     {
       "id": "xiaomi_token_plan_sgp",
       "display_name": "Xiaomi Token Plan (Singapore)",
-      "aliases": [],
+      "aliases": [
+        "Xiaomi Mimo",
+        "xiaomi",
+        "xiaomi-token-plan-ams",
+        "xiaomi-token-plan-cn"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -32250,7 +39918,37 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "axonhub",
+          "chats",
+          "cline",
+          "llm-connector",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "opencode",
+          "opencodex",
+          "pi",
+          "plano"
+        ],
+        "access": {
+          "openai_compat": 19,
+          "native": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "xiaomi",
+          "Xiaomi Mimo",
+          "xiaomi-token-plan-ams",
+          "xiaomi-token-plan-cn",
+          "xiaomi-token-plan-sgp"
+        ]
+      }
     },
     {
       "id": "xiaomimimo",
@@ -32348,7 +40046,22 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "rig"
+        ],
+        "access": {
+          "openai_compat": 1
+        },
+        "special_entries": 0,
+        "spellings": [
+          "xiaomimimo"
+        ]
+      }
     },
     {
       "id": "xinference",
@@ -32408,7 +40121,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "APIPark",
+          "langchain",
+          "langchain4j",
+          "litellm",
+          "llama_index",
+          "llm-connector",
+          "new-api"
+        ],
+        "access": {
+          "openai_compat": 5,
+          "special": 2
+        },
+        "special_entries": 2,
+        "spellings": [
+          "xinference"
+        ]
+      }
     },
     {
       "id": "xpersona",
@@ -32494,12 +40229,33 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "xpersona"
+        ]
+      }
     },
     {
       "id": "xunfei",
       "display_name": "Xunfei",
-      "aliases": [],
+      "aliases": [
+        "Xunfei 讯飞星火(旧)",
+        "spark",
+        "讯飞星火",
+        "讯飞星火 Xunfei"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -32540,7 +40296,32 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "higress",
+          "new-api",
+          "one-api",
+          "one-hub"
+        ],
+        "access": {
+          "special": 4,
+          "openai_compat": 2
+        },
+        "special_entries": 5,
+        "spellings": [
+          "spark",
+          "xunfei",
+          "Xunfei 讯飞星火(旧)",
+          "讯飞星火",
+          "讯飞星火 Xunfei"
+        ]
+      }
     },
     {
       "id": "you_com",
@@ -32591,12 +40372,29 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 1,
+        "projects": [
+          "litellm"
+        ],
+        "access": {
+          "special": 1
+        },
+        "special_entries": 1,
+        "spellings": [
+          "you_com"
+        ]
+      }
     },
     {
       "id": "zai",
       "display_name": "Z.AI",
-      "aliases": [],
+      "aliases": [
+        "zai-coding-plan"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "L2",
@@ -32815,12 +40613,47 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": true
+      "implemented_in_aimux": true,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "awaken",
+          "axonhub",
+          "cline",
+          "continue",
+          "litellm",
+          "litellm-rust",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "oh-my-opencode-slim",
+          "opencode",
+          "opencodex",
+          "pi",
+          "pydantic-ai",
+          "rig",
+          "Roo-Code",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 19,
+          "none": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "zai",
+          "zai-coding-plan"
+        ]
+      }
     },
     {
       "id": "zai_coding_plan",
       "display_name": "Z.AI Coding Plan",
-      "aliases": [],
+      "aliases": [
+        "zai"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -32910,7 +40743,40 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 20,
+        "projects": [
+          "awaken",
+          "axonhub",
+          "cline",
+          "continue",
+          "litellm",
+          "litellm-rust",
+          "llmgateway",
+          "manifest",
+          "mastra",
+          "oh-my-opencode-slim",
+          "opencode",
+          "opencodex",
+          "pi",
+          "pydantic-ai",
+          "rig",
+          "Roo-Code",
+          "rust-genai"
+        ],
+        "access": {
+          "openai_compat": 19,
+          "none": 1
+        },
+        "special_entries": 4,
+        "spellings": [
+          "zai",
+          "zai-coding-plan"
+        ]
+      }
     },
     {
       "id": "zeldoc",
@@ -32991,7 +40857,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "zeldoc"
+        ]
+      }
     },
     {
       "id": "zenifra",
@@ -33054,7 +40936,23 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 2,
+        "projects": [
+          "mastra",
+          "opencode"
+        ],
+        "access": {
+          "openai_compat": 2
+        },
+        "special_entries": 0,
+        "spellings": [
+          "zenifra"
+        ]
+      }
     },
     {
       "id": "zenmux",
@@ -33210,7 +41108,25 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 4,
+        "projects": [
+          "agentsdk",
+          "mastra",
+          "opencode",
+          "opencodex"
+        ],
+        "access": {
+          "openai_compat": 4
+        },
+        "special_entries": 0,
+        "spellings": [
+          "zenmux"
+        ]
+      }
     },
     {
       "id": "zhipu_v4",
@@ -33272,7 +41188,18 @@
     {
       "id": "zhipuai_coding_plan",
       "display_name": "Zhipu AI Coding Plan",
-      "aliases": [],
+      "aliases": [
+        "Zhipu AI",
+        "Zhipu 智谱",
+        "bigmodel",
+        "chatglm",
+        "glm",
+        "zhipu",
+        "zhipu_ai",
+        "zhipuai",
+        "智谱",
+        "智谱 GLM"
+      ],
       "provider_kind": "model_vendor",
       "compatibility": {
         "tier": "unknown",
@@ -33365,7 +41292,155 @@
           "compatibility_hint": "unknown"
         }
       ],
-      "implemented_in_aimux": false
+      "implemented_in_aimux": false,
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 22,
+        "projects": [
+          "aiproxy",
+          "APIPark",
+          "awaken",
+          "axonhub",
+          "chats",
+          "higress",
+          "langchain4j",
+          "langchain-swift",
+          "llama_index",
+          "mastra",
+          "one-api",
+          "one-hub",
+          "opencode",
+          "OpenHands",
+          "plano",
+          "portkey-gateway",
+          "rust-genai",
+          "simple-one-api"
+        ],
+        "access": {
+          "openai_compat": 16,
+          "special": 5,
+          "native": 1
+        },
+        "special_entries": 8,
+        "spellings": [
+          "bigmodel",
+          "chatglm",
+          "glm",
+          "zhipu",
+          "Zhipu AI",
+          "Zhipu 智谱",
+          "zhipu_ai",
+          "zhipuai",
+          "zhipuai-coding-plan",
+          "智谱",
+          "智谱 GLM"
+        ]
+      }
+    },
+    {
+      "id": "codex",
+      "display_name": "codex",
+      "aliases": [
+        "openai-codex"
+      ],
+      "provider_kind": "subscription_proxy",
+      "compatibility": {
+        "tier": "unknown",
+        "protocol": "unknown",
+        "openai_compatible": null,
+        "confidence": 0.4
+      },
+      "trust": {
+        "status": "review",
+        "score": 60,
+        "reasons": [
+          "from reference-audit (104 projects, 2026-08-01)",
+          "seen in 7 audited project(s)",
+          "protocol not verified against official docs"
+        ]
+      },
+      "capabilities": [],
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 7,
+        "projects": [
+          "agent-of-empires",
+          "axonhub",
+          "CCSwitcher",
+          "cline",
+          "pi",
+          "Roo-Code",
+          "uni-api"
+        ],
+        "access": {
+          "special": 5,
+          "none": 2
+        },
+        "special_entries": 5,
+        "spellings": [
+          "codex",
+          "openai-codex"
+        ]
+      },
+      "integration_candidate": {
+        "priority": "high",
+        "reason": "seen in 7 reference project(s)"
+      }
+    },
+    {
+      "id": "azure_ai_foundry",
+      "display_name": "azure (AI Foundry)",
+      "aliases": [
+        "azure_foundry"
+      ],
+      "provider_kind": "cloud_platform",
+      "compatibility": {
+        "tier": "unknown",
+        "protocol": "unknown",
+        "openai_compatible": null,
+        "confidence": 0.4
+      },
+      "trust": {
+        "status": "review",
+        "score": 60,
+        "reasons": [
+          "from reference-audit (104 projects, 2026-08-01)",
+          "seen in 6 audited project(s)",
+          "protocol not verified against official docs"
+        ]
+      },
+      "capabilities": [],
+      "audit": {
+        "source": "reference-audit",
+        "audit_date": "2026-08-01",
+        "count": 6,
+        "projects": [
+          "chats",
+          "dotnet-extensions",
+          "ferro-ai-gateway",
+          "guidance",
+          "llmgateway",
+          "pydantic-ai"
+        ],
+        "access": {
+          "special": 5,
+          "openai_compat": 1
+        },
+        "special_entries": 5,
+        "spellings": [
+          "azure (AI Foundry)",
+          "Azure AI Foundry",
+          "azure_ai_foundry",
+          "azure_foundry",
+          "azure-ai-foundry"
+        ]
+      },
+      "integration_candidate": {
+        "priority": "high",
+        "reason": "seen in 6 reference project(s)"
+      }
     }
   ]
 }

--- a/rfc/0016-align-with-aisdk.md
+++ b/rfc/0016-align-with-aisdk.md
@@ -1,6 +1,6 @@
 # RFC-0016: 对齐 Vercel AI SDK 能力缺口
 
-> **Status**: DRAFT (pending review)
+> **Status**: DRAFT (pending review) — 实施状态与下游 wrapper 影响见 [§7](#7-实施状态截至-2026-08-02)(2026-08-02 更新)
 > **Date**: 2026-08-01
 > **Scope**: 系统对比 aimux 0.1.2 与 Vercel AI SDK (`@ai-sdk/openai` / `@ai-sdk/openai-compatible` / `@ai-sdk/provider` V4) 的接口与实现,识别能力缺口,并按优先级规划补齐路径
 > **Related**: [RFC-0009](0009-request-resilience.md) request resilience(retry/timeout,本 RFC 的 abortSignal/timeout 缺口与之相关),[RFC-0014](0014-logging.md) 统一日志体系(可观测性缺口依赖本 RFC 的 span 树)
@@ -145,3 +145,63 @@ aimux 的 `OpenAIResponsesModel`([responses/mod.rs](../aimux-providers/src/opena
 2. **L2 tool-call.input 类型**:aimux 用 `Value`(解析后 JSON)而非 V4 规范的 `string`。需确认是否回归 V4 的 string 形态,还是保留为 aimux 的有意设计(Node 侧消费更友好)。
 3. **M4 通用 providerOptions 透传的安全边界**:从白名单改为透传后,需确保不会把内部字段(如 `prompt_cache_breakpoint` 已在白名单)重复发送。
 4. **H4 多步工具循环的范围**:是否对标 Vercel `generateText` 的完整多步(stopWhen/maxSteps/prepareStep/activeTools/toolOrder/refineToolInput/repairToolCall),还是先做最小可用版(tools 自动执行 + steps)。
+
+---
+
+## 7. 实施状态(截至 2026-08-02)
+
+> 本节为实施追踪:记录 §2 各缺口的落地状态与下游 wrapper 联动影响,作为后续补齐的核对依据。
+> §2 表格保持"起草时缺口"原样,不随实施改动;落地情况一律以本节为准。
+
+### 7.1 已落地(相对本 RFC 起草时)
+
+| # | 缺口 | 落地方式 | 版本 |
+|---|------|---------|------|
+| H2 | maxRetries 不可配 | `CallOptions.max_retries` + `GenerateTextOptions.max_retries`([options.rs:90](../aimux-core/src/options.rs#L90)、[generate.rs:58](../aimux-core/src/generate.rs#L58));Node `ProviderConfig.max_retries` 透传([lib.rs:207](../bindings/node/src/lib.rs#L207)) | 0.1.3 |
+| M1 | 工厂级 headers/org/project/retry | Node 工厂收 `ProviderConfig { baseUrl, headers, organization, project, maxRetries, bodyOverrides }`([lib.rs:168](../bindings/node/src/lib.rs#L168)),透传 `with_headers`/`with_org_id`/`with_project`/`with_retry_config`([lib.rs:189-218](../bindings/node/src/lib.rs#L189));anthropic 同理 | 0.1.3 |
+| M4/M5 | providerOptions 透传 / transformRequestBody | **换形态解决**:`RequestBodyOverride` 封闭枚举退役,改 RFC-0017 通用 `body_overrides`(JSON deep-merge,per-call + provider 级 + 全 binding 透出,[convert.rs:1437](../aimux-providers/src/openai/convert.rs#L1437))。任意新 API 参数均可发送;但**不是** Vercel 式"未知 providerOptions key 自动透传"(core `provider_options` 仍白名单读取,[convert.rs:376](../aimux-providers/src/openai/convert.rs#L376)),也**不是** transform 闭包 | 0.1.3 |
+| L4 | env 自动读取 | 部分:`provider()`/`deepseek()` 走注册表,api_key 可空读 env([lib.rs:314](../bindings/node/src/lib.rs#L314));`openai()`/`anthropic()` 工厂仍强制传参 | 0.1.3 |
+| M9 | warnings 丢弃 | 部分:非流式已透传([model.rs:383](../aimux-providers/src/openai/model.rs#L383));流式仍 `StreamStart{warnings:vec![]}`([model.rs:450](../aimux-providers/src/openai/model.rs#L450)) | 0.1.3 |
+| L2 | tool-call.input 类型 | 维持 `Value`(设计选择,Node 侧消费更友好),不回归 V4 string 形态 | — |
+
+### 7.2 未落地清单(逐条追踪)
+
+**高优先级:**
+- **H1** abortSignal — `CallOptions` 无 `abort_signal` 字段,`do_generate`/`do_stream` 硬编码 `abort_signal: None`([model.rs:271](../aimux-providers/src/openai/model.rs#L271)、[model.rs:420](../aimux-providers/src/openai/model.rs#L420));`LanguageModel` trait 不带 signal。media provider 在用、LLM 漏着
+- **H3** timeout — core 零实现,无任何超时字段
+- **H4** 多步工具循环 — 全仓库无 steps/maxSteps/工具执行循环,`generate_text` 仍单次调用
+
+**中优先级:**
+- **M2** includeRawChunks — `StreamPart::Raw` 已定义但全仓 0 处 emit;`CallOptions` 无字段
+- **M3** logprobs 请求 — 仅响应侧解析([model.rs:363](../aimux-providers/src/openai/model.rs#L363)),请求体不写 `logprobs`/`top_logprobs`
+- **M6** 自定义 fetch / proxy — 仍是进程级共享 reqwest client
+- **M7** 顶层结果聚合 — `GenerateTextResult` 仅 text/tool_calls([generate.rs:96](../aimux-core/src/generate.rs#L96));reasoning/files/sources 在 `raw.content`,无 `responseMessages`
+- **M8** 缺 variant — `tool-approval-request`/`custom`/`reasoning-file` 均无;`source` 无 document 子类型([stream_part.rs:156](../aimux-core/src/stream_part.rs#L156))
+- **M10** usage.raw — `convert_usage` 写死 `raw: None`([model.rs:172](../aimux-providers/src/openai/model.rs#L172));流式 raw usage 只进 provider_metadata([model.rs:762](../aimux-providers/src/openai/model.rs#L762))
+- **M11** streamText 聚合器 — Node 仍 yield 原始 StreamPart JSON([lib.rs:63](../bindings/node/src/lib.rs#L63));core 仅 `StreamTextResult::text()`
+- **M12** 结构化 output / generateObject — 无
+- **M13** 生命周期 callbacks — 无
+
+**低优先级:**
+- **L1** response-metadata.timestamp 恒 None(非流式 [model.rs:387](../aimux-providers/src/openai/model.rs#L387)、流式 [model.rs:539](../aimux-providers/src/openai/model.rs#L539))
+- **L3** supportsStructuredOutputs / includeUsage 仍硬编码
+- **L5** telemetry、**L6** toolApproval — 无
+- **L7** queryParams / errorStructure / supportedUrls / metadataExtractor / convertUsage — 均未做(注:error structure 有 `DEFAULT_ERROR_STRUCTURE` 常量但写死不可配)
+
+### 7.3 下游 wrapper 影响矩阵
+
+架构事实:所有 binding 走 JSON 边界 —— `aimux-ffi`(C ABI,供 C/Go/Java/Kotlin/Swift/Flutter)与 Node(napi)、Python(pyo3)独立,但都是 options 进 JSON、结果回 JSON([aimux_generate_text(handle, prompt_json, opts_json)](../aimux-ffi/src/lib.rs#L433))。因此**可序列化字段自动透传**,只有**运行时桥接**(回调/取消/宿主函数)必须动 wire 层。
+
+| 类别 | 改动量 | 涉及缺口 |
+|------|--------|---------|
+| ① 加字段(机械性,每 wrapper 类型层同步;Node/Python JSON 直传可不加字段仅丢类型提示) | 小 | H3、M2、M3(options 字段);M7、M9、M10、L1(结果/StreamPart 字段) |
+| ② 动 FFI + 全 wrapper(结构性) | 大 | H1(需新增 `aimux_cancel(handle)` 类 C 入口 + 各语言 cancel();Node 另需 JS AbortSignal→native 桥接);H4(若做 core 自动执行工具需回调注册,若做"tool_results 回填重调"API 则 wire 不动、各 wrapper 写 loop helper);M13(宿主回调注册);M12(若新增独立入口 `aimux_generate_object` 则全链改动,若复用 generate_text + options 字段则降级为 ①) |
+| ③ wrapper 自实现(wire 不动) | 中 | M11(streamText 聚合器,宿主语言便利层);M6(跨语言注入宿主 fetch 不现实,大概率 core 内 reqwest 配置,归 ① 或不涉及) |
+| ④ 契约测试同步 | 小 | 所有新增字段需同步 `contract-tests/fixtures/wire-format.json` 及各 binding wire 测试(go `wire_format_test.go`、python `test_wrapper.py`、node `__test__`) |
+
+### 7.4 文档跟踪状态
+
+- §2/§4 是唯一系统记录缺口的文档;本 RFC 创建后未随实施更新(§2 表格仍把 H2/M1 标 ❌、按 `RequestBodyOverride` 描述 M4/M5),本节起作为修正与追踪入口
+- `docs/plan/backlog.md` 仅跟踪 RFC-0017 阶段 2 项,无本 RFC 条目;`docs/api/gaps.md` 是 binding 多模态差距(已闭合),与本 RFC 无关
+- 内部审计(QUALITY_REVIEW/REMEDIATION)顺带提到 H1 未接线及 core util.rs `AbortSignal` 缺陷(全仓零调用,建议删除改 `tokio_util::CancellationToken`),未覆盖其余缺口
+- 后续实施建议:本表逐条勾销;若进入排期,迁移到 `docs/plan/backlog.md` 分区跟踪

--- a/rfc/0018-codex-subscription.md
+++ b/rfc/0018-codex-subscription.md
@@ -1,0 +1,104 @@
+﻿# RFC-0018: Codex 订阅通道 provider 集成评估
+
+> **Status**: PROPOSED (pending protocol verification)
+> **Date**: 2026-08-02
+> **Scope**: 评估并设计 Codex(OpenAI 编程模型/订阅通道)在 aimux 的集成路径。
+> 本 RFC 基于 104 项目参考审计的发现,先给出动机与现状,再列出**必须核验的协议事实**,
+> 核验通过后按本 RFC 的设计草案实现;核验不通过则降级为 backlog。
+> **Related**: [RFC-0016](0016-align-with-aisdk.md) AISDK 对齐、[RFC-0006](0006-provider-development.md) provider 开发规范、
+> [provider-inventory/INTEGRATION-PRIORITY.md](../provider-inventory/INTEGRATION-PRIORITY.md)
+
+---
+
+## 1. 背景与动机
+
+### 1.1 审计发现
+
+参考项目审计(104 项目,2026-08-01)中,**7 个编码 agent/网关项目**支持 Codex 通道:
+agent-of-empires、axonhub、CCSwitcher、cline、pi、Roo-Code、uni-api。
+接入判定 **5 个 special + 2 个 none**,即参考实现全部走**特殊接入**(订阅 OAuth/私有端点),
+没有任何一个走标准 API key 薄封装。
+
+参考实现要点(见各项目审计文件):
+- **pi**: `openai-codex` provider,ChatGPT 订阅 OAuth(device flow/account_id + refresh_token),私有端点 `chatgpt.com/backend-api/codex/responses`
+- **opencodex**: Responses 透传 + 账号池(affinity/quota/cooldown/failover),`x-codex-turn-state` 粘性路由
+- **codex CLI**: 官方 CLI,`[model_providers.<id>]` 自定义 + 订阅 token,Responses-over-WebSocket
+- **cline/pi/Roo-Code**: OAuth 设备码登录 + token 刷新
+
+### 1.2 为什么值得评估
+
+- Codex 是 OpenAI 官方编程模型,7 个参考项目背书,是"订阅通道"这一类
+  (`subscription_proxy`:github_copilot/chatgpt/codex/kiro/cursor)中支持面最广的
+- 订阅通道的**用户价值**与 API key 不同:固定订阅费、无需按 token 计费
+- aimux 现有 provider 全部是 API key 模式,订阅通道是**全新的接入形态**,
+  涉及 OAuth 设备码 + token 刷新 + 私有端点,需要独立的配置与凭证模型
+
+### 1.3 风险与不确定
+
+- OpenAI 官方对第三方接入订阅通道的**条款限制**(历史上 ChatGPT 订阅 API 为逆向/非官方路径),
+  必须核验官方文档是否允许
+- 若官方已提供 **Codex API key 模式**(Responses API + `codex-1` 模型),则大多数用户走
+  标准路径即可,订阅通道价值下降——**先核验再决定**
+
+---
+
+## 2. 必须核验的协议事实(阻塞项)
+
+按 [RFC-0006 §2.1](../rfc/0006-provider-development.md) 证据裁决顺序,核验以下事实:
+
+| # | 事实 | 来源 | 当前状态 |
+|---|---|---|---|
+| V1 | Codex 官方 API 是否存在 API key 模式(端点/模型 ID/定价) | OpenAI 官方文档 | 未核验 |
+| V2 | 订阅通道接入方式(端点、鉴权流程、条款) | OpenAI 官方文档/官方 SDK | 未核验 |
+| V3 | 订阅 OAuth 设备码流程细节(scope/刷新/失效) | 参考实现(pi/opencodex/codex) | 参考实现有,官方未确认 |
+| V4 | 协议形态(Responses API?WebSocket?) | 官方 + 参考实现 | 参考实现不一致,待确认 |
+| V5 | 流式与工具调用支持 | 官方 + 参考实现 | 待确认 |
+
+**核验完成后**更新本 RFC 的 §3/§4 并进入 review;若 V1 成立(有官方 API key 模式),
+建议实现路径改为"标准 Responses 薄封装 + 订阅通道降级为 backlog"。
+
+---
+
+## 3. 设计草案(待核验后定稿)
+
+### 3.1 路径 A:标准 API key 模式(若 V1 成立)
+
+- 走现有 `openai` provider 的 Responses API 通道(codex 模型 + API key)
+- 无需新架构;`OpenAICompatProfile`/`OpenAIResponsesModel` 复用
+- 工作量:小(模型 ID + 验证测试)
+
+### 3.2 路径 B:订阅通道(若 V2/V3 成立且条款允许)
+
+新增 `aimux-providers/src/codex/`:
+
+```
+CodexConfig {
+  mode: ApiKey | Subscription,
+  // ApiKey 模式复用 OpenAIConfig 能力
+  // Subscription 模式:
+  account_token: Option<String>,   // OAuth 产物
+  refresh_token: Option<String>,
+  base_url: String,                // 默认 https://chatgpt.com/backend-api
+}
+```
+
+- **凭证管理**:OAuth 设备码(登录一次,存 refresh_token,自动刷新);
+  参考实现:pi(`openai-codex` OAuth)、opencodex(账号池 + cooldown/failover)
+- **协议**:Responses API 透传 + `ChatGPT-Account-Id`/`x-codex-turn-state` 头
+  (实现细节以 V4 核验结果为准)
+- **明确不做**:账号池/多账号负载均衡(网关系,见 [LEARNINGS](../reference/audit/LEARNINGS.md) 定位结论)
+
+---
+
+## 4. 验收标准
+
+- [ ] V1-V5 核验记录附于本 RFC(官方文档 URL + 结论)
+- [ ] 核验结论决定路径 A 或 B,更新 §3 后 review
+- [ ] 实现后:cassette 测试覆盖非流式/流式/工具调用(复用 RFC-0003 测试方案)
+- [ ] 订阅模式凭证刷新有测试(401 → 刷新 → 重试)
+
+## 5. 参考资料
+
+- 审计:`reference/audit/{pi,opencodex,cline,Roo-Code,agent-of-empires,axonhub,CCSwitcher}.md`
+- inventory 候选:codex(high,7 项目,`special:5, none:2`)
+- 参考实现:pi `openai-codex`、opencodex `accounts`、codex CLI `[model_providers]`

--- a/rfc/0019-session-affinity.md
+++ b/rfc/0019-session-affinity.md
@@ -1,0 +1,100 @@
+﻿# RFC-0019: 会话亲和(session affinity)轻量支持
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-02
+> **Scope**: 在 aimux 请求层增加可选的 `session_id`,由 provider 自动注入各厂商的
+> 会话/提示缓存头。轻量设计,不引入粘性路由。
+> **Related**: [RFC-0017](0017-provider-config-dx.md) 配置层(本 RFC 的字段走同一 options 通道)、
+> [RFC-0005](0005-protocol-conversion.md) 协议转换(头部注入点)
+
+---
+
+## 1. 背景与动机
+
+### 1.1 审计发现
+
+参考项目审计(104 项目)中,**15+ 项目实现会话亲和**,分三档形态:
+
+| 形态 | 代表实现 | 机制 |
+|---|---|---|
+| 轻:固定 header/body 注入 | cline、pi、llmgateway、dynamo | `session_id` → `x-session-id` / `x-session-affinity` / `x-claude-code-session-id` |
+| 中:哈希粘性路由 | TokenHub、claude-code-router、axonhub、plano | `hash(sessionId)%100`、SHA-256 rendezvous、`TraceStickyMode=prefer_previous_channel` |
+| 重:账号/会话级绑定 | codex、opencodex、uni-api | `x-codex-turn-state`、账号池按会话选择 |
+
+**价值**:同一会话固定同一上游/携带稳定会话标识,可提升上游提示缓存命中率
+(Anthropic prompt caching、OpenAI prompt cache 均按会话/前缀命中),降低延迟与成本。
+
+### 1.2 aimux 现状
+
+- `CallOptions.headers: Option<HashMap<String, String>>` 已存在(options.rs:74)——**零代码即可表达**
+  任意会话头(用户手动传 `x-session-id` 即可)
+- 但无**一等公民**字段:各厂商头名不同(`x-session-id`/`x-session-affinity`/
+  `x-claude-code-session-id`/`prompt_cache_key` 等),用户需自行查表,
+  且流式/非流式/各 provider 行为由用户保证一致
+
+### 1.3 边界(明确不做)
+
+- **不做**哈希粘性/渠道路由/账号池(中/重形态)——属网关/账号层,aimux 定位是接入层
+  (LEARNINGS.md 结论)
+- **不做**会话状态管理(会话生命周期由用户持有,aimux 只透传)
+
+---
+
+## 2. 设计
+
+### 2.1 用户面:复用 GenerateTextOptions 的 headers,或新增便捷字段
+
+两条候选路径,倾向 **A**(最小侵入):
+
+**路径 A(推荐)**:不新增核心字段,文档化 + 便捷常量
+
+- 在 `aimux-core` 增加会话头常量表(供用户/绑定层查表):
+
+```rust
+/// 会话亲和 header 名(按 provider 分组,供用户选用)。
+pub const SESSION_HEADERS: &[(&str, &str)] = &[
+    ("openai", "x-session-id"),            // OpenAI 系(部分网关)
+    ("anthropic", "x-claude-code-session-id"), // Anthropic 系(dynamo 透传)
+    ("openrouter", "x-session-id"),        // OpenRouter sticky session
+    // ...
+];
+```
+
+- 用户通过现有 `headers` 字段注入;绑定层(Node/Python)在 options 里加
+  `sessionId?: string` 便捷参数,自动填对应 provider 的 header
+- 工作量:极小(常量表 + 绑定层一个字段)
+
+**路径 B**:core 的 `CallOptions` 加 `session_id: Option<String>`,provider 侧自动注入。
+
+- 优点:语义化、各语言绑定统一
+- 缺点:header 名是 provider 专属知识,放 core 字段会造成"core 知道厂商头名"的耦合;
+  且与 `headers` 重叠,两份入口易冲突(需定义合并优先级)
+
+**结论**:路径 A 保持 core 纯净(厂商差异仍在 provider/绑定层表达,符合现有架构);
+若后续发现 session 需要参与重试/粘性等**语义**,再升级为路径 B。
+
+### 2.2 注入点
+
+- Node/Python 绑定层:工厂函数/生成函数 options 增加 `sessionId`,映射到对应
+  provider 的 header(查 §2.1 常量表)
+- Rust 用户:直接 `with_headers`(现状已支持,无需改动)
+
+### 2.3 行为契约
+
+- `sessionId` 只做**透传**,不校验格式、不保证上游行为(上游缓存策略在厂商侧)
+- 流式/非流式一致注入
+- 与用户显式传的同名 header 冲突时:**用户显式 header 优先**(绑定层不覆盖)
+
+---
+
+## 3. 验收标准
+
+- [ ] 常量表覆盖至少 3 个主流厂商/网关(openai 系、anthropic 系、openrouter)
+- [ ] Node 绑定:`generateText({ sessionId })` 产出对应 header(cassette 断言)
+- [ ] 与显式 headers 冲突时用户优先(测试)
+- [ ] Rust 侧无 API 破坏(仅新增)
+
+## 4. 参考资料
+
+- 审计:`reference/audit/{cline,pi,llmgateway,dynamo,TokenHub,claude-code-router,axonhub,plano}.md`
+- reference/audit/LEARNINGS.md 会话亲和三档形态表


### PR DESCRIPTION
## 变更内容

### 1. provider-inventory 数据合并 (schema 1.1.0)
- `providers.json` / `providers.csv` 合并 reference-audit(104 项目, 2026-08-01)审计结果
- 审计 canonical 合并后保留 **2 个**新条目:`codex`、`azure_ai_foundry`,总数 325 → 327
- 293 个既有 provider 补充 `audit` 字段与 kind 修正
- audit 来源条目标记 `audit.source`,需协议验证(见 RFC-0018)

### 2. RFC-0016 追加 §7 实施状态追踪
- 记录 §2 各缺口落地状态与下游 wrapper 影响(截至 2026-08-02)

### 3. 新 RFC
- **RFC-0018**: Codex 订阅通道 provider 集成评估(PROPOSED,待协议核验)
- **RFC-0019**: 会话亲和(session affinity)轻量支持(DRAFT)

## 提交
- `d9f751f` data: provider-inventory 合并 reference-audit 审计结果 (schema 1.1.0)
- `b7d789f` docs: RFC-0016 追加 §7 实施状态追踪 (2026-08-02)
- `ffa4dca` docs: 新增 RFC-0018 Codex 订阅集成评估 与 RFC-0019 会话亲和轻量支持
