### PR TITLE
fix(go): cgo LDFLAGS breaks macOS build — split by platform, add macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,12 @@ jobs:
 
   # ── Go binding: build FFI static archive + vet/test ───────────────────────
   go-binding:
-    name: Go binding
-    runs-on: ubuntu-latest
+    name: Go binding (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -10,7 +10,10 @@ package aimux
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/../../aimux-ffi
-#cgo LDFLAGS: -L${SRCDIR}/../../target/release -Wl,-Bstatic -laimux_ffi -Wl,-Bdynamic -lpthread -ldl -lm
+// GNU ld (Linux/mingw/BSD) needs -Bstatic/-Bdynamic to prefer the static
+// archive; ld64 (macOS) rejects those flags, so link the .a explicitly there.
+#cgo !darwin LDFLAGS: -L${SRCDIR}/../../target/release -Wl,-Bstatic -laimux_ffi -Wl,-Bdynamic -lpthread -ldl -lm
+#cgo darwin LDFLAGS: ${SRCDIR}/../../target/release/libaimux_ffi.a -lpthread -ldl -lm
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/bindings/go/multimodal.go
+++ b/bindings/go/multimodal.go
@@ -10,7 +10,10 @@ package aimux
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/../../aimux-ffi
-#cgo LDFLAGS: -L${SRCDIR}/../../target/release -Wl,-Bstatic -laimux_ffi -Wl,-Bdynamic -lpthread -ldl -lm
+// GNU ld (Linux/mingw/BSD) needs -Bstatic/-Bdynamic to prefer the static
+// archive; ld64 (macOS) rejects those flags, so link the .a explicitly there.
+#cgo !darwin LDFLAGS: -L${SRCDIR}/../../target/release -Wl,-Bstatic -laimux_ffi -Wl,-Bdynamic -lpthread -ldl -lm
+#cgo darwin LDFLAGS: ${SRCDIR}/../../target/release/libaimux_ffi.a -lpthread -ldl -lm
 
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Problem

`go build` of the Go binding fails on macOS:

```
ld: unknown options: -Bstatic -Bdynamic -Bstatic -Bdynamic
clang: error: linker command failed with exit code 1
```

`-Wl,-Bstatic` / `-Wl,-Bdynamic` is GNU ld-specific. macOS ld64 rejects both flags. The Go-binding CI job only ran on `ubuntu-latest`, so this was never caught.

## Fix

- **`bindings/go/aimux.go` + `bindings/go/multimodal.go`**: split the cgo LDFLAGS by platform.
  - Non-darwin (`#cgo !darwin`) keeps the original flags — Linux/mingw/BSD all accept `-Bstatic`, so Windows and other platforms are unaffected.
  - `#cgo darwin` links the archive by explicit path (`libaimux_ffi.a`) — ld64 prefers `.dylib` over `.a` with `-l`, so a bare `-laimux_ffi` would silently switch to dynamic linking, breaking the static single-binary guarantee.
- **`.github/workflows/ci.yml`**: run the Go-binding job on `macos-latest` as well, so the macOS build is verified on every PR.

## Verification

- `go test ./...` passes on macOS (links and runs the mock-server test suite).
- cgo `!GOOS` negation syntax verified both directions against the actual build commands.

Closes nothing; RFC-0011 §7.2 Phase 4 CI matrix partially covered (macOS added; Windows/linux-arm64 still pending).