### PR TITLE
fix(ffi): preserve serde_json error detail for invalid prompt_json

### DIFF
--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -790,8 +790,11 @@ pub extern "C" fn aimux_generate_text(
         Some(m) => m,
         None => return error_json_raw("invalid handle"),
     };
-    let prompt = match cstr_to_string(prompt_json).and_then(|s| parse_prompt(&s).ok()) {
-        Some(p) => p,
+    let prompt = match cstr_to_string(prompt_json) {
+        Some(s) => match parse_prompt(&s) {
+            Ok(p) => p,
+            Err(e) => return error_json_raw(format!("invalid prompt_json: {e}")),
+        },
         None => return error_json_raw("invalid prompt_json"),
     };
     let opts = match cstr_to_string(opts_json) {
@@ -839,8 +842,14 @@ pub extern "C" fn aimux_stream_text(
         }
     };
 
-    let prompt = match cstr_to_string(prompt_json).and_then(|s| parse_prompt(&s).ok()) {
-        Some(p) => p,
+    let prompt = match cstr_to_string(prompt_json) {
+        Some(s) => match parse_prompt(&s) {
+            Ok(p) => p,
+            Err(e) => {
+                fire_error(on_error, format!("invalid prompt_json: {e}"));
+                return;
+            }
+        },
         None => {
             fire_error(on_error, "invalid prompt_json");
             return;


### PR DESCRIPTION
## What

`aimux_generate_text` and `aimux_stream_text` parse `prompt_json` via `parse_prompt(&s).ok()`, discarding the `serde_json::Error` and returning a bare `"invalid prompt_json"` with no indication of what was actually wrong. The sibling `opts_json` branch in both of these same functions already preserves the underlying error (`format!("invalid opts_json: {e}")`) — `prompt_json` was the only inconsistent path.

```
before: {"error":"invalid prompt_json", ...}
after:  {"error":"invalid prompt_json: expected value at line 1 column 1", ...}
```

This affects every C-ABI binding sharing the compiled `aimux-ffi` archive (Go, Java, Kotlin, Swift, Flutter, C). Node/Python use the native (napi/PyO3) path with their own independent `parse_prompt`, which already formats the serde_json error correctly — unaffected.

Found while diagnosing the doc bug fixed in #11: a caller passing an un-JSON-encoded string got only `"invalid prompt_json"`, no clue that the fix was "wrap it in quotes" — the missing detail directly obscured the root cause.

## Not in scope

Every FFI constructor (`aimux_openai_new`, `aimux_provider_new`, `aimux_provider_from_env`, etc. — ~40 functions) returns a bare `u64` handle with `0` on any failure and no error channel at all. That's a much larger, deliberate architectural pattern (already tracked internally as a P2 item proposing a `aimux_last_error()`-style retrieval symbol) — a proper fix needs a new cross-cutting mechanism wired through every constructor and every C-ABI binding, not a one-line change. Left untouched here to keep this PR narrow and low-risk.

## Verification

- `cargo build -p aimux-ffi --release`
- `cargo test -p aimux-ffi --release` — 4/4 `native_constructors_test` passing
- `go test ./...` and `go test -race ./...` in `bindings/go` — unaffected, all passing
- Ran a throwaway Go program against the rebuilt archive: both `GenerateText` and `StreamText` now surface `invalid prompt_json: expected value at line 1 column 1` instead of the previous bare message
