### PR TITLE
ci: run Go binding on macOS + fix go-build runner (macos-13 → macos-15-intel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,14 @@ jobs:
 
   # ── Go binding: build FFI static archive + vet/test ───────────────────────
   go-binding:
-    name: Go binding
-    runs-on: ubuntu-latest
+    name: Go binding (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS included because the cgo LDFLAGS are platform-specific
+        # (ld64 rejects GNU -Bstatic/-Bdynamic; see bindings/go/aimux.go).
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,7 @@ jobs:
         settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - host: macos-13
+          - host: macos-15-intel
             target: x86_64-apple-darwin
           - host: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
Extends the Go binding CI job to macOS, guarding the platform-specific cgo LDFLAGS (ld64 rejects GNU -Bstatic/-Bdynamic) against regression. Suggestion taken from #12.