### PR TITLE
feat(codex): OpenAI Codex provider (RFC-0018) + session affinity docs (RFC-0019)

### DIFF
--- a/aimux-core/bindings/AiMuxError.ts
+++ b/aimux-core/bindings/AiMuxError.ts
@@ -3,4 +3,4 @@
 /**
  * Unified error type for all aimux operations.
  */
-export type AiMuxError = { "Provider": string } | { "Http": string } | { "Json": string } | { "Stream": string } | { "Tool": string } | { "InvalidArgument": string } | { "InvalidPrompt": string } | { "RateLimited": { retry_after_ms: bigint, } } | { "Auth": string } | { "ModelNotFound": string } | { "Unsupported": string } | { "NoSuchModel": string } | { "UnknownProvider": string } | { "ApiCall": string } | { "Timeout": string } | "Aborted" | { "Other": string };
+export type AiMuxError = { "Provider": string } | { "Http": string } | { "Json": string } | { "Stream": string } | { "Tool": string } | { "InvalidArgument": string } | { "InvalidPrompt": string } | { "RateLimited": { retry_after_ms: bigint, } } | { "Auth": string } | { "TokenExpired": string } | { "ModelNotFound": string } | { "Unsupported": string } | { "NoSuchModel": string } | { "UnknownProvider": string } | { "ApiCall": string } | { "Timeout": string } | "Aborted" | { "Other": string };

--- a/aimux-core/src/error.rs
+++ b/aimux-core/src/error.rs
@@ -35,6 +35,13 @@ pub enum AiMuxError {
     #[error("authentication failed: {0}")]
     Auth(String),
 
+    /// The access token has expired (or was invalidated) and must be refreshed
+    /// by the caller. RFC-0018 subscription mode: the library maps a 401 from
+    /// the Codex subscription endpoint to this variant; the integrator
+    /// orchestrates `codex_refresh` + retry.
+    #[error("token expired: {0}")]
+    TokenExpired(String),
+
     #[error("model not found: {0}")]
     ModelNotFound(String),
 
@@ -104,6 +111,7 @@ impl AiMuxError {
             AiMuxError::InvalidPrompt(_) => "InvalidPrompt",
             AiMuxError::RateLimited { .. } => "RateLimited",
             AiMuxError::Auth(_) => "Auth",
+            AiMuxError::TokenExpired(_) => "TokenExpired",
             AiMuxError::ModelNotFound(_) => "ModelNotFound",
             AiMuxError::Unsupported(_) => "Unsupported",
             AiMuxError::NoSuchModel(_) => "NoSuchModel",

--- a/aimux-ffi/aimux-ffi.h
+++ b/aimux-ffi/aimux-ffi.h
@@ -273,6 +273,14 @@ uint64_t aimux_tavily_search_new(const char *api_key, const char *model_id);
 uint64_t aimux_tavily_search_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_search(uint64_t handle, const char *opts_json);
 
+/* Codex (RFC-0018) */
+
+/* Refresh a Codex subscription access token (stateless OAuth helper).
+   Returns JSON {"access_token","refresh_token","expires_in_secs"} or error
+   JSON; caller frees with aimux_free_string. Caller owns token persistence
+   and the 401 -> refresh -> retry orchestration. */
+char *aimux_codex_refresh(const char *refresh_token, const char *client_id);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -1423,3 +1423,30 @@ pub extern "C" fn aimux_search(handle: u64, opts_json: *const c_char) -> *mut c_
         };
     run_and_serialize("search", async move { model.do_search(&opts).await })
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C ABI: Codex subscription helper (RFC-0018 §3.2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Refresh a Codex subscription access token (RFC-0018 §3.2).
+///
+/// Stateless: performs one OAuth `refresh_token` grant against
+/// `auth.openai.com/oauth/token`. Returns
+/// `{"access_token","refresh_token","expires_in_secs"}` JSON on success, or
+/// the standard error JSON (caller must free with `aimux_free_string`).
+/// The caller owns token persistence and the 401 → refresh → retry
+/// orchestration — the library never stores credentials.
+#[unsafe(no_mangle)]
+pub extern "C" fn aimux_codex_refresh(
+    refresh_token: *const c_char,
+    client_id: *const c_char,
+) -> *mut c_char {
+    let (Some(refresh_token), Some(client_id)) =
+        (cstr_to_string(refresh_token), cstr_to_string(client_id))
+    else {
+        return error_json_raw("invalid arguments");
+    };
+    run_and_serialize("codex_refresh", async move {
+        aimux_providers::codex_refresh(&refresh_token, &client_id).await
+    })
+}

--- a/aimux-providers/src/codex.rs
+++ b/aimux-providers/src/codex.rs
@@ -1,0 +1,469 @@
+//! Codex provider (RFC-0018) — OpenAI Codex models over the Responses API.
+//!
+//! Codex models (`gpt-5.2-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`,
+//! `gpt-5-codex`, …) are available **only** through the Responses API
+//! (verified 2026-08-03, RFC-0018 §2 V1).
+//!
+//! Two access modes ([`CodexMode`]):
+//!
+//! - **ApiKey** (default): `https://api.openai.com/v1/responses` — the
+//!   official, documented, usage-based channel. Recommended for CI/automation.
+//! - **Subscription**: `https://chatgpt.com/backend-api/codex/responses` —
+//!   the ChatGPT-subscription channel (single personal account, per OpenAI
+//!   ToU). Undocumented endpoint — **best-effort, no SLA**. Mirrors the
+//!   official Codex client: **always streams** (`stream: true`, `store: false`).
+//!
+//! OAuth is *not* the library's job (RFC-0018 §3.2 responsibility split): the
+//! integrator performs the device-code login, persists tokens, and orchestrates
+//! refresh. The library exposes [`codex_refresh`] as a stateless protocol
+//! helper and maps subscription-channel 401 responses to
+//! [`AiMuxError::TokenExpired`] so the integrator can refresh and retry.
+//!
+//! Scope boundaries (RFC-0018): no account pools, no quota rotation, no
+//! reselling — single account, single user.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use aimux_core::error::AiMuxError;
+use aimux_core::language_model::LanguageModel;
+use aimux_core::options::CallOptions;
+use aimux_core::provider::Provider;
+use aimux_core::result::{GenerateResult, StreamResult};
+use aimux_core::types::Warning;
+
+use aimux_provider_utils::response::DEFAULT_ERROR_STRUCTURE;
+use aimux_provider_utils::{
+    HttpBody, HttpMethod, HttpRequest, RetryConfig, send, send_stream_timed,
+};
+use aimux_stream::SseStream;
+
+use crate::openai::responses::responses_convert::{
+    build_header_list, build_responses_event_stream, build_responses_generate_result,
+};
+use crate::openai::responses::{OpenAIResponsesModel, build_responses_request_body};
+use crate::openai::{OpenAICompatProfile, OpenAIConfig};
+
+/// Default API-key base URL (official OpenAI Responses endpoint).
+pub const CODEX_API_BASE_URL: &str = "https://api.openai.com/v1";
+/// Default subscription base URL (undocumented ChatGPT backend endpoint).
+pub const CODEX_SUBSCRIPTION_BASE_URL: &str = "https://chatgpt.com/backend-api";
+/// Environment variable read by [`CodexConfig::from_env`].
+pub const CODEX_API_KEY_ENV_VAR: &str = "CODEX_API_KEY";
+/// OAuth token endpoint used by [`codex_refresh`] (RFC-0018 §2 V3).
+pub const CODEX_OAUTH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+
+/// Access mode for the Codex provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexMode {
+    /// Official API-key channel (`api.openai.com`), usage-based.
+    ApiKey,
+    /// ChatGPT-subscription channel (`chatgpt.com/backend-api`), single
+    /// personal account; always streams.
+    Subscription,
+}
+
+/// Configuration for the Codex provider.
+#[derive(Debug, Clone)]
+pub struct CodexConfig {
+    openai: OpenAIConfig,
+    mode: CodexMode,
+    /// Subscription mode: `ChatGPT-Account-Id` header value (optional).
+    chatgpt_account_id: Option<String>,
+    /// Subscription mode: `Originator` header value (client identifier;
+    /// reference clients use e.g. `"opencode"` / `"codex_cli_rs"`).
+    originator: String,
+}
+
+impl CodexConfig {
+    /// API-key mode with the official base URL.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            openai: OpenAIConfig::new(api_key)
+                .with_base_url(CODEX_API_BASE_URL)
+                .with_provider("codex")
+                .with_profile(OpenAICompatProfile::full()),
+            mode: CodexMode::ApiKey,
+            chatgpt_account_id: None,
+            originator: "aimux".to_string(),
+        }
+    }
+
+    /// Subscription mode with the ChatGPT backend base URL.
+    ///
+    /// `account_token` is the access token minted by the integrator's OAuth
+    /// device-code flow — the library never performs login, persists tokens,
+    /// or refreshes automatically (RFC-0018 §3.2).
+    pub fn subscription(account_token: impl Into<String>) -> Self {
+        Self {
+            openai: OpenAIConfig::new(account_token)
+                .with_base_url(CODEX_SUBSCRIPTION_BASE_URL)
+                .with_provider("codex")
+                .with_profile(OpenAICompatProfile::full()),
+            mode: CodexMode::Subscription,
+            chatgpt_account_id: None,
+            originator: "aimux".to_string(),
+        }
+    }
+
+    /// API-key mode reading `CODEX_API_KEY` from the environment.
+    pub fn from_env() -> Result<Self, AiMuxError> {
+        let key = aimux_provider_utils::load_api_key(None, CODEX_API_KEY_ENV_VAR, "Codex")?;
+        Ok(Self::new(key))
+    }
+
+    /// Override the base URL (tests / self-hosted endpoints).
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.openai = self.openai.with_base_url(url);
+        self
+    }
+
+    /// Subscription mode: set the `ChatGPT-Account-Id` header.
+    pub fn with_chatgpt_account_id(mut self, id: impl Into<String>) -> Self {
+        self.chatgpt_account_id = Some(id.into());
+        self
+    }
+
+    /// Subscription mode: override the `Originator` header (default `"aimux"`).
+    pub fn with_originator(mut self, originator: impl Into<String>) -> Self {
+        self.originator = originator.into();
+        self
+    }
+
+    /// Override the retry configuration.
+    pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
+        self.openai = self.openai.with_retry_config(config);
+        self
+    }
+
+    /// Extra headers merged into every request (user-supplied values win over
+    /// the subscription-mode defaults).
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.openai = self.openai.with_headers(headers);
+        self
+    }
+}
+
+/// Codex provider — creates [`CodexModel`] instances.
+pub struct CodexProvider {
+    config: CodexConfig,
+}
+
+impl CodexProvider {
+    pub fn new(config: CodexConfig) -> Self {
+        Self { config }
+    }
+
+    /// Create a model instance for the given Codex model id
+    /// (e.g. `"gpt-5.2-codex"`).
+    pub fn model(&self, model_id: &str) -> CodexModel {
+        CodexModel {
+            model_id: model_id.to_string(),
+            config: self.config.clone(),
+        }
+    }
+}
+
+impl Provider for CodexProvider {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    fn language_model(&self, model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
+        Ok(Box::new(self.model(model_id)))
+    }
+}
+
+/// A Codex language model over the Responses API.
+#[derive(Debug, Clone)]
+pub struct CodexModel {
+    model_id: String,
+    config: CodexConfig,
+}
+
+impl CodexModel {
+    fn inner(&self) -> OpenAIResponsesModel {
+        OpenAIResponsesModel::new(self.model_id.clone(), self.config.openai.clone())
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/responses", self.config.openai.base_url)
+    }
+
+    /// Subscription mode: fold the channel headers (`Originator`,
+    /// `ChatGPT-Account-Id`) into the per-call options. User-supplied header
+    /// values win (`entry().or_insert`).
+    fn subscription_options(&self, options: &CallOptions) -> CallOptions {
+        let mut opts = options.clone();
+        let mut headers = opts.headers.take().unwrap_or_default();
+        headers
+            .entry("Originator".to_string())
+            .or_insert_with(|| self.config.originator.clone());
+        if let Some(id) = &self.config.chatgpt_account_id {
+            headers
+                .entry("ChatGPT-Account-Id".to_string())
+                .or_insert_with(|| id.clone());
+        }
+        opts.headers = Some(headers);
+        opts
+    }
+
+    /// Build the request body; the subscription channel always streams and
+    /// never stores (mirrors the official Codex client).
+    fn body(
+        &self,
+        options: &CallOptions,
+        stream: bool,
+    ) -> Result<(Value, Vec<Warning>), AiMuxError> {
+        let mut result = build_responses_request_body(&self.model_id, options, stream);
+        if self.config.mode == CodexMode::Subscription {
+            result.body["store"] = Value::Bool(false);
+        }
+        Ok((result.body, result.warnings))
+    }
+
+    /// Map a subscription-channel authentication failure to
+    /// [`AiMuxError::TokenExpired`] so the integrator can refresh the access
+    /// token and retry (RFC-0018 §3.2). The only credential on the
+    /// subscription channel is the account token, so any `Auth` error (401
+    /// from the endpoint) means the token is invalid/expired.
+    fn map_subscription_401(&self, error: AiMuxError) -> AiMuxError {
+        match error {
+            AiMuxError::Auth(message) => AiMuxError::TokenExpired(message),
+            other => other,
+        }
+    }
+
+    /// Subscription `do_generate`: the endpoint only accepts streaming, so
+    /// request with `stream: true` and assemble the final result from the
+    /// terminal `response.completed` / `response.incomplete` event (the
+    /// official client always streams; non-streaming requests error).
+    async fn subscription_generate(
+        &self,
+        options: &CallOptions,
+    ) -> Result<GenerateResult, AiMuxError> {
+        let opts = self.subscription_options(options);
+        let headers = self.inner().build_headers(opts.headers.as_ref());
+        let (body, warnings) = self.body(&opts, true)?;
+
+        let resp = send_stream_timed(
+            HttpRequest {
+                method: HttpMethod::Post,
+                url: self.endpoint(),
+                headers: build_header_list(&headers),
+                body: HttpBody::Json(body.clone()),
+                abort_signal: opts.abort_signal.clone(),
+            },
+            self.config.openai.retry_config,
+            &DEFAULT_ERROR_STRUCTURE,
+            opts.timeout.map(Into::into),
+        )
+        .await
+        .map_err(|e| self.map_subscription_401(e))?;
+
+        let response_headers = resp.headers;
+        let mut sse = SseStream::new(resp.body);
+        let mut completed: Option<Value> = None;
+        let mut failure: Option<AiMuxError> = None;
+
+        while let Some(event) = sse.next().await {
+            match event {
+                Ok(ev) => {
+                    let data: Value = match serde_json::from_str(&ev.data) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            failure = Some(AiMuxError::Json(e.to_string()));
+                            break;
+                        }
+                    };
+                    // The endpoint emits `data:`-only SSE frames — the event
+                    // type lives in the JSON payload, not the SSE event field.
+                    let etype = data.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    match etype {
+                        "response.completed" | "response.incomplete" => {
+                            // The completed event nests the full response
+                            // object under `response` — the generate-result
+                            // parser expects the response object itself.
+                            completed = Some(data.get("response").cloned().unwrap_or(data));
+                            break;
+                        }
+                        "response.failed" | "error" => {
+                            let err_obj = data
+                                .get("error")
+                                .or_else(|| data.get("response").and_then(|r| r.get("error")));
+                            let message = err_obj
+                                .and_then(|e| e.get("message"))
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("subscription response failed");
+                            failure = Some(AiMuxError::Provider(message.to_string()));
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                Err(e) => {
+                    failure = Some(AiMuxError::Stream(e.to_string()));
+                    break;
+                }
+            }
+        }
+
+        match completed {
+            Some(data) => build_responses_generate_result(
+                &data,
+                warnings,
+                "openai".to_string(),
+                body,
+                response_headers,
+            ),
+            None => Err(failure.unwrap_or_else(|| {
+                AiMuxError::Stream(
+                    "subscription stream ended without response.completed".to_string(),
+                )
+            })),
+        }
+    }
+
+    /// Subscription `do_stream`: always streams with `store: false`.
+    async fn subscription_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
+        let opts = self.subscription_options(options);
+        let headers = self.inner().build_headers(opts.headers.as_ref());
+        let (body, warnings) = self.body(&opts, true)?;
+
+        let resp = send_stream_timed(
+            HttpRequest {
+                method: HttpMethod::Post,
+                url: self.endpoint(),
+                headers: build_header_list(&headers),
+                body: HttpBody::Json(body.clone()),
+                abort_signal: opts.abort_signal.clone(),
+            },
+            self.config.openai.retry_config,
+            &DEFAULT_ERROR_STRUCTURE,
+            opts.timeout.map(Into::into),
+        )
+        .await
+        .map_err(|e| self.map_subscription_401(e))?;
+
+        let response_headers = resp.headers;
+        let mut sse_stream = SseStream::new(resp.body);
+        let first_event = sse_stream.next().await;
+        let stream = build_responses_event_stream(
+            first_event,
+            sse_stream,
+            "openai".to_string(),
+            warnings,
+            false,
+        )?;
+
+        Ok(StreamResult {
+            stream,
+            request_body: Some(body),
+            response_headers: Some(response_headers),
+        })
+    }
+}
+
+#[async_trait]
+impl LanguageModel for CodexModel {
+    fn provider(&self) -> &str {
+        "codex"
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
+        match self.config.mode {
+            CodexMode::ApiKey => self.inner().do_generate(options).await,
+            CodexMode::Subscription => self.subscription_generate(options).await,
+        }
+    }
+
+    async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
+        match self.config.mode {
+            CodexMode::ApiKey => self.inner().do_stream(options).await,
+            CodexMode::Subscription => self.subscription_stream(options).await,
+        }
+    }
+}
+
+/// Tokens returned by the Codex OAuth token endpoint (RFC-0018 §2 V3).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexTokens {
+    /// Access token to pass as `CodexConfig::subscription(..)`.
+    pub access_token: String,
+    /// Rotated refresh token — **single use**; the caller must persist the
+    /// new value (the library never persists credentials).
+    pub refresh_token: Option<String>,
+    /// Access-token lifetime in seconds, if the endpoint reports it.
+    pub expires_in_secs: Option<u64>,
+}
+
+/// Stateless OAuth token-refresh helper for the Codex subscription channel
+/// (RFC-0018 §3.2). Performs one `POST auth.openai.com/oauth/token` call and
+/// returns the refreshed tokens — **no persistence, no orchestration**; the
+/// integrator owns storage and the 401 → refresh → retry loop.
+///
+/// Retries are disabled on purpose: refresh tokens rotate on first use, so
+/// retrying a refresh whose first response was lost would burn the rotation
+/// (`refresh_token_reused`).
+pub async fn codex_refresh(
+    refresh_token: &str,
+    client_id: &str,
+) -> Result<CodexTokens, AiMuxError> {
+    codex_refresh_at(refresh_token, client_id, CODEX_OAUTH_TOKEN_URL).await
+}
+
+/// [`codex_refresh`] with an explicit token endpoint (tests / self-hosted
+/// identity providers).
+pub async fn codex_refresh_at(
+    refresh_token: &str,
+    client_id: &str,
+    token_url: &str,
+) -> Result<CodexTokens, AiMuxError> {
+    let body = json!({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    });
+
+    let resp = send(
+        HttpRequest {
+            method: HttpMethod::Post,
+            url: token_url.to_string(),
+            headers: vec![("content-type".to_string(), "application/json".to_string())],
+            body: HttpBody::Json(body),
+            abort_signal: None,
+        },
+        RetryConfig {
+            max_retries: 0,
+            ..RetryConfig::default()
+        },
+        &DEFAULT_ERROR_STRUCTURE,
+    )
+    .await?;
+
+    let data: Value =
+        serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Json(e.to_string()))?;
+    let access_token = data
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            AiMuxError::Provider("oauth token response missing access_token".to_string())
+        })?;
+
+    Ok(CodexTokens {
+        access_token: access_token.to_string(),
+        refresh_token: data
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        expires_in_secs: data.get("expires_in").and_then(|v| v.as_u64()),
+    })
+}

--- a/aimux-providers/src/lib.rs
+++ b/aimux-providers/src/lib.rs
@@ -23,6 +23,7 @@ pub mod openai;
 pub mod vertex;
 pub mod voyage;
 
+pub mod codex;
 pub mod openrouter;
 pub mod xai;
 
@@ -100,6 +101,11 @@ pub use vertex::{
 };
 pub use voyage::{VoyageConfig, VoyageEmbeddingModel, VoyageProvider};
 
+pub use codex::{
+    CODEX_API_BASE_URL, CODEX_API_KEY_ENV_VAR, CODEX_OAUTH_TOKEN_URL, CODEX_SUBSCRIPTION_BASE_URL,
+    CodexConfig, CodexMode, CodexModel, CodexProvider, CodexTokens, codex_refresh,
+    codex_refresh_at,
+};
 pub use openrouter::{OpenRouterConfig, OpenRouterProvider};
 pub use xai::{XAIConfig, XAIProvider};
 

--- a/aimux-providers/src/openai/responses/mod.rs
+++ b/aimux-providers/src/openai/responses/mod.rs
@@ -67,7 +67,10 @@ impl OpenAIResponsesModel {
         Self { model_id, config }
     }
 
-    fn build_headers(&self, extra: Option<&HashMap<String, String>>) -> HashMap<String, String> {
+    pub(crate) fn build_headers(
+        &self,
+        extra: Option<&HashMap<String, String>>,
+    ) -> HashMap<String, String> {
         let mut headers = HashMap::new();
         headers.insert(
             "Authorization".to_string(),

--- a/aimux-providers/tests/codex_test.rs
+++ b/aimux-providers/tests/codex_test.rs
@@ -1,0 +1,515 @@
+//! Tests for the Codex provider (RFC-0018).
+//!
+//! Path A (API-key mode): non-streaming, streaming, and tool-call paths over
+//! the standard Responses endpoint, asserting delegation to the shared
+//! OpenAI Responses channel.
+//!
+//! Path B (subscription mode): forced `stream: true` / `store: false`,
+//! channel headers (`Originator` / `ChatGPT-Account-Id`), 401 →//! `AiMuxError::TokenExpired` mapping, and the stateless `codex_refresh`
+//! OAuth helper.
+
+use futures::StreamExt;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aimux_core::content::ContentPart;
+use aimux_core::error::AiMuxError;
+use aimux_core::language_model::LanguageModel;
+use aimux_core::language_model_message::{LanguageModelPrompt, LanguageModelPromptMessage};
+use aimux_core::message::Role;
+use aimux_core::options::{CallOptions, Tool, ToolChoice};
+use aimux_core::result::StreamResult;
+use aimux_core::stream_part::StreamPart;
+use aimux_core::tool::FunctionTool;
+use aimux_core::types::FinishReasonUnified;
+
+use aimux_providers::{CODEX_OAUTH_TOKEN_URL, CodexConfig, CodexProvider, codex_refresh_at};
+
+// helpers
+
+fn test_prompt() -> LanguageModelPrompt {
+    vec![LanguageModelPromptMessage {
+        role: Role::User,
+        content: vec![ContentPart::text("Hello")],
+        ..Default::default()
+    }]
+}
+
+fn default_options(prompt: LanguageModelPrompt) -> CallOptions {
+    CallOptions::new(prompt)
+}
+
+fn weather_tool() -> FunctionTool {
+    FunctionTool {
+        name: "weather".to_string(),
+        description: None,
+        input_schema: json!({
+            "type": "object",
+            "properties": { "location": { "type": "string" } },
+            "required": ["location"],
+            "additionalProperties": false,
+        }),
+        strict: None,
+        provider_options: None,
+        input_examples: None,
+    }
+}
+
+fn sse_event(json_str: &str) -> String {
+    format!("data: {}\n\n", json_str)
+}
+
+fn sse_body(events: &[&str]) -> String {
+    let mut body = String::new();
+    for event in events {
+        body.push_str(&sse_event(event));
+    }
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+/// Concatenate string SSE events (for events built at runtime).
+fn sse_body_strings(events: &[String]) -> String {
+    let mut body = String::new();
+    for event in events {
+        body.push_str(event);
+    }
+    body.push_str("data: [DONE]\n\n");
+    body
+}
+
+async fn mock_json_response(server: &MockServer, body: Value) {
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+async fn mock_sse_response(server: &MockServer, sse_body: &str) {
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_body.to_string()),
+        )
+        .mount(server)
+        .await;
+}
+
+async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
+    let mut parts = Vec::new();
+    let mut stream = result.stream;
+    while let Some(part) = stream.next().await {
+        match part {
+            Ok(p) => parts.push(p),
+            Err(e) => panic!("stream error: {:?}", e),
+        }
+    }
+    parts
+}
+
+async fn first_request(server: &MockServer) -> (Value, wiremock::http::HeaderMap) {
+    let requests = server
+        .received_requests()
+        .await
+        .expect("no requests received");
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("invalid JSON body");
+    (body, requests[0].headers.clone())
+}
+
+/// A basic text response body (single message output item).
+fn text_response_body() -> Value {
+    json!({
+        "id": "resp_codex_1",
+        "object": "response",
+        "created_at": 1741257730,
+        "status": "completed",
+        "error": null,
+        "incomplete_details": null,
+        "model": "gpt-5.2-codex",
+        "output": [
+            {
+                "id": "msg_1",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    { "type": "output_text", "text": "answer text", "annotations": [] }
+                ]
+            }
+        ],
+        "usage": {
+            "input_tokens": 345,
+            "input_tokens_details": { "cached_tokens": 234 },
+            "output_tokens": 538,
+            "output_tokens_details": { "reasoning_tokens": 123 }
+        },
+        "reasoning": { "effort": null, "summary": null, "context": "current_turn" }
+    })
+}
+
+/// The text streaming event sequence (RFC-0018 acceptance: streaming path).
+const TEXT_STREAM_EVENTS: &[&str] = &[
+    r#"{"type":"response.created","response":{"id":"resp_1","created_at":1741269019,"model":"gpt-5.2-codex"}}"#,
+    r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","status":"in_progress","role":"assistant","content":[]}}"#,
+    r#"{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":"Hello,"}"#,
+    r#"{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"delta":" World!"}"#,
+    r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[]}}"#,
+    r#"{"type":"response.completed","response":{"id":"resp_1","created_at":1741269019,"model":"gpt-5.2-codex","incomplete_details":null,"usage":{"input_tokens":543,"input_tokens_details":{"cached_tokens":234},"output_tokens":478,"output_tokens_details":{"reasoning_tokens":123}}}}"#,
+];
+
+/// The tool-call streaming event sequence.
+const TOOL_STREAM_EVENTS: &[&str] = &[
+    r#"{"type":"response.created","response":{"id":"resp_tc","created_at":1741362087,"model":"gpt-5.2-codex"}}"#,
+    r#"{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_added","name":"weather","arguments":"","status":"completed"}}"#,
+    r#"{"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"location\":"}"#,
+    r#"{"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"\"Rome\"}"}"#,
+    r#"{"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"arguments":"{\"location\":\"Rome\"}"}"#,
+    r#"{"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_done","name":"weather","arguments":"{\"location\":\"Rome\"}","status":"completed"}}"#,
+    r#"{"type":"response.completed","response":{"id":"resp_tc","created_at":1741362087,"model":"gpt-5.2-codex","incomplete_details":null,"usage":{"input_tokens":0,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0}}}}"#,
+];
+
+/// A `response.completed` event whose nested response object carries the full
+/// output —what the subscription channel emits at the end of a stream.
+fn subscription_completed_event() -> String {
+    sse_event(
+        &json!({ "type": "response.completed", "response": text_response_body() }).to_string(),
+    )
+}
+
+// Path A: API-key mode
+
+#[tokio::test]
+async fn api_key_generates_text() {
+    let server = MockServer::start().await;
+    mock_json_response(&server, text_response_body()).await;
+
+    let config = CodexConfig::new("test-key").with_base_url(server.uri());
+    let model = CodexProvider::new(config).model("gpt-5.2-codex");
+
+    let result = model
+        .do_generate(&default_options(test_prompt()))
+        .await
+        .expect("should succeed");
+
+    match &result.content[0] {
+        aimux_core::result::GenerateContent::Text { text, .. } => {
+            assert_eq!(text, "answer text")
+        }
+        other => panic!("expected Text, got {:?}", other),
+    }
+    assert_eq!(model.provider(), "codex");
+    assert_eq!(model.model_id(), "gpt-5.2-codex");
+
+    // Request shape: Responses endpoint, bearer auth, non-streaming body
+    // (the `stream` key is absent for non-streaming requests).
+    let (body, headers) = first_request(&server).await;
+    assert_eq!(body["model"], "gpt-5.2-codex");
+    assert_ne!(body["stream"], json!(true));
+    assert_eq!(body["input"][0]["role"], "user");
+    assert_eq!(
+        headers.get("authorization").map(|v| v.to_str().unwrap()),
+        Some("Bearer test-key")
+    );
+}
+
+#[tokio::test]
+async fn api_key_streams_text() {
+    let server = MockServer::start().await;
+    mock_sse_response(&server, &sse_body(TEXT_STREAM_EVENTS)).await;
+
+    let config = CodexConfig::new("test-key").with_base_url(server.uri());
+    let model = CodexProvider::new(config).model("gpt-5.2-codex");
+
+    let result = model
+        .do_stream(&default_options(test_prompt()))
+        .await
+        .expect("should succeed");
+    let parts = collect_stream(result).await;
+
+    assert_eq!(parts.len(), 7);
+    assert!(matches!(
+        &parts[0],
+        StreamPart::StreamStart { warnings } if warnings.is_empty()
+    ));
+    match &parts[2] {
+        StreamPart::TextStart { id, .. } => assert_eq!(id, "msg_1"),
+        other => panic!("expected TextStart, got {:?}", other),
+    }
+    match &parts[3] {
+        StreamPart::TextDelta { delta, .. } => assert_eq!(delta, "Hello,"),
+        other => panic!("expected TextDelta, got {:?}", other),
+    }
+    match &parts[6] {
+        StreamPart::Finish { usage, .. } => assert_eq!(usage.input_tokens.total, Some(543)),
+        other => panic!("expected Finish, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn api_key_streams_tool_calls() {
+    let server = MockServer::start().await;
+    mock_sse_response(&server, &sse_body(TOOL_STREAM_EVENTS)).await;
+
+    let config = CodexConfig::new("test-key").with_base_url(server.uri());
+    let model = CodexProvider::new(config).model("gpt-5.2-codex");
+
+    let options = CallOptions {
+        tools: Some(vec![Tool::from(weather_tool())]),
+        tool_choice: ToolChoice::Auto,
+        ..CallOptions::new(test_prompt())
+    };
+
+    let result = model.do_stream(&options).await.expect("should succeed");
+    let parts = collect_stream(result).await;
+
+    match &parts[6] {
+        StreamPart::ToolCall {
+            tool_call_id,
+            tool_name,
+            input,
+            ..
+        } => {
+            assert_eq!(tool_call_id, "call_done");
+            assert_eq!(tool_name, "weather");
+            assert_eq!(input["location"], "Rome");
+        }
+        other => panic!("expected ToolCall, got {:?}", other),
+    }
+    match &parts[7] {
+        StreamPart::Finish { finish_reason, .. } => {
+            assert_eq!(finish_reason.unified, FinishReasonUnified::ToolCalls);
+        }
+        other => panic!("expected Finish, got {:?}", other),
+    }
+}
+
+// Path B: subscription mode
+
+#[tokio::test]
+async fn subscription_generate_forces_stream_and_assembles_result() {
+    let server = MockServer::start().await;
+    // The subscription endpoint only streams: text deltas + a final
+    // response.completed carrying the full response object.
+    let events: Vec<String> = TEXT_STREAM_EVENTS[..5]
+        .iter()
+        .map(|e| sse_event(e))
+        .chain(std::iter::once(subscription_completed_event()))
+        .collect();
+    mock_sse_response(&server, &sse_body_strings(&events)).await;
+
+    let config = CodexConfig::subscription("account-token")
+        .with_base_url(server.uri())
+        .with_chatgpt_account_id("acct_123")
+        .with_originator("aimux-test");
+    let model = CodexProvider::new(config).model("gpt-5.2-codex");
+
+    let result = model
+        .do_generate(&default_options(test_prompt()))
+        .await
+        .expect("subscription generate should succeed");
+
+    match &result.content[0] {
+        aimux_core::result::GenerateContent::Text { text, .. } => {
+            assert_eq!(text, "answer text")
+        }
+        other => panic!("expected Text, got {:?}", other),
+    }
+
+    // The request must be a *streaming* request with store disabled.
+    let (body, headers) = first_request(&server).await;
+    assert_eq!(
+        body["stream"], true,
+        "subscription channel must always stream"
+    );
+    assert_eq!(
+        body["store"], false,
+        "subscription channel must never store"
+    );
+
+    // Channel headers: bearer account token + originator + account id.
+    assert_eq!(
+        headers.get("authorization").map(|v| v.to_str().unwrap()),
+        Some("Bearer account-token")
+    );
+    assert_eq!(
+        headers.get("originator").map(|v| v.to_str().unwrap()),
+        Some("aimux-test")
+    );
+    assert_eq!(
+        headers
+            .get("chatgpt-account-id")
+            .map(|v| v.to_str().unwrap()),
+        Some("acct_123")
+    );
+}
+
+#[tokio::test]
+async fn subscription_stream_forces_store_false() {
+    let server = MockServer::start().await;
+    mock_sse_response(&server, &sse_body(TEXT_STREAM_EVENTS)).await;
+
+    let config = CodexConfig::subscription("account-token").with_base_url(server.uri());
+    let model = CodexProvider::new(config).model("gpt-5.2-codex");
+
+    let result = model
+        .do_stream(&default_options(test_prompt()))
+        .await
+        .expect("should succeed");
+    let parts = collect_stream(result).await;
+    assert_eq!(parts.len(), 7);
+
+    let (body, _) = first_request(&server).await;
+    assert_eq!(body["stream"], true);
+    assert_eq!(body["store"], false);
+}
+
+#[tokio::test]
+async fn subscription_user_headers_win_over_defaults() {
+    let server = MockServer::start().await;
+    mock_sse_response(&server, &sse_body(TEXT_STREAM_EVENTS)).await;
+
+    let config = CodexConfig::subscription("account-token")
+        .with_base_url(server.uri())
+        .with_originator("library-default");
+    let model = CodexProvider::new(config).model("gpt-5.2-codex");
+
+    let options = CallOptions {
+        headers: Some(
+            [("Originator".to_string(), "user-value".to_string())]
+                .into_iter()
+                .collect(),
+        ),
+        ..CallOptions::new(test_prompt())
+    };
+
+    model.do_stream(&options).await.expect("should succeed");
+    let (_, headers) = first_request(&server).await;
+    assert_eq!(
+        headers.get("originator").map(|v| v.to_str().unwrap()),
+        Some("user-value"),
+        "explicit user headers must win over subscription defaults"
+    );
+}
+
+#[tokio::test]
+async fn subscription_401_maps_to_token_expired() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .set_body_json(json!({ "error": { "message": "invalid token" } })),
+        )
+        .mount(&server)
+        .await;
+
+    let config = CodexConfig::subscription("expired-token").with_base_url(server.uri());
+    let model = CodexProvider::new(config).model("gpt-5.2-codex");
+    let options = default_options(test_prompt());
+
+    let gen_err = model
+        .do_generate(&options)
+        .await
+        .expect_err("401 must fail");
+    assert!(
+        matches!(gen_err, AiMuxError::TokenExpired(_)),
+        "do_generate: expected TokenExpired, got {gen_err:?}"
+    );
+    assert!(!gen_err.is_retryable());
+
+    let stream_err = model.do_stream(&options).await.expect_err("401 must fail");
+    assert!(
+        matches!(stream_err, AiMuxError::TokenExpired(_)),
+        "do_stream: expected TokenExpired, got {stream_err:?}"
+    );
+}
+
+// codex_refresh (stateless OAuth helper)
+
+#[tokio::test]
+async fn codex_refresh_exchanges_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        })))
+        .mount(&server)
+        .await;
+
+    let tokens = codex_refresh_at(
+        "old-refresh",
+        "test-client",
+        &format!("{}/oauth/token", server.uri()),
+    )
+    .await
+    .expect("refresh should succeed");
+
+    assert_eq!(tokens.access_token, "new-access");
+    assert_eq!(tokens.refresh_token.as_deref(), Some("new-refresh"));
+    assert_eq!(tokens.expires_in_secs, Some(3600));
+
+    // Wire format: the refresh grant must carry the old refresh token.
+    let requests = server.received_requests().await.expect("request received");
+    let sent: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(sent["grant_type"], "refresh_token");
+    assert_eq!(sent["refresh_token"], "old-refresh");
+    assert_eq!(sent["client_id"], "test-client");
+
+    // The production helper targets the official endpoint.
+    assert_eq!(CODEX_OAUTH_TOKEN_URL, "https://auth.openai.com/oauth/token");
+}
+
+#[tokio::test]
+async fn codex_refresh_never_retries() {
+    // Refresh tokens rotate on first use: a retry of a lost response would
+    // burn the rotation (`refresh_token_reused`). Exactly one request even on
+    // a retryable-looking status.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(429))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let err = codex_refresh_at(
+        "old-refresh",
+        "test-client",
+        &format!("{}/oauth/token", server.uri()),
+    )
+    .await
+    .expect_err("429 must fail");
+    assert!(matches!(err, AiMuxError::RateLimited { .. }));
+}
+
+#[tokio::test]
+async fn codex_refresh_rejects_bad_grant() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "invalid_grant",
+            "error_description": "refresh token is invalid or expired",
+        })))
+        .mount(&server)
+        .await;
+
+    let err = codex_refresh_at(
+        "stale-refresh",
+        "test-client",
+        &format!("{}/oauth/token", server.uri()),
+    )
+    .await
+    .expect_err("400 must fail");
+    // parse_provider_error maps non-401/403 4xx to Provider (not retryable).
+    assert!(matches!(err, AiMuxError::Provider(_)));
+    assert!(!err.is_retryable());
+}

--- a/docs/codex-subscription-guide.md
+++ b/docs/codex-subscription-guide.md
@@ -1,0 +1,145 @@
+# Codex 订阅通道集成指南（RFC-0018）
+
+> **适用版本**: aimux 0.x（2026-08-03，[RFC-0018](../rfc/0018-codex-subscription.md)）
+> **核心分工**: **OAuth 由集成方做，aimux 库只做协议面**。
+> 库不执行设备码登录、不持久化 token、不自动刷新——它提供订阅模式的请求协议、
+> 一个无状态的 `codex_refresh` 纯函数，以及 401 → `AiMuxError::TokenExpired` 的类型化错误。
+
+---
+
+## 1. 两种模式怎么选
+
+| | API key 模式（Path A） | 订阅模式（Path B） |
+|---|---|---|
+| 端点 | `api.openai.com/v1/responses` | `chatgpt.com/backend-api/codex/responses` |
+| 凭据 | API key | ChatGPT 订阅账号的 OAuth access token |
+| 状态 | 官方、有文档、支持 CI/自动化 | **无文档、无 SLA、best-effort** |
+| 适用 | 生产/自动化（推荐） | 个人订阅账号自用 |
+| ToS 边界 | 正常使用 | **单账号自用**；账号池/多账号轮换/转售违反 OpenAI ToU |
+
+**默认用 API key 模式**。订阅模式仅当你确实持有 ChatGPT 订阅且愿意承担端点漂移风险时使用。
+
+## 2. API key 模式（Rust）
+
+```rust
+use aimux_providers::{CodexConfig, CodexProvider};
+
+let config = CodexConfig::new("sk-..."); // 或 CodexConfig::from_env()（读 CODEX_API_KEY）
+let model = CodexProvider::new(config).model("gpt-5.2-codex");
+// 之后就是标准 LanguageModel 用法：generate_text / stream_text 均可
+```
+
+可用模型（2026-08 核验）：`gpt-5.2-codex`、`gpt-5.1-codex`、`gpt-5.1-codex-mini`、`gpt-5-codex`。
+Codex 模型**只走 Responses API**——不要在 chat-completions 通道使用。
+
+## 3. 订阅模式：职责边界
+
+**集成方负责**（交互与状态）：
+1. 设备码登录 UI（展示 user_code，轮询取 token）
+2. token 持久化（`~/.codex/auth.json` 之类的自有存储）
+3. 刷新编排：收到 `TokenExpired` → 调 `codex_refresh` → 持久化新 refresh token → 重试
+
+**aimux 库负责**（协议面，全部无状态）：
+1. 订阅模式 provider：端点、`Originator`/`ChatGPT-Account-Id` 头、**强制 `stream:true` + `store:false`**（`generate_text` 内部自动走流式采集——该端点不接受非流式请求）
+2. `codex_refresh(refresh_token, client_id)`：一次 `/oauth/token` 调用，无持久化
+3. 401 → `AiMuxError::TokenExpired`（`error_type` = `"TokenExpired"`，不可重试）
+
+## 4. 集成方示例：登录 → 调用 → 刷新编排
+
+### 4.1 设备码登录（集成方实现，协议细节来自官方 Codex CLI 源码）
+
+```rust,ignore
+// 伪代码——设备码流程属于集成方，aimux 不提供
+async fn device_login(client_id: &str) -> Tokens {
+    // 1. 申请设备码
+    let resp = post("https://auth.openai.com/api/accounts/deviceauth/usercode",
+        json!({ "client_id": client_id })).await?;
+    // → { user_code, device_auth_id, interval }
+
+    // 2. 展示: 让用户到 https://auth.openai.com/codex/device 输入 user_code（15 分钟有效）
+    println!("Open https://chatgpt.com/codex/device and enter: {}", resp.user_code);
+
+    // 3. 轮询（按 interval）
+    loop {
+        let r = post("https://auth.openai.com/api/accounts/deviceauth/token",
+            json!({ "device_auth_id": resp.device_auth_id, "user_code": resp.user_code })).await?;
+        if let Some(auth_code) = r.authorization_code {
+            // 4. 用 authorization_code + PKCE code_verifier 换 token
+            return post("https://auth.openai.com/oauth/token", json!({
+                "grant_type": "authorization_code",
+                "code": auth_code,
+                "client_id": client_id,
+                "code_verifier": verifier,
+            })).await?; // → { access_token, refresh_token, expires_in }
+        }
+        sleep(resp.interval).await;
+    }
+}
+```
+
+> 细节：PKCE S256、scope=`openid profile email offline_access ...`、refresh token **一次性轮换**。
+> 完整协议以 `openai/codex` 官方源码（`login/src/device_code_auth.rs`）为准。
+
+### 4.2 调用（库）
+
+```rust
+use aimux_core::error::AiMuxError;
+use aimux_core::generate::{generate_text, GenerateTextOptions};
+use aimux_providers::{CodexConfig, CodexProvider};
+
+let config = CodexConfig::subscription(access_token) // OAuth 产物
+    .with_chatgpt_account_id("acct_...")            // 可选
+    .with_originator("my-client");                  // 可选，默认 "aimux"
+let model = CodexProvider::new(config).model("gpt-5.2-codex");
+
+let result = generate_text(model, "Hello", GenerateTextOptions::default()).await?;
+```
+
+### 4.3 刷新编排（集成方）
+
+```rust
+use aimux_providers::{codex_refresh, CodexConfig, CodexProvider};
+
+const CLIENT_ID: &str = "your-oauth-client-id";
+
+async fn call_with_refresh(access: &str, refresh: &str, refresh_store: &mut String) -> Result<(), AiMuxError> {
+    let model = CodexProvider::new(CodexConfig::subscription(access)).model("gpt-5.2-codex");
+    match generate_text(model, "Hello", Default::default()).await {
+        Ok(_) => Ok(()),
+        Err(AiMuxError::TokenExpired(_)) => {
+            // 1. 刷新（库的纯函数，无状态）
+            let tokens = codex_refresh(refresh, CLIENT_ID).await?;
+            // 2. 持久化轮换后的新 refresh token（一次性！）
+            if let Some(new_refresh) = &tokens.refresh_token {
+                *refresh_store = new_refresh.clone();
+            }
+            // 3. 用新 access token 重试一次
+            let model = CodexProvider::new(CodexConfig::subscription(tokens.access_token))
+                .model("gpt-5.2-codex");
+            generate_text(model, "Hello", Default::default()).await?;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+```
+
+### 4.4 C ABI（Swift/Kotlin/C/Go/...）
+
+```c
+// 刷新：返回 JSON 或错误 JSON，用完 aimux_free_string 释放
+char *json = aimux_codex_refresh("old-refresh", "client-id");
+// → {"access_token":"...","refresh_token":"...","expires_in_secs":3600}
+```
+
+错误判别：JSON 里的 `"error_type":"TokenExpired"`（`error.rs` 的 `error_type()`）——
+集成方据此触发刷新流程。`TokenExpired` 不可重试（`is_retryable() == false`），
+库不会在 401 上自动重试，刷新后由你重发请求。
+
+## 5. 注意事项（best-effort 边界）
+
+- 订阅端点**无公开文档**，协议细节以官方 Codex CLI 源码为唯一权威，可能随官方客户端演进而变
+- 该端点强制流式：库在订阅模式下**总是** `stream:true` + `store:false`，非流式请求会报错
+- 配额/冷却按订阅计划（5 小时窗口），**不做账号池**——多账号轮换违反 ToU
+- 订阅模式只适合个人自用；生产/CI 用 API key 模式
+- WS 变体、`x-codex-turn-state` 透传、`/responses/compact` 不在 v1 范围

--- a/docs/session-affinity-guide.md
+++ b/docs/session-affinity-guide.md
@@ -1,0 +1,139 @@
+# Session Affinity 集成指南
+
+> **适用版本**: aimux 0.x(2026-08-03 定稿,[RFC-0019](../rfc/0019-session-affinity.md))
+> **结论先行**: aimux **不预置、不自动注入**任何会话头——会话头是"你的网关"的属性,不是 provider 的属性。
+> 机制已存在(`headers` 参数),本文档告诉你**传什么、怎么传、何时别传**。
+
+---
+
+## 1. 一句话背景
+
+LLM 网关/上游普遍提供"会话亲和":同一会话的请求带上稳定标识,网关据此把请求路由到同一上游/实例,从而**命中提示缓存、降低延迟与成本**。aimux 是接入层,不做路由、不做账号池、不管理会话状态——只负责把你的标识**原样透传**。
+
+## 2. 支持矩阵(2026-08-03 调研)
+
+来源:reference/audit 全量扫描(22 项目命中)+ 官方文档核证。按**你面对的网关/上游**查表:
+
+| 你的上游/网关 | 会话标识 | 注入方式 | 语义 | 证据 |
+|---|---|---|---|---|
+| **OpenRouter** | `session_id`(body 顶层,≤256 字符)或 `x-session-id` 头,body 优先 | header 或 body | **粘性路由键**(默认按首条消息哈希识别会话;显式传则直接用);兜底 `prompt_cache_key`;按 账户×模型×会话 粒度跟踪 | [OpenRouter prompt-caching 指南](https://openrouter.ai/docs/guides/best-practices/prompt-caching) |
+| **Cloudflare Workers AI** | `x-session-affinity` | header | 路由到同一模型实例,提升前缀缓存命中 | [Workers AI prompt-caching](https://developers.cloudflare.com/workers-ai/features/prompt-caching/) |
+| **Anthropic 自托管**(dynamo/SGLang 等) | `x-claude-code-session-id` / `x-claude-code-agent-id` / `x-claude-code-parent-agent-id` | header | Claude Code harness → 自托管会话路由(子 agent KV 隔离);**对 Anthropic 托管 API 的缓存不参与** | [dynamo.md](../reference/audit/dynamo.md#L102-L107) |
+| **ChatGPT 订阅(Codex)** | `session_id`/`originator` 私有头 + `x-codex-turn-state`(服务端回传) | header | 私有约定、无文档;属 [RFC-0018](../rfc/0018-codex-subscription.md) 通道,只透传白名单头 | [plano.md](../reference/audit/plano.md#L88)、[uni-api.md](../reference/audit/uni-api.md#L57-L61) |
+| **Kimi / Z.AI** | `prompt_cache_key`(透传不生成) | header/body | 缓存标识;值由你的上游体系决定 | [opencodex.md](../reference/audit/opencodex.md)、[cc-switch.md](../reference/audit/cc-switch.md) |
+| **LiteLLM** | `x-litellm-session-id` / `x-litellm-trace-id` / `x-<vendor>-session-id` | header/body | 网关亲和/固定 deployment | [litellm.md](../reference/audit/litellm.md#L113-L120) |
+| **TokenHub** | `x-tokenhub-session-id` / `session-id` / `thread-id` | header | rendezvous 缓存亲和 | [TokenHub.md](../reference/audit/TokenHub.md#L113-L131) |
+| **llmgateway** | `x-session-id` → `prompt_cache_key` → `user`(解析优先级) | header/body | 钉 provider+region 保上游 prompt cache | [llmgateway.md](../reference/audit/llmgateway.md#L156-L160) |
+| **OpenAI 官方 API** | **无 session id** | — | 会话用 `previous_response_id`/`conversation.id`(与本文档无关) | OpenAI conversation-state 指南 |
+| 其他自建网关 | 看你的网关文档 | — | 无统一标准 | — |
+
+> ⚠️ **"支持 Responses API" ≠ "支持 session id"**。Responses 规范无 session id 概念;OpenRouter 的 Responses 实现 stateless,甚至 400 拒绝 `previous_response_id`。判据只能是网关自己的文档。
+
+## 3. 集成示例(各语言)
+
+### Rust —— `GenerateTextOptions.headers`
+
+```rust
+use aimux_providers::openai;
+use aimux_core::{generate::generate_text, options::GenerateTextOptions};
+use std::collections::HashMap;
+
+let model = openai("sk-...", "gpt-4o", None);
+
+// 会话标识:由你(集成方)持有——agent 循环里生成一次,复用整轮
+let session_id = "conv_abc123".to_string();
+
+let mut headers = HashMap::new();
+headers.insert("x-session-id".to_string(), session_id.clone());
+
+let result = generate_text(model, "你好", GenerateTextOptions {
+    headers: Some(headers),
+    ..Default::default()
+}).await?;
+```
+
+### Node —— 工厂级(所有请求)或调用级
+
+```ts
+import { openai, generateText } from 'aimux';
+
+// 工厂级:整个 provider 实例都带
+const model = openai('sk-...', 'gpt-4o', {
+  headers: JSON.stringify({ 'x-session-id': 'conv_abc123' }),
+});
+
+// 调用级:仅本次调用(推荐——会话是调用级概念)
+const result = await generateText(model, '你好', {
+  headers: JSON.stringify({ 'x-session-id': 'conv_abc123' }),
+});
+```
+
+### Python —— options 字典透传
+
+```python
+from aimux import openai, generate_text
+
+model = openai("sk-...", "gpt-4o")
+result = generate_text(model, "你好", {
+    "headers": {"x-session-id": "conv_abc123"},
+})
+```
+
+### FFI 语言(Swift/Kotlin/C/Go/Java/Flutter)
+
+headers 经 options JSON 透传,无额外代码:
+
+```jsonc
+// opts_json 里加一个键即可
+{ "headers": { "x-session-id": "conv_abc123" } }
+```
+
+## 4. 何时**别**传(安全规则)
+
+1. **opt-in**:只在你有真实会话标识时传;aimux 不会替你生成/默认注入
+2. **值校验**:≤256 字符、可打印 ASCII、无 CR/LF/NUL(非法值 → 400/431)
+3. **AWS SigV4 通道**(bedrock/vertex 等):**不要**加会话头——签名链不一致 → SignatureDoesNotMatch(官方 codex 客户端就是在签名前剔除 `session_id` 等头的)
+4. **私有后端**(ChatGPT 订阅等):只透传其放行的头(白名单)
+5. **严格网关**:LiteLLM 官方文档明言 "Some providers reject unknown headers"——目标网关不认识的头,别发
+6. **意外语义**:`x-session-id` 对 OpenRouter 是粘性路由键——传了就**真的会钉住路由**,值变长/变短会切换上游,请保持同一会话内稳定
+
+## 5. FAQ
+
+**Q: 默认给所有请求传一个 session id 会不会报错?**
+A: 大概率不会(HTTP 语义下未知头被忽略,RFC 9110;OpenCode 对全部 provider 每请求发送为实证),但非零风险:SigV4 签名链、严格白名单网关、私有后端三类场景可能真实报错;且对 OpenRouter 会触发真实行为变更(粘性钉住)。**正确做法:opt-in,只对你的网关支持的头传。**
+
+**Q: 为什么 aimux 不把会话头预置进 registry?**
+A: 会话头是"你的网关"的属性,不是 provider 的属性。同一个 OpenAI 兼容 provider,直连官方、走 OpenRouter、走自建网关,要传的头完全不同;而大多数自建网关根本不在 registry 里。预置会误导,且与集成方的部署强耦合——所以 aimux 交付文档,不交付预置数据。
+
+**Q: 我的上游是 OpenRouter,`session_id` 传 body 还是 header?**
+A: OpenRouter 两者都接受,body 顶层 `session_id` 优先于 `x-session-id` 头。aimux 的 `body_overrides` 可传 body 字段,`headers` 可传头;二选一即可。
+
+**Q: 会话 id 谁来生成?**
+A: 你。aimux 不做会话状态管理(生命周期由你持有);同一会话内保持值稳定即可获得粘性/缓存收益。
+
+## 6. 附:完整调研矩阵(22 项目)
+
+| 项目 | 会话头/字段 | 注入方式 | 机制 | 证据 |
+|---|---|---|---|---|
+| cline | `session_id` | body(json-body) | 缓存标识 | cline.md#L82-L85 |
+| pi | `x-session-affinity` | header | 前缀缓存折扣(Workers AI) | pi.md#L75-L79 |
+| llmgateway | `x-session-id`→`prompt_cache_key`→`user` | header/body | sticky 路由 | llmgateway.md#L156-L160 |
+| dynamo | `x-claude-code-session-id` 族 | header | 自托管 KV 隔离 | dynamo.md#L102-L107 |
+| claude-code-router | `sessionId` | 内部脚本 | 哈希分桶路由 | claude-code-router.md#L188-L191 |
+| TokenHub | `x-tokenhub-session-id`/`thread-id`/`prompt_cache_key` | header/字段 | rendezvous 亲和 | TokenHub.md#L113-L131 |
+| axonhub | `traceID` | 内部 | 渠道级 sticky | axonhub.md#L149-L157 |
+| plano | `X-Model-Affinity` | header | 路由结果缓存 | plano.md#L142-L147 |
+| uni-api | `Session_id`/`Originator` | header | 账号绑定(ChatGPT 订阅) | uni-api.md#L57-L61 |
+| opencodex | 白名单头(`authorization`/`chatgpt-account-id`/`beta`/`originator`/`session`);kimi/zai `prompt_cache_key` 透传 | header | 账号池亲和 | opencodex.md#L100-L104 |
+| cc-switch | 稳定 `prompt_cache_key` + `session_id` | body | 缓存标识+用量 | cc-switch.md#L157-L161 |
+| gemini-cli | `session_id`/`user_prompt_id` | body | 状态管理(Code Assist) | gemini-cli.md#L43-L44 |
+| ai.rs | `session_id`+`x-client-request-id`+`x-session-affinity`(Openai)/`x-session-id`(Openrouter) | header/body | 缓存标识,**opt-in 开关** | ai.rs.md#L88-L93 |
+| pydantic-ai | `openai_previous_response_id`/`openai_conversation_id` | body | 服务端会话复用(OpenAI) | pydantic-ai.md#L145-L150 |
+| litellm | `x-litellm-session-id`/`x-<vendor>-session-id` | header/body | deployment 亲和 | litellm.md#L113-L120 |
+| new-api | Channel Affinity 规则引擎 | 内部 | 渠道固定 | new-api.md#L110-L117 |
+| awaken | thread/run id | 内部 | HRW 路由 | awaken.md#L113-L119 |
+| codex(官方) | `x-codex-turn-state` | header | 官方粘性路由 | codex.md#L76-L81 |
+| opencode | `X-Session-Id` + `x-session-affinity`(全量发送) | header | 缓存标识(被忽略无害实证) | opencode#39913 |
+| claude-code-router / TokenHub / axonhub / awaken | 见上 | — | — | — |
+
+> 以上行号基于 2026-08-01 审计快照,后续提交可能偏移。

--- a/rfc/0018-codex-subscription.md
+++ b/rfc/0018-codex-subscription.md
@@ -1,6 +1,6 @@
 ﻿# RFC-0018: Codex 订阅通道 provider 集成评估
 
-> **Status**: PROPOSED (pending protocol verification)
+> **Status**: IMPLEMENTED (2026-08-03 核验→定案→实现完成:Path A + Path B + codex_refresh + C ABI,测试全绿)
 > **Date**: 2026-08-02
 > **Scope**: 评估并设计 Codex(OpenAI 编程模型/订阅通道)在 aimux 的集成路径。
 > 本 RFC 基于 104 项目参考审计的发现,先给出动机与现状,再列出**必须核验的协议事实**,
@@ -42,63 +42,100 @@ agent-of-empires、axonhub、CCSwitcher、cline、pi、Roo-Code、uni-api。
 
 ---
 
-## 2. 必须核验的协议事实(阻塞项)
+## 2. 协议事实核验结果(2026-08-03)
 
-按 [RFC-0006 §2.1](../rfc/0006-provider-development.md) 证据裁决顺序,核验以下事实:
+按 [RFC-0006 §2.1](0006-provider-development.md) 证据裁决顺序核验完毕。
+证据来源:OpenAI 官方文档(developers.openai.com / learn.chatgpt.com / openai.com)+
+`openai/codex` 官方源码(当日 main 分支稀疏克隆核验)+ 本地参考实现交叉验证。
 
-| # | 事实 | 来源 | 当前状态 |
-|---|---|---|---|
-| V1 | Codex 官方 API 是否存在 API key 模式(端点/模型 ID/定价) | OpenAI 官方文档 | 未核验 |
-| V2 | 订阅通道接入方式(端点、鉴权流程、条款) | OpenAI 官方文档/官方 SDK | 未核验 |
-| V3 | 订阅 OAuth 设备码流程细节(scope/刷新/失效) | 参考实现(pi/opencodex/codex) | 参考实现有,官方未确认 |
-| V4 | 协议形态(Responses API?WebSocket?) | 官方 + 参考实现 | 参考实现不一致,待确认 |
-| V5 | 流式与工具调用支持 | 官方 + 参考实现 | 待确认 |
+| # | 事实 | 核验结论 | 证据 | 可靠度 |
+|---|---|---|---|---|
+| V1 | Codex 官方 API(API key 模式)是否存在 | **存在且官方推荐**。Codex 模型**只走 Responses API**(端点 `https://api.openai.com/v1/responses`)。当前模型与定价:gpt-5.2-codex $1.75/$14(400K ctx)、gpt-5.1-codex $1.25/$10、gpt-5.1-codex-mini $0.25/$2、gpt-5-codex $1.25/$10。**"codex-1" 不是 API 模型 ID**——是 ChatGPT/Codex 云端内部模型名;API 侧 ID 为 gpt-5.x-codex 系列 | developers.openai.com/api/docs/models/gpt-5.2-codex 等 | 官方文档 ✅ |
+| V2 | 订阅通道接入方式与条款 | 订阅登录**是官方支持功能**(Codex CLI/IDE/桌面 "Sign in with ChatGPT for subscription access");但 `chatgpt.com/backend-api/codex/responses` **无任何公开文档**(仅官方客户端自用)。消费者 ToU 红线:禁止程序化提取输出、禁止绕过限流、**禁止共享账号凭据**——账号池/多账号轮换/转售踩线;单账号自用为官方允许边界 | learn.chatgpt.com/docs/auth;openai.com/policies/row-terms-of-use(2026-01-01 版) | 官方文档 ✅(端点无官方表述=第三方推断 ⚠️) |
+| V3 | 订阅 OAuth 设备码流程 | 官方流程(源码):issuer `auth.openai.com`;①`/api/accounts/deviceauth/usercode` → user_code/device_auth_id/interval;②用户输码(user_code 15 分钟过期);③轮询 `/api/accounts/deviceauth/token` → authorization_code + PKCE verifier;④`/oauth/token` grant_type=authorization_code 换 id/access/refresh token。scope=`openid profile email offline_access api.connectors.read api.connectors.invoke`,PKCE S256。**刷新**:`/oauth/token` grant_type=refresh_token,到期前 5 分钟窗口每 8 分钟自动检查;**refresh token 一次性轮换**(reused/expired/invalidated 均需重新登录)。凭据存 `~/.codex/auth.json` 或 keyring | openai/codex `login/src/device_code_auth.rs`、`login/src/auth/manager.rs`;learn.chatgpt.com/docs/auth | 官方源码 ✅(与 plano/uni-api 参考实现一致) |
+| V4 | 协议形态 | **Responses-over-HTTP**:订阅通道 `POST https://chatgpt.com/backend-api/codex/responses`(官方常量 `CHATGPT_CODEX_BASE_URL` + `/responses`)。**存在 WS 变体**(同路径 wss,官方 CLI 优先 WS、重试预算耗尽回退 HTTP)。另有 `/responses/compact`、`/backend-api/codex/models`。参考实现(opencodex/plano/uni-api)全部指向同一端点 | openai/codex `model-provider-info/src/lib.rs`、`core/src/client.rs` | 官方源码 ✅ |
+| V5 | 流式与工具调用 | 官方客户端**恒发 `stream:true` + `store:false`**;"非流式请求报错"无官方原文(plano 第三方记录),按"订阅模式仅支持流式"设计并容错。工具调用完整支持(Responses 工具事件流);**代码执行是客户端侧能力**(模型出工具调用,CLI 本地沙箱执行);订阅端另有 `x-codex-turn-state` 头做服务端同会话粘性路由 | openai/codex `core/src/client.rs`;本地 [plano.md](reference/audit/plano.md#L88) | 官方源码 ✅(非流式报错=第三方推断 ⚠️) |
 
-**核验完成后**更新本 RFC 的 §3/§4 并进入 review;若 V1 成立(有官方 API key 模式),
-建议实现路径改为"标准 Responses 薄封装 + 订阅通道降级为 backlog"。
+**核验结论**:V1 成立 → **路径 A(API key 薄封装)必做**,是默认通道;路径 B(订阅通道)做单账号自用形态。
 
 ---
 
-## 3. 设计草案(待核验后定稿)
+## 3. 设计(定案)
 
-### 3.1 路径 A:标准 API key 模式(若 V1 成立)
+### 3.1 路径 A:标准 API key 模式(默认通道,必做)
 
-- 走现有 `openai` provider 的 Responses API 通道(codex 模型 + API key)
-- 无需新架构;`OpenAICompatProfile`/`OpenAIResponsesModel` 复用
-- 工作量:小(模型 ID + 验证测试)
+- 走现有 OpenAI Responses 通道(codex 模型 + API key),`OpenAIResponsesModel` 复用
+- **实现形态(2026-08-03)**:新增原生模块 `aimux-providers/src/codex.rs`(对齐 openrouter.rs 模式),导出 `CodexConfig`/`CodexProvider`/`CodexModel` + `CODEX_API_KEY_ENV_VAR`(读 `CODEX_API_KEY`);**registry 条目不可行**——registry 只表达 OpenAI 兼容 chat-completions 通道(`provider()` 统一走 `OpenAIProvider.language_model`),而 Codex 模型只接受 Responses API
+- 模型表:gpt-5.2-codex / gpt-5.1-codex / gpt-5.1-codex-mini / gpt-5-codex(退役日期不硬编码)
+- 工作量:小(模块 + 模型 ID + 测试,已完成)
 
-### 3.2 路径 B:订阅通道(若 V2/V3 成立且条款允许)
+### 3.2 路径 B:订阅通道(可选模式,单账号自用)
 
-新增 `aimux-providers/src/codex/`:
+新增 `aimux-providers/src/codex/`(Subscription 模式):
 
 ```
 CodexConfig {
   mode: ApiKey | Subscription,
   // ApiKey 模式复用 OpenAIConfig 能力
   // Subscription 模式:
-  account_token: Option<String>,   // OAuth 产物
-  refresh_token: Option<String>,
+  account_token: Option<String>,   // 集成方 OAuth 产物(access token)
   base_url: String,                // 默认 https://chatgpt.com/backend-api
 }
 ```
 
-- **凭证管理**:OAuth 设备码(登录一次,存 refresh_token,自动刷新);
-  参考实现:pi(`openai-codex` OAuth)、opencodex(账号池 + cooldown/failover)
-- **协议**:Responses API 透传 + `ChatGPT-Account-Id`/`x-codex-turn-state` 头
-  (实现细节以 V4 核验结果为准)
-- **明确不做**:账号池/多账号负载均衡(网关系,见 [LEARNINGS](../reference/audit/LEARNINGS.md) 定位结论)
+**职责分离(2026-08-03 定案):OAuth 由集成方做,库只做协议面。**
+
+| 层 | 职责 | 形态 |
+|---|---|---|
+| 库(协议面,无状态) | 订阅模式 provider:端点/头/流式解析,**强制 `stream:true` + `store:false`**(generate_text 内部走流式采集 shim;非流式请求报错);`codex_refresh(refresh_token, client_id) -> Tokens` **纯函数**(一次 `/oauth/token` 调用,无持久化);401 → `AiMuxError::TokenExpired` 类型化错误,**不自动重试刷新** | Rust API + C ABI,8 语言可调 |
+| 集成方(交互与状态) | 设备码登录 UI(user_code 展示 → 轮询 → 取 token);token 持久化(库零明文落盘);刷新编排(收到 TokenExpired → 调 `codex_refresh` → 存新 token → 重试) | 参考示例脚本(库外) |
+
+**明确不做(ToS/定位红线)**:
+- 账号池/多账号负载均衡/配额轮换(opencodex pool、uni-api 多账号)——违反 ToU"禁止共享账号凭据/绕过限流"
+- 转售或对外暴露共享 API 面
+- v1 不做 WS 变体(记未来);不做 `x-codex-turn-state` 透传(服务端 opaque token,官方自述"对第三方网关无意义",记未来);不做 `/responses/compact`
+- 订阅端配额窗口/模型可用性不硬编码(随产品策略变动)
+
+**风险**:端点无文档、无 SLA,协议细节以官方 CLI 源码为唯一权威,随官方客户端演进而变——订阅模式标注"best-effort,非稳定承诺"。
 
 ---
 
 ## 4. 验收标准
 
-- [ ] V1-V5 核验记录附于本 RFC(官方文档 URL + 结论)
-- [ ] 核验结论决定路径 A 或 B,更新 §3 后 review
-- [ ] 实现后:cassette 测试覆盖非流式/流式/工具调用(复用 RFC-0003 测试方案)
-- [ ] 订阅模式凭证刷新有测试(401 → 刷新 → 重试)
+- [x] V1-V5 核验记录(本 RFC §2,官方文档 URL + 源码位置)
+- [x] 核验结论定案(2026-08-03):Path A 必做 + Path B 单账号自用(§3)
+- [x] Path A 实现:非流式/流式/工具调用测试覆盖(wiremock,复用 openai_responses_test.rs 模式的真实响应形状;真实 codex cassette 后续可补)
+- [x] 订阅模式:`codex_refresh`/`codex_refresh_at` 纯函数单测(wiremock mock `/oauth/token`);401 → `TokenExpired` 错误测试(do_generate + do_stream);强制流式 shim 测试(stream:true + store:false 断言)
+- [x] 集成方示例文档:[docs/codex-subscription-guide.md](../docs/codex-subscription-guide.md)(设备码登录 → 取 token → 调用 → 刷新编排 完整流程)
+- [x] C ABI:`aimux_codex_refresh` 导出 + 头文件声明(2026-08-03 追加)
 
-## 5. 参考资料
+## 5. 实施状态(2026-08-03)
+
+| 项 | 状态 | 位置 |
+|---|---|---|
+| `AiMuxError::TokenExpired` 变体 | ✅ | aimux-core/src/error.rs(error_type="TokenExpired",不可重试) |
+| `codex.rs` 模块(ApiKey + Subscription) | ✅ | aimux-providers/src/codex.rs |
+| 订阅强制流式 shim(generate 采集 response.completed) | ✅ | codex.rs `subscription_generate` |
+| 订阅 401 → TokenExpired 映射 | ✅ | codex.rs `map_subscription_401`(订阅模式任何 `Auth` 错误即 token 问题) |
+| `codex_refresh` / `codex_refresh_at`(OAuth 刷新纯函数,零重试) | ✅ | codex.rs(重试禁用理由:refresh token 一次性轮换) |
+| C ABI `aimux_codex_refresh` | ✅ | aimux-ffi/src/lib.rs + aimux-ffi.h |
+| 测试 10 项 | ✅ | aimux-providers/tests/codex_test.rs(全绿) |
+| Node/Python 绑定工厂(codex 构造入口) | ⏳ 后续 | 绑定层按需补 `codex()` 工厂(与 openai/anthropic 同模式) |
+
+**实现偏差记录**:§3.1 原计划"registry 条目",实现改为原生模块(理由见 §3.1);订阅端点无文档,
+`Originator` 默认值 `"aimux"`、头语义以参考实现(plano/uni-api/opencodex)为准,best-effort。
+
+## 6. 参考资料
 
 - 审计:`reference/audit/{pi,opencodex,cline,Roo-Code,agent-of-empires,axonhub,CCSwitcher}.md`
 - inventory 候选:codex(high,7 项目,`special:5, none:2`)
 - 参考实现:pi `openai-codex`、opencodex `accounts`、codex CLI `[model_providers]`
+- 官方文档:developers.openai.com/api/docs/models/gpt-5.2-codex、learn.chatgpt.com/docs/auth、learn.chatgpt.com/codex/pricing、openai.com/policies
+- 官方源码:openai/codex(`login/src/device_code_auth.rs`、`model-provider-info/src/lib.rs`、`core/src/client.rs`、`codex-api/src/lib.rs`)
+
+## 7. 决策记录
+
+| 日期 | 决策 | 理由 |
+|---|---|---|
+| 2026-08-03 | V1-V5 核验完成;Path A 必做、Path B 单账号自用 | API key 模式官方且支持 CI/自动化;订阅端点无文档、ToU 红线禁止账号池/共享凭据 |
+| 2026-08-03 | OAuth(设备码 UI/持久化/刷新编排)归集成方;库只做协议面(provider + `codex_refresh` 纯函数 + `TokenExpired` 错误) | refresh token 一次性轮换,持久化天然是集成方职责;库保持无状态、零落盘、8 语言一致 |

--- a/rfc/0019-session-affinity.md
+++ b/rfc/0019-session-affinity.md
@@ -1,11 +1,11 @@
-﻿# RFC-0019: 会话亲和(session affinity)轻量支持
+﻿# RFC-0019: 会话亲和(session affinity)支持方案
 
-> **Status**: DRAFT (pending review)
-> **Date**: 2026-08-02
-> **Scope**: 在 aimux 请求层增加可选的 `session_id`,由 provider 自动注入各厂商的
-> 会话/提示缓存头。轻量设计,不引入粘性路由。
-> **Related**: [RFC-0017](0017-provider-config-dx.md) 配置层(本 RFC 的字段走同一 options 通道)、
-> [RFC-0005](0005-protocol-conversion.md) 协议转换(头部注入点)
+> **Status**: ACCEPTED (2026-08-03 定稿为文档化方案——代码零改动)
+> **Date**: 2026-08-02(初稿)/ 2026-08-03(定稿)
+> **Scope**: 为 aimux 用户提供"会话亲和头怎么传、何时传、安全边界"的最佳实践集成指南与支持矩阵。
+> 不新增 core 字段、不预置 registry 数据、不改任何绑定层代码——现有 `CallOptions.headers` 已可表达全部机制。
+> **Related**: [RFC-0017](0017-provider-config-dx.md) 配置层、[RFC-0015](0015-cache-trace-audit.md) 缓存审计(session scope)、
+> [RFC-0018](0018-codex-subscription.md) 订阅通道(私有会话头)
 
 ---
 
@@ -21,80 +21,78 @@
 | 中:哈希粘性路由 | TokenHub、claude-code-router、axonhub、plano | `hash(sessionId)%100`、SHA-256 rendezvous、`TraceStickyMode=prefer_previous_channel` |
 | 重:账号/会话级绑定 | codex、opencodex、uni-api | `x-codex-turn-state`、账号池按会话选择 |
 
-**价值**:同一会话固定同一上游/携带稳定会话标识,可提升上游提示缓存命中率
-(Anthropic prompt caching、OpenAI prompt cache 均按会话/前缀命中),降低延迟与成本。
+**价值**:同一会话固定同一上游/携带稳定会话标识,可提升网关侧粘性路由与上游提示缓存命中率,降低延迟与成本。
 
-### 1.2 aimux 现状
+### 1.2 定稿前调研结论(2026-08-03)
 
-- `CallOptions.headers: Option<HashMap<String, String>>` 已存在(options.rs:74)——**零代码即可表达**
-  任意会话头(用户手动传 `x-session-id` 即可)
-- 但无**一等公民**字段:各厂商头名不同(`x-session-id`/`x-session-affinity`/
-  `x-claude-code-session-id`/`prompt_cache_key` 等),用户需自行查表,
-  且流式/非流式/各 provider 行为由用户保证一致
+对 reference/audit 全量扫描(22 项目命中)+ 联网核证官方文档后,三个事实改变了设计:
 
-### 1.3 边界(明确不做)
+1. **会话头是"网关/部署"属性,不是"provider"属性**。同一个 OpenAI 兼容 provider,用户可能直连官方、或走 OpenRouter、或走自建 LiteLLM/网关——会话头名由**用户面对的网关**决定,不由 registry 里的 provider 决定。按 provider 预置(无论 registry 字段还是 core 常量表)都会误导,且大量自建网关根本不在 registry 里。因此**预置注入与集成方开发强耦合,正确形态是文档化最佳实践**。
+2. **默认注入未知头整体安全但非零风险**。HTTP 语义上未知头被忽略(RFC 9110;OpenCode 对全部 provider 每请求发会话头为实证);但四类例外:非法字符/超长(400/431)、**AWS SigV4 签名链**(签名后加头 → SignatureDoesNotMatch)、严格白名单网关(LiteLLM 文档明言 "Some providers reject unknown headers")、私有后端(ChatGPT 订阅通道只放行白名单头)。另有意外语义:给 OpenRouter 发 `x-session-id` 会真实触发粘性钉住。→ **必须 opt-in,由集成方按自己的网关决定;库不做默认注入。**
+3. **"支持 Responses API" ≠ "支持 session id"**。Responses 规范无 session id(官方用 `previous_response_id`/`conversation.id`/手动回灌);OpenRouter 的 Responses 实现 stateless 且**拒绝** `previous_response_id`(400);session id 是网关私有扩展。→ 不能以协议面作判据,只能逐家文档化。
 
-- **不做**哈希粘性/渠道路由/账号池(中/重形态)——属网关/账号层,aimux 定位是接入层
-  (LEARNINGS.md 结论)
+### 1.3 aimux 现状
+
+- `CallOptions.headers: Option<HashMap<String, String>>` 已存在([options.rs:93](../aimux-core/src/options.rs#L93))——**零代码即可表达**任意会话头
+- Node 绑定:工厂级 `ProviderConfig.headers` + 每次调用 `opts.headers`([lib.rs:224/319](../bindings/node/src/lib.rs#L224));Python/FFI 经 options JSON 透传
+- 但无统一文档:各厂商头名不同(`x-session-id`/`x-session-affinity`/`x-claude-code-session-id`/`prompt_cache_key` 等),用户需自行查表
+
+### 1.4 边界(明确不做)
+
+- **不做**哈希粘性/渠道路由/账号池(中/重形态)——属网关/账号层,aimux 定位是接入层(LEARNINGS.md 结论)
 - **不做**会话状态管理(会话生命周期由用户持有,aimux 只透传)
+- **不做**自动生成 session id、不默认注入、不按 provider 预置头名
 
 ---
 
-## 2. 设计
+## 2. 设计(定案:文档化方案,代码零改动)
 
-### 2.1 用户面:复用 GenerateTextOptions 的 headers,或新增便捷字段
+### 2.1 核心决策
 
-两条候选路径,倾向 **A**(最小侵入):
+会话亲和的全部机制已存在于 `CallOptions.headers` / `ProviderConfig.headers`。
+aimux 的交付物是**集成指南 + 支持矩阵 + 安全规则**,而非新代码:
 
-**路径 A(推荐)**:不新增核心字段,文档化 + 便捷常量
+1. 新增 `docs/session-affinity-guide.md` 集成指南(本 RFC 的实现物):
+   - 支持矩阵(§2.2)+ 每个上游的官方语义、头名、注入方式、示例代码
+   - 安全规则(§2.3)与校验清单
+   - 各语言示例:Rust `with_headers`、Node `headers` 参数、Python/FFI JSON 透传
+2. 绑定层 `sessionId` 便捷参数:**记为可选增强,不做**——用户有真实需求(如多语言一致体验)再议;届时实现为 wrapper 层纯 sugar(合并规则 `{...auto, ...user}`,用户显式优先),不碰 core/FFI wire
 
-- 在 `aimux-core` 增加会话头常量表(供用户/绑定层查表):
+### 2.2 支持矩阵(2026-08-03 调研;完整 22 项目矩阵见集成指南)
 
-```rust
-/// 会话亲和 header 名(按 provider 分组,供用户选用)。
-pub const SESSION_HEADERS: &[(&str, &str)] = &[
-    ("openai", "x-session-id"),            // OpenAI 系(部分网关)
-    ("anthropic", "x-claude-code-session-id"), // Anthropic 系(dynamo 透传)
-    ("openrouter", "x-session-id"),        // OpenRouter sticky session
-    // ...
-];
-```
+| 上游/网关 | 会话标识 | 注入方式 | 语义 | 证据 |
+|---|---|---|---|---|
+| OpenRouter | `session_id`(body 顶层,≤256 字符)或 `x-session-id` 头,body 优先 | header/body | **粘性路由键**,兜底 `prompt_cache_key`;按 账户×模型×会话 粒度跟踪 | openrouter.ai/docs/guides/best-practices/prompt-caching |
+| Cloudflare Workers AI | `x-session-affinity` | header | 路由到同一模型实例,提升前缀缓存命中 | developers.cloudflare.com/workers-ai/features/prompt-caching |
+| Anthropic 生态 | `x-claude-code-session-id` / `-agent-id` / `-parent-agent-id` | header | Claude Code harness → **自托管**会话路由(SGLang 子 agent KV 隔离,dynamo);对托管 API 缓存**不参与** | [dynamo.md](../reference/audit/dynamo.md#L102-L107) |
+| ChatGPT 订阅(Codex) | `session_id`/`originator` 私有头 + `x-codex-turn-state`(服务端回传) | header | 私有约定,无文档;属 [RFC-0018](0018-codex-subscription.md) 通道 | [plano.md](../reference/audit/plano.md#L88)、[uni-api.md](../reference/audit/uni-api.md#L57-L61) |
+| Kimi / Z.AI | `prompt_cache_key`(仅透传不生成) | header/body | 缓存标识;值由用户/上游体系决定 | [opencodex.md](../reference/audit/opencodex.md)、[cc-switch.md](../reference/audit/cc-switch.md) |
+| OpenAI 官方 API | **无 session id** | — | 会话用 `previous_response_id`/`conversation.id`;OpenRouter Responses 实现甚至 400 拒绝 previous_response_id | developers.openai.com 对话状态指南 |
+| 自建网关约定 | litellm `x-litellm-session-id`、TokenHub `x-tokenhub-session-id`、llmgateway `x-session-id`→`prompt_cache_key`→`user` 等 | header/body | 各自约定,无统一标准;集成方按自己的网关选 | [litellm.md](../reference/audit/litellm.md)、[TokenHub.md](../reference/audit/TokenHub.md)、[llmgateway.md](../reference/audit/llmgateway.md) |
 
-- 用户通过现有 `headers` 字段注入;绑定层(Node/Python)在 options 里加
-  `sessionId?: string` 便捷参数,自动填对应 provider 的 header
-- 工作量:极小(常量表 + 绑定层一个字段)
+### 2.3 安全规则(opt-in 注入的边界)
 
-**路径 B**:core 的 `CallOptions` 加 `session_id: Option<String>`,provider 侧自动注入。
-
-- 优点:语义化、各语言绑定统一
-- 缺点:header 名是 provider 专属知识,放 core 字段会造成"core 知道厂商头名"的耦合;
-  且与 `headers` 重叠,两份入口易冲突(需定义合并优先级)
-
-**结论**:路径 A 保持 core 纯净(厂商差异仍在 provider/绑定层表达,符合现有架构);
-若后续发现 session 需要参与重试/粘性等**语义**,再升级为路径 B。
-
-### 2.2 注入点
-
-- Node/Python 绑定层:工厂函数/生成函数 options 增加 `sessionId`,映射到对应
-  provider 的 header(查 §2.1 常量表)
-- Rust 用户:直接 `with_headers`(现状已支持,无需改动)
-
-### 2.3 行为契约
-
-- `sessionId` 只做**透传**,不校验格式、不保证上游行为(上游缓存策略在厂商侧)
-- 流式/非流式一致注入
-- 与用户显式传的同名 header 冲突时:**用户显式 header 优先**(绑定层不覆盖)
+1. **opt-in**:用户显式传 session 标识才注入;库不自动生成、不默认注入
+2. **值校验**:≤256 字符、可打印 ASCII、无 CR/LF/NUL(非法值可能 400/431)
+3. **SigV4 排除**:bedrock/vertex 等签名请求通道不注入会话头(签名链不一致 → SignatureDoesNotMatch;官方 codex 客户端即签名前剔头)
+4. **私有后端仅白名单**:ChatGPT 订阅等通道只透传其放行的头
+5. **意外语义提示**:对 OpenRouter 类网关传 `x-session-id` 会触发粘性钉住——这是功能,但文档需明示
+6. **与显式 headers 冲突时用户优先**(若未来加 sugar,合并规则 `{...auto, ...user}`)
 
 ---
 
-## 3. 验收标准
+## 3. 验收标准(文档交付,代码零改动)
 
-- [ ] 常量表覆盖至少 3 个主流厂商/网关(openai 系、anthropic 系、openrouter)
-- [ ] Node 绑定:`generateText({ sessionId })` 产出对应 header(cassette 断言)
-- [ ] 与显式 headers 冲突时用户优先(测试)
-- [ ] Rust 侧无 API 破坏(仅新增)
+- [ ] `docs/session-affinity-guide.md` 落盘:支持矩阵(≥8 上游,含官方语义/头名/注入方式)+ 安全规则 + 校验清单
+- [ ] 指南含 3 种以上语言示例(Rust/Node/Python 起步),FFI 语言注明 headers JSON 透传
+- [ ] 指南明示:"支持 Responses API"不等于支持 session id(§1.2-3);OpenAI 官方 API 无 session id
+- [ ] 指南引用全部证据位置(reference/audit 文件:行号 + 官方文档 URL)
+- [ ] 代码零改动(本 RFC 定稿即验收);若后续加绑定层 sugar,需单独提案或本 RFC 修订
+
+---
 
 ## 4. 参考资料
 
-- 审计:`reference/audit/{cline,pi,llmgateway,dynamo,TokenHub,claude-code-router,axonhub,plano}.md`
-- reference/audit/LEARNINGS.md 会话亲和三档形态表
+- 审计:`reference/audit/{cline,pi,llmgateway,dynamo,claude-code-router,TokenHub,axonhub,plano,uni-api,opencodex,cc-switch,gemini-cli,ai.rs,pydantic-ai,litellm,new-api,awaken}.md`、`reference/audit/LEARNINGS.md`
+- 官方文档:OpenRouter prompt-caching、Cloudflare Workers AI prompt-caching、OpenAI conversation-state、LiteLLM request_headers/forward_client_headers、RFC 9110
+- 调研存档:2026-08-03 会话亲和调研(22 项目矩阵 + 注入安全性 + Responses 会话机制三份结论,完整矩阵并入集成指南)


### PR DESCRIPTION
Two RFCs, one PR.

**RFC-0018 — Codex provider (implementation, IMPLEMENTED)**
- **Path A (API key, default)**: CodexProvider over the official Responses API (api.openai.com/v1/responses) - gpt-5.x-codex models, non-stream/stream/tools.
- **Path B (subscription)**: single-account ChatGPT-subscription channel (chatgpt.com/backend-api/codex/responses) with forced stream:true + store:false; OAuth stays with the integrator per RFC design.
- **Stateless refresh helper**: codex_refresh() (Rust API) + aimux_codex_refresh C ABI export (header + regenerated AiMuxError.ts binding with TokenExpired).
- **New error**: AiMuxError::TokenExpired, mapped from subscription 401s.
- Tests: 10 wiremock cases, all green (cargo_exit=0).
- Guide: docs/codex-subscription-guide.md.

**RFC-0019 — session affinity (docs-only, finalized)**
- Session-affinity headers are a gateway/deployment attribute, not a provider property - pre-configuring them in core/registry would be misleading, so zero code changes (existing CallOptions.headers covers the mechanism).
- RFC-0019 rewritten: decision record + 10-upstream support matrix + safety rules.
- New docs/session-affinity-guide.md: 22-project audit matrix, per-upstream integration cases (Rust/Node/Python), FAQ.

Verification: cargo test --workspace (full suite, all green).