### PR TITLE
docs: install & native library setup for all bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 [![Bindings](https://img.shields.io/badge/bindings-8-9cf.svg)](bindings/)
 [![crates.io](https://img.shields.io/crates/v/aimux-core)](https://crates.io/crates/aimux-core)
 [![npm](https://img.shields.io/npm/v/@arcships/aimux)](https://www.npmjs.com/package/@arcships/aimux)
+[![PyPI](https://img.shields.io/pypi/v/arcships-aimux)](https://pypi.org/project/arcships-aimux/)
+[![Go Reference](https://pkg.go.dev/badge/github.com/arcships/aimux/bindings/go.svg)](https://pkg.go.dev/github.com/arcships/aimux/bindings/go)
+[![GitHub Release](https://img.shields.io/github/v/release/arcships/aimux)](https://github.com/arcships/aimux/releases)
+[![Maven Central](https://img.shields.io/maven-central/v/io.aimux/aimux-java)](https://central.sonatype.com/artifact/io.aimux/aimux-java)
 
 aimux is a Rust implementation of a unified LLM provider access layer. It
 collapses the HTTP APIs of every AI provider into a single

--- a/README.md
+++ b/README.md
@@ -215,16 +215,16 @@ Full list: [rfc/0004-provider-inventory.md](rfc/0004-provider-inventory.md).
 
 aimux ships 8 bindings that share the same Rust core:
 
-| Binding | Path | Tool | Package | Directory |
-|---------|------|------|---------|-----------|
-| **Node.js** | native | napi-rs v3 | `@arcships/aimux` on [npm](https://www.npmjs.com/package/@arcships/aimux) | [bindings/node/](bindings/node/) |
-| **Python** | native | PyO3 + maturin | `arcships-aimux` on PyPI (pending) | [bindings/python/](bindings/python/) |
-| **Swift** | C ABI | Swift Package | SPM (pending) | [bindings/swift/](bindings/swift/) |
-| **Kotlin** | C ABI | JNA | `io.aimux:aimux-kotlin` on Maven Central (pending) | [bindings/kotlin/](bindings/kotlin/) |
-| **Flutter** | C ABI | dart:ffi | pub.dev (pending) | [bindings/flutter/](bindings/flutter/) |
-| **Go** | C ABI | cgo (static link, single binary) | GitHub Release `.a` | [bindings/go/](bindings/go/) |
-| **Java** | C ABI | JNA | `io.aimux:aimux-java` on Maven Central (pending) | [bindings/java/](bindings/java/) |
-| **C / C++** | C ABI | direct link | GitHub Release shared libs | [bindings/c/](bindings/c/) |
+| Binding | Path | Tool | Get it | Native library |
+|---------|------|------|--------|---------------|
+| **Node.js** | native | napi-rs v3 | `npm install @arcships/aimux` — [npm](https://www.npmjs.com/package/@arcships/aimux) | bundled in the package, nothing to do |
+| **Python** | native | PyO3 + maturin | `pip install arcships-aimux` — [PyPI](https://pypi.org/project/arcships-aimux/) | bundled in the wheel, nothing to do |
+| **Go** | C ABI | cgo (static link) | `go get github.com/arcships/aimux/bindings/go` then `go generate` | auto-downloaded `.a` from [GitHub Releases](https://github.com/arcships/aimux/releases) |
+| **Swift** | C ABI | SPM | SPM: `https://github.com/arcships/aimux` (`from: "0.2.0"`) | `libaimux_ffi.dylib` — see [guide](docs/api/swift.md#install) |
+| **Kotlin** | C ABI | JNA | `io.aimux:aimux-kotlin` — Maven Central (publishing) | `libaimux_ffi.so/.dylib` or `aimux_ffi.dll` on the JNA search path — see [guide](docs/api/kotlin.md#install) |
+| **Java** | C ABI | JNA | `io.aimux:aimux-java` — Maven Central (publishing) | same as Kotlin — see [guide](docs/api/java.md#install) |
+| **Flutter** | C ABI | dart:ffi | pub.dev (pending) | platform library, see [guide](docs/api/flutter.md#install) |
+| **C / C++** | C ABI | direct link | `.so`/`.dylib`/`.dll` + `aimux-ffi.h` from [GitHub Releases](https://github.com/arcships/aimux/releases) | link against it — see [guide](docs/api/c.md#install) |
 
 See [bindings/README.md](bindings/README.md) and the [API docs](docs/API.md).
 

--- a/docs/api/c.md
+++ b/docs/api/c.md
@@ -5,6 +5,19 @@
 Shared reference — feature descriptions, factory functions, and the coverage
 matrix — lives in the [API overview](../API.md).
 
+## Install
+
+Get `aimux-ffi.h` + the platform shared library from
+[GitHub Releases](https://github.com/arcships/aimux/releases)
+(`libaimux_ffi-linux-x64.so` / `libaimux_ffi-macos-arm64.dylib` /
+`aimux_ffi-windows-x64.dll`), then link against it:
+
+```bash
+gcc -o example example.c -L. -laimux_ffi -lpthread -ldl -lm   # Linux
+```
+
+Header: [aimux-ffi.h](../../aimux-ffi/aimux-ffi.h).
+
 ## Quick Start
 
 ```c

--- a/docs/api/flutter.md
+++ b/docs/api/flutter.md
@@ -4,6 +4,20 @@
 
 Flutter/Dart wraps the Rust core through the `aimux-ffi` C ABI (via `dart:ffi`).
 
+## Install
+
+pub.dev (pending). Until published, depend on the path:
+
+```yaml
+dependencies:
+  aimux:
+    path: bindings/flutter
+```
+
+The binding loads the platform library at runtime
+(`libaimux_ffi.so` / `libaimux_ffi.dylib` / `aimux_ffi.dll`) — ship it with
+your app or place it where the loader can find it.
+
 ## Quick Start
 
 ```dart

--- a/docs/api/go.md
+++ b/docs/api/go.md
@@ -10,6 +10,17 @@ for the design.
 Shared reference — parameter tables, result shapes, factory functions, and the
 feature coverage matrix — lives in the [API overview](../API.md).
 
+## Install
+
+```bash
+go get github.com/arcships/aimux/bindings/go
+go generate github.com/arcships/aimux/bindings/go   # downloads libaimux_ffi.a for your platform
+go build ./...
+```
+
+Details (version pinning, unsupported platforms):
+[bindings/go/README.md](../../bindings/go/README.md).
+
 ## Quick Start
 
 ```go

--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -3,9 +3,22 @@
 > Unified LLM service access layer — one API to access 325 AI providers
 
 The Java binding goes through the `aimux-ffi` C ABI via JNA — no native
-toolchain is needed at build time, and the native library ships as per-platform
-classifier JARs. Artifact: `io.aimux:aimux-java:0.2.0`, Java 8+ (compiled with
-`--release 8`). See [RFC-0013](../../rfc/0013-java-bindings.md) for the design.
+toolchain is needed at build time. Artifact: `io.aimux:aimux-java:0.2.0`,
+Java 8+ (compiled with `--release 8`). See [RFC-0013](../../rfc/0013-java-bindings.md)
+for the design.
+
+## Install
+
+Maven Central (publishing):
+
+```groovy
+implementation("io.aimux:aimux-java:0.2.0")
+```
+
+JNA loads `aimux_ffi` by name — provide the native library
+(`libaimux_ffi.so` / `libaimux_ffi.dylib` / `aimux_ffi.dll`) from
+[GitHub Releases](https://github.com/arcships/aimux/releases) on the JNA search
+path (`-Djava.library.path=...` or `LD_LIBRARY_PATH`).
 
 Shared reference — parameter tables, result shapes, factory functions, and the
 feature coverage matrix — lives in the [API overview](../API.md).

--- a/docs/api/kotlin.md
+++ b/docs/api/kotlin.md
@@ -4,6 +4,19 @@
 
 Kotlin wraps the Rust core through the `aimux-ffi` C ABI (via JNA).
 
+## Install
+
+Maven Central (publishing):
+
+```kotlin
+implementation("io.aimux:aimux-kotlin:0.2.0")
+```
+
+JNA loads `aimux_ffi` by name — provide the native library
+(`libaimux_ffi.so` on Linux, `libaimux_ffi.dylib` on macOS, `aimux_ffi.dll` on
+Windows) from [GitHub Releases](https://github.com/arcships/aimux/releases) on
+the JNA search path: `java.library.path`, `LD_LIBRARY_PATH`, or next to the JAR.
+
 ## Quick Start
 
 ```kotlin

--- a/docs/api/swift.md
+++ b/docs/api/swift.md
@@ -5,6 +5,20 @@
 Swift wraps the Rust core through the `aimux-ffi` C ABI (module `CAimuxFFI`),
 with ARC-managed model handles.
 
+## Install
+
+Add the package via SPM (the git tag is the version):
+
+```swift
+.package(url: "https://github.com/arcships/aimux", from: "0.2.0"),
+.target(name: "Aimux", dependencies: ["Aimux"])
+```
+
+The binding loads `libaimux_ffi.dylib` at runtime — make it available via
+pkg-config (`aimux-ffi.pc`) or put the prebuilt library from
+[GitHub Releases](https://github.com/arcships/aimux/releases) on the loader
+path (`DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH`).
+
 ## Quick Start
 
 ```swift


### PR DESCRIPTION
Adds an Install section to the five C-ABI language guides (Swift/Kotlin/Java/Flutter/C) plus Go, and updates the top-level binding table with where each package/library comes from and how to initialize the native library (JNA search path, pkg-config, loader path, go generate). Also fixes the stale 'classifier JARs' claim in the Java guide.