### PR TITLE
fix(ffi): preserve detailed errors across the C ABI (issue #17)

### DIFF
--- a/aimux-ffi/Cargo.toml
+++ b/aimux-ffi/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 # Needed to drive `Stream::next` while consuming `stream_text` output.
 futures = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/aimux-ffi/aimux-ffi.h
+++ b/aimux-ffi/aimux-ffi.h
@@ -219,6 +219,31 @@ void aimux_drop_handle(uint64_t handle);
  */
 void aimux_free_string(char *ptr);
 
+/**
+ * Take (read-and-clear) the last constructor error on this thread.
+ *
+ * Constructors return a bare handle with 0 reserved for failure, so callers
+ * cannot distinguish "unknown provider" from "bad config" from "missing env
+ * var". On failure, the constructor records the full error JSON envelope
+ * `{"error","error_type","status_code"}`; callers read it back with this
+ * function and feed it through their existing error-JSON parser.
+ *
+ * Semantics:
+ * - Returns NULL if the last constructor call on this thread succeeded.
+ * - Destructive read: a second call returns NULL.
+ * - The returned pointer is owned by the caller; MUST be freed with
+ *   aimux_free_string.
+ * - Only set by aimux_*_new / aimux_provider_new / aimux_provider_from_env.
+ *
+ * Threading: the constructor and this read must run on the SAME OS thread,
+ * with no other aimux_*_new call in between. Runtimes that can migrate work
+ * between OS threads between native calls (Go goroutines, Java virtual
+ * threads, Kotlin coroutines) must pin both calls to one thread.
+ *
+ * @return Error JSON envelope, or NULL (no error).
+ */
+char *aimux_last_error(void);
+
 /* ── Embedding ───────────────────────────────────────────────────────────── */
 
 uint64_t aimux_openai_embedding_new(const char *api_key, const char *model_id);

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -26,6 +26,7 @@
 // design: the C ABI contract requires callers to pass valid pointers (see
 // memory-ownership docs above), so the functions are safe only on the C side.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
@@ -101,6 +102,19 @@ fn intern_handle(h: ModelHandle) -> u64 {
         .expect("aimux-ffi: registry mutex poisoned")
         .insert(handle, h);
     handle
+}
+
+/// Uniform constructor exit (issue #17): on success register the model and
+/// return its handle; on failure record the error in the thread-local slot
+/// (see [`aimux_last_error`]) and return 0.
+fn intern_or_record_lang(result: Result<Box<dyn LanguageModel>, AiMuxError>) -> u64 {
+    match result {
+        Ok(m) => intern_model(Arc::from(m)),
+        Err(e) => {
+            record_error(&e);
+            0
+        }
+    }
 }
 
 /// Look up a model by handle, cloning the `Arc` out of the registry.
@@ -189,31 +203,77 @@ fn into_cstring_raw(s: String) -> *mut c_char {
         .unwrap_or(std::ptr::null_mut())
 }
 
+/// Build an error JSON envelope string.
+///
+/// Output: `{"error":"<message>","error_type":"<variant>","status_code":<u16|null>}`
+fn raw_error_json_string(msg: impl std::fmt::Display) -> String {
+    serde_json::json!({
+        "error": msg.to_string(),
+        "error_type": "Other",
+        "status_code": null,
+    })
+    .to_string()
+}
+
+/// Build an error JSON envelope string from an `AiMuxError`, preserving the
+/// variant name and HTTP status code for programmatic use by bindings.
+fn error_json_string(err: &AiMuxError) -> String {
+    serde_json::json!({
+        "error": err.to_string(),
+        "error_type": err.error_type(),
+        "status_code": err.status_code(),
+    })
+    .to_string()
+}
+
 /// Build an error JSON string with error type, message, and optional status code.
 ///
 /// Output: `{"error":"<message>","error_type":"<variant>","status_code":<u16|null>}`
 fn error_json_raw(msg: impl std::fmt::Display) -> *mut c_char {
-    into_cstring_raw(
-        serde_json::json!({
-            "error": msg.to_string(),
-            "error_type": "Other",
-            "status_code": null,
-        })
-        .to_string(),
-    )
+    into_cstring_raw(raw_error_json_string(msg))
 }
 
 /// Build an error JSON string from an `AiMuxError`, preserving the variant
 /// name and HTTP status code for programmatic use by bindings.
 fn error_json_from(err: &AiMuxError) -> *mut c_char {
-    into_cstring_raw(
-        serde_json::json!({
-            "error": err.to_string(),
-            "error_type": err.error_type(),
-            "status_code": err.status_code(),
-        })
-        .to_string(),
-    )
+    into_cstring_raw(error_json_string(err))
+}
+
+// Thread-local last-constructor-error slot (issue #17).
+//
+// Constructors return a bare `u64` handle with `0` reserved for failure, so
+// they have no error channel of their own; failures record the full error
+// JSON envelope here and callers read it back with `aimux_last_error`.
+// Always stores a JSON envelope (never plain text) so bindings can parse
+// every value with their existing envelope parser.
+thread_local! {
+    static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Must be called at the entry of every constructor: clears any stale error
+/// left on this thread by a previous failed constructor.
+fn begin_constructor() {
+    LAST_ERROR.with(|slot| *slot.borrow_mut() = None);
+}
+
+/// Record a constructor failure as an `AiMuxError` envelope.
+fn record_error(err: &AiMuxError) {
+    LAST_ERROR.with(|slot| *slot.borrow_mut() = Some(error_json_string(err)));
+}
+
+/// Record a synthetic constructor failure (null / invalid-UTF-8 arguments,
+/// config JSON parse errors) as an envelope with the given error type.
+fn record_error_msg(msg: impl std::fmt::Display, error_type: &str) {
+    LAST_ERROR.with(|slot| {
+        *slot.borrow_mut() = Some(
+            serde_json::json!({
+                "error": msg.to_string(),
+                "error_type": error_type,
+                "status_code": null,
+            })
+            .to_string(),
+        )
+    });
 }
 
 /// Invoke the `on_error` callback with an error JSON string.
@@ -221,26 +281,14 @@ fn error_json_from(err: &AiMuxError) -> *mut c_char {
 /// The pointer is valid only for the duration of the callback (no leak: the
 /// backing `CString` is freed when this function returns).
 fn fire_error(on_error: extern "C" fn(*const c_char), msg: impl std::fmt::Display) {
-    let json = serde_json::json!({
-        "error": msg.to_string(),
-        "error_type": "Other",
-        "status_code": null,
-    })
-    .to_string();
-    if let Ok(cstr) = CString::new(json) {
+    if let Ok(cstr) = CString::new(raw_error_json_string(msg)) {
         on_error(cstr.as_ptr());
     }
 }
 
 /// Like `fire_error` but preserves the `AiMuxError` variant name and status code.
 fn fire_error_struct(on_error: extern "C" fn(*const c_char), err: &AiMuxError) {
-    let json = serde_json::json!({
-        "error": err.to_string(),
-        "error_type": err.error_type(),
-        "status_code": err.status_code(),
-    })
-    .to_string();
-    if let Ok(cstr) = CString::new(json) {
+    if let Ok(cstr) = CString::new(error_json_string(err)) {
         on_error(cstr.as_ptr());
     }
 }
@@ -316,13 +364,12 @@ fn parse_json_arg<T: DeserializeOwned>(json: *const c_char, name: &str) -> Resul
 /// Returns `0` on failure (null arguments or invalid model id).
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_openai_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    OpenAIProvider::new(OpenAIConfig::new(api_key))
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(OpenAIProvider::new(OpenAIConfig::new(api_key)).language_model(&model_id))
 }
 
 /// Create an OpenAI model instance with a custom base URL.
@@ -335,17 +382,16 @@ pub extern "C" fn aimux_openai_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    OpenAIProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(OpenAIProvider::new(config).language_model(&model_id))
 }
 
 /// Create an Anthropic model instance, returning its opaque handle.
@@ -353,13 +399,14 @@ pub extern "C" fn aimux_openai_new_with_base(
 /// Returns `0` on failure (null arguments or invalid model id).
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_anthropic_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    AnthropicProvider::new(AnthropicConfig::new(api_key))
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(
+        AnthropicProvider::new(AnthropicConfig::new(api_key)).language_model(&model_id),
+    )
 }
 
 /// Create an Anthropic model instance with a custom base URL.
@@ -372,17 +419,16 @@ pub extern "C" fn aimux_anthropic_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = AnthropicConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    AnthropicProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(AnthropicProvider::new(config).language_model(&model_id))
 }
 
 /// Create an Anthropic-on-AWS model instance (API key + region).
@@ -394,6 +440,7 @@ pub extern "C" fn aimux_anthropic_aws_new(
     region: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(region),
@@ -403,12 +450,13 @@ pub extern "C" fn aimux_anthropic_aws_new(
         _ => None,
     };
     let Some((api_key, region, model_id)) = parsed else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    AnthropicAwsProvider::new(AnthropicAwsProviderConfig::with_api_key(api_key, region))
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(
+        AnthropicAwsProvider::new(AnthropicAwsProviderConfig::with_api_key(api_key, region))
+            .language_model(&model_id),
+    )
 }
 
 /// Create an Anthropic-on-AWS model instance with a custom base URL.
@@ -419,6 +467,7 @@ pub extern "C" fn aimux_anthropic_aws_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(region),
@@ -428,16 +477,14 @@ pub extern "C" fn aimux_anthropic_aws_new_with_base(
         _ => None,
     };
     let Some((api_key, region, model_id)) = parsed else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = AnthropicAwsProviderConfig::with_api_key(api_key, region);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    AnthropicAwsProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(AnthropicAwsProvider::new(config).language_model(&model_id))
 }
 
 /// Create an Azure OpenAI model instance (API key + resource name).
@@ -451,6 +498,7 @@ pub extern "C" fn aimux_azure_new(
     deployment: *const c_char,
     api_version: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(resource_name),
@@ -460,6 +508,7 @@ pub extern "C" fn aimux_azure_new(
         _ => None,
     };
     let Some((api_key, resource_name, deployment)) = parsed else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = AzureConfig::new()
@@ -468,13 +517,7 @@ pub extern "C" fn aimux_azure_new(
     if let Some(version) = parse_base_url(api_version) {
         config = config.with_api_version(version);
     }
-    match AzureProvider::new(config) {
-        Ok(p) => p
-            .language_model(&deployment)
-            .map(|m| intern_model(Arc::from(m)))
-            .unwrap_or(0),
-        Err(_) => 0,
-    }
+    intern_or_record_lang(AzureProvider::new(config).and_then(|p| p.language_model(&deployment)))
 }
 
 /// Create an Azure OpenAI model instance with a custom base URL.
@@ -488,6 +531,7 @@ pub extern "C" fn aimux_azure_new_with_base(
     deployment: *const c_char,
     api_version: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(base_url),
@@ -497,6 +541,7 @@ pub extern "C" fn aimux_azure_new_with_base(
         _ => None,
     };
     let Some((api_key, base_url, deployment)) = parsed else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = AzureConfig::new()
@@ -505,13 +550,7 @@ pub extern "C" fn aimux_azure_new_with_base(
     if let Some(version) = parse_base_url(api_version) {
         config = config.with_api_version(version);
     }
-    match AzureProvider::new(config) {
-        Ok(p) => p
-            .language_model(&deployment)
-            .map(|m| intern_model(Arc::from(m)))
-            .unwrap_or(0),
-        Err(_) => 0,
-    }
+    intern_or_record_lang(AzureProvider::new(config).and_then(|p| p.language_model(&deployment)))
 }
 
 /// Create a Bedrock model instance (AWS SigV4 credentials).
@@ -525,19 +564,19 @@ pub extern "C" fn aimux_bedrock_new(
     region: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((access_key_id, secret_access_key, region, model_id)) =
         (unsafe { parse_four_args(access_key_id, secret_access_key, region, model_id) })
     else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    BedrockProvider::new(BedrockProviderConfig::new(
+    intern_or_record_lang(BedrockProvider::new(BedrockProviderConfig::new(
         access_key_id,
         secret_access_key,
         region,
     ))
-    .language_model(&model_id)
-    .map(|m| intern_model(Arc::from(m)))
-    .unwrap_or(0)
+    .language_model(&model_id))
 }
 
 /// Create a Bedrock model instance with a custom base URL.
@@ -549,19 +588,18 @@ pub extern "C" fn aimux_bedrock_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((access_key_id, secret_access_key, region, model_id)) =
         (unsafe { parse_four_args(access_key_id, secret_access_key, region, model_id) })
     else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = BedrockProviderConfig::new(access_key_id, secret_access_key, region);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    BedrockProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(BedrockProvider::new(config).language_model(&model_id))
 }
 
 /// Create a Vertex AI model instance (GCP bearer token).
@@ -575,15 +613,17 @@ pub extern "C" fn aimux_vertex_new(
     location: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((access_token, project, location, model_id)) =
         (unsafe { parse_four_args(access_token, project, location, model_id) })
     else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    VertexProvider::new(VertexProviderConfig::new(access_token, project, location))
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(
+        VertexProvider::new(VertexProviderConfig::new(access_token, project, location))
+            .language_model(&model_id),
+    )
 }
 
 /// Create a Vertex AI model instance with a custom base URL.
@@ -595,19 +635,18 @@ pub extern "C" fn aimux_vertex_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((access_token, project, location, model_id)) =
         (unsafe { parse_four_args(access_token, project, location, model_id) })
     else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = VertexProviderConfig::new(access_token, project, location);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    VertexProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(VertexProvider::new(config).language_model(&model_id))
 }
 
 /// Create a Cohere model instance, returning its opaque handle.
@@ -615,13 +654,14 @@ pub extern "C" fn aimux_vertex_new_with_base(
 /// Returns `0` on failure (null arguments or invalid model id).
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_cohere_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    CohereProvider::new(CohereConfig::new(api_key))
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(
+        CohereProvider::new(CohereConfig::new(api_key)).language_model(&model_id),
+    )
 }
 
 /// Create a Cohere model instance with a custom base URL.
@@ -631,17 +671,16 @@ pub extern "C" fn aimux_cohere_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = CohereConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    CohereProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(CohereProvider::new(config).language_model(&model_id))
 }
 
 /// Create a Mistral model instance, returning its opaque handle.
@@ -649,13 +688,14 @@ pub extern "C" fn aimux_cohere_new_with_base(
 /// Returns `0` on failure (null arguments or invalid model id).
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_mistral_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    MistralProvider::new(MistralConfig::new(api_key))
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(
+        MistralProvider::new(MistralConfig::new(api_key)).language_model(&model_id),
+    )
 }
 
 /// Create a Mistral model instance with a custom base URL.
@@ -665,17 +705,16 @@ pub extern "C" fn aimux_mistral_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = MistralConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    MistralProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(MistralProvider::new(config).language_model(&model_id))
 }
 
 /// Create an xAI model instance, returning its opaque handle.
@@ -683,13 +722,12 @@ pub extern "C" fn aimux_mistral_new_with_base(
 /// Returns `0` on failure (null arguments or invalid model id).
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_xai_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    XAIProvider::new(XAIConfig::new(api_key))
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(XAIProvider::new(XAIConfig::new(api_key)).language_model(&model_id))
 }
 
 /// Create an xAI model instance with a custom base URL.
@@ -699,17 +737,16 @@ pub extern "C" fn aimux_xai_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = XAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    XAIProvider::new(config)
-        .language_model(&model_id)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(XAIProvider::new(config).language_model(&model_id))
 }
 
 /// Create a language model from the registry by provider name (RFC-0017 phase 4).
@@ -731,10 +768,13 @@ pub extern "C" fn aimux_provider_new(
     model_id: *const c_char,
     config_json: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some(name) = cstr_to_string(name) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let Some(model_id) = cstr_to_string(model_id) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let key = cstr_to_string(api_key); // None => env var from registry entry
@@ -742,29 +782,31 @@ pub extern "C" fn aimux_provider_new(
         Some(s) if !s.trim().is_empty() && s.trim() != "null" => {
             match serde_json::from_str::<ProviderOptions>(&s) {
                 Ok(o) => Some(o),
-                Err(_) => return 0,
+                Err(e) => {
+                    record_error_msg(format!("invalid config_json: {e}"), "Json");
+                    return 0;
+                }
             }
         }
         _ => None,
     };
-    provider(&name, key, &model_id, opts)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(provider(&name, key, &model_id, opts))
 }
 
 /// Convenience: create a language model by provider name, reading the API key
 /// from the provider's env var. Returns `0` on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_provider_from_env(name: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some(name) = cstr_to_string(name) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let Some(model_id) = cstr_to_string(model_id) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
-    provider(&name, None, &model_id, None)
-        .map(|m| intern_model(Arc::from(m)))
-        .unwrap_or(0)
+    intern_or_record_lang(provider(&name, None, &model_id, None))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -790,8 +832,11 @@ pub extern "C" fn aimux_generate_text(
         Some(m) => m,
         None => return error_json_raw("invalid handle"),
     };
-    let prompt = match cstr_to_string(prompt_json).and_then(|s| parse_prompt(&s).ok()) {
-        Some(p) => p,
+    let prompt = match cstr_to_string(prompt_json) {
+        Some(s) => match parse_prompt(&s) {
+            Ok(p) => p,
+            Err(e) => return error_json_raw(format!("invalid prompt_json: {e}")),
+        },
         None => return error_json_raw("invalid prompt_json"),
     };
     let opts = match cstr_to_string(opts_json) {
@@ -839,8 +884,14 @@ pub extern "C" fn aimux_stream_text(
         }
     };
 
-    let prompt = match cstr_to_string(prompt_json).and_then(|s| parse_prompt(&s).ok()) {
-        Some(p) => p,
+    let prompt = match cstr_to_string(prompt_json) {
+        Some(s) => match parse_prompt(&s) {
+            Ok(p) => p,
+            Err(e) => {
+                fire_error(on_error, format!("invalid prompt_json: {e}"));
+                return;
+            }
+        },
         None => {
             fire_error(on_error, "invalid prompt_json");
             return;
@@ -917,6 +968,24 @@ pub unsafe extern "C" fn aimux_free_string(ptr: *mut c_char) {
     drop(unsafe { CString::from_raw(ptr) });
 }
 
+/// Take (read-and-clear) the last constructor error recorded on this thread.
+///
+/// - Returns the error JSON envelope `{"error","error_type","status_code"}`
+///   from the most recent failed constructor on this thread, or NULL if the
+///   most recent constructor call succeeded.
+/// - The returned pointer is owned by the caller and MUST be freed with
+///   [`aimux_free_string`].
+/// - Destructive read: a second call returns NULL.
+/// - Must be called on the same OS thread as the failed constructor,
+///   immediately after it returned 0. Bindings whose runtime can migrate
+///   work between OS threads (Go goroutines, Java virtual threads, Kotlin
+///   coroutines) must pin both calls to one thread.
+#[unsafe(no_mangle)]
+pub extern "C" fn aimux_last_error() -> *mut c_char {
+    let s = LAST_ERROR.with(|slot| slot.borrow_mut().take());
+    s.map(into_cstring_raw).unwrap_or(std::ptr::null_mut())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // C ABI: Embedding
 // ─────────────────────────────────────────────────────────────────────────────
@@ -927,7 +996,9 @@ pub extern "C" fn aimux_openai_embedding_new(
     api_key: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).embedding_model(&model_id);
@@ -940,7 +1011,9 @@ pub extern "C" fn aimux_openai_embedding_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -956,7 +1029,9 @@ pub extern "C" fn aimux_cohere_embedding_new(
     api_key: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = CohereProvider::new(CohereConfig::new(api_key)).embedding_model(&model_id);
@@ -969,7 +1044,9 @@ pub extern "C" fn aimux_cohere_embedding_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = CohereConfig::new(api_key);
@@ -985,7 +1062,9 @@ pub extern "C" fn aimux_google_embedding_new(
     api_key: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).embedding_model(&model_id);
@@ -998,7 +1077,9 @@ pub extern "C" fn aimux_google_embedding_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = GoogleConfig::new(api_key);
@@ -1049,7 +1130,9 @@ pub extern "C" fn aimux_embed(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_openai_speech_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).speech(&model_id);
@@ -1062,7 +1145,9 @@ pub extern "C" fn aimux_openai_speech_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1093,7 +1178,9 @@ pub extern "C" fn aimux_speech_generate(handle: u64, opts_json: *const c_char) -
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_openai_image_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).image(&model_id);
@@ -1106,7 +1193,9 @@ pub extern "C" fn aimux_openai_image_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1119,7 +1208,9 @@ pub extern "C" fn aimux_openai_image_new_with_base(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_google_image_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).image(&model_id);
@@ -1132,7 +1223,9 @@ pub extern "C" fn aimux_google_image_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = GoogleConfig::new(api_key);
@@ -1166,7 +1259,9 @@ pub extern "C" fn aimux_openai_transcription_new(
     api_key: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).transcription(&model_id);
@@ -1179,7 +1274,9 @@ pub extern "C" fn aimux_openai_transcription_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1225,7 +1322,9 @@ pub extern "C" fn aimux_transcription_generate(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_openai_files_new(api_key: *const c_char) -> u64 {
+    begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let files = OpenAIProvider::new(OpenAIConfig::new(api_key)).files();
@@ -1237,7 +1336,9 @@ pub extern "C" fn aimux_openai_files_new_with_base(
     api_key: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1286,7 +1387,9 @@ pub extern "C" fn aimux_cohere_reranking_new(
     api_key: *const c_char,
     model_id: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = CohereProvider::new(CohereConfig::new(api_key)).reranking_model(&model_id);
@@ -1299,7 +1402,9 @@ pub extern "C" fn aimux_cohere_reranking_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = CohereConfig::new(api_key);
@@ -1334,7 +1439,9 @@ pub extern "C" fn aimux_rerank(handle: u64, opts_json: *const c_char) -> *mut c_
 /// Create a Google video model instance. Returns 0 on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_google_video_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).video(&model_id);
@@ -1347,7 +1454,9 @@ pub extern "C" fn aimux_google_video_new_with_base(
     model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = GoogleConfig::new(api_key);
@@ -1383,7 +1492,9 @@ pub extern "C" fn aimux_video_generate(handle: u64, opts_json: *const c_char) ->
 /// symmetry but ignored (Tavily uses a fixed endpoint). Returns 0 on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_tavily_search_new(api_key: *const c_char, _model_id: *const c_char) -> u64 {
+    begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let model = TavilyProvider::new(TavilyConfig::new(api_key)).search_model();
@@ -1396,7 +1507,9 @@ pub extern "C" fn aimux_tavily_search_new_with_base(
     _model_id: *const c_char,
     base_url: *const c_char,
 ) -> u64 {
+    begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
+        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
         return 0;
     };
     let mut config = TavilyConfig::new(api_key);

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -366,7 +366,10 @@ fn parse_json_arg<T: DeserializeOwned>(json: *const c_char, name: &str) -> Resul
 pub extern "C" fn aimux_openai_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     intern_or_record_lang(OpenAIProvider::new(OpenAIConfig::new(api_key)).language_model(&model_id))
@@ -384,7 +387,10 @@ pub extern "C" fn aimux_openai_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -401,7 +407,10 @@ pub extern "C" fn aimux_openai_new_with_base(
 pub extern "C" fn aimux_anthropic_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     intern_or_record_lang(
@@ -421,7 +430,10 @@ pub extern "C" fn aimux_anthropic_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = AnthropicConfig::new(api_key);
@@ -450,7 +462,10 @@ pub extern "C" fn aimux_anthropic_aws_new(
         _ => None,
     };
     let Some((api_key, region, model_id)) = parsed else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     intern_or_record_lang(
@@ -477,7 +492,10 @@ pub extern "C" fn aimux_anthropic_aws_new_with_base(
         _ => None,
     };
     let Some((api_key, region, model_id)) = parsed else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = AnthropicAwsProviderConfig::with_api_key(api_key, region);
@@ -508,7 +526,10 @@ pub extern "C" fn aimux_azure_new(
         _ => None,
     };
     let Some((api_key, resource_name, deployment)) = parsed else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = AzureConfig::new()
@@ -541,7 +562,10 @@ pub extern "C" fn aimux_azure_new_with_base(
         _ => None,
     };
     let Some((api_key, base_url, deployment)) = parsed else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = AzureConfig::new()
@@ -568,15 +592,20 @@ pub extern "C" fn aimux_bedrock_new(
     let Some((access_key_id, secret_access_key, region, model_id)) =
         (unsafe { parse_four_args(access_key_id, secret_access_key, region, model_id) })
     else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
-    intern_or_record_lang(BedrockProvider::new(BedrockProviderConfig::new(
-        access_key_id,
-        secret_access_key,
-        region,
-    ))
-    .language_model(&model_id))
+    intern_or_record_lang(
+        BedrockProvider::new(BedrockProviderConfig::new(
+            access_key_id,
+            secret_access_key,
+            region,
+        ))
+        .language_model(&model_id),
+    )
 }
 
 /// Create a Bedrock model instance with a custom base URL.
@@ -592,7 +621,10 @@ pub extern "C" fn aimux_bedrock_new_with_base(
     let Some((access_key_id, secret_access_key, region, model_id)) =
         (unsafe { parse_four_args(access_key_id, secret_access_key, region, model_id) })
     else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = BedrockProviderConfig::new(access_key_id, secret_access_key, region);
@@ -617,7 +649,10 @@ pub extern "C" fn aimux_vertex_new(
     let Some((access_token, project, location, model_id)) =
         (unsafe { parse_four_args(access_token, project, location, model_id) })
     else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     intern_or_record_lang(
@@ -639,7 +674,10 @@ pub extern "C" fn aimux_vertex_new_with_base(
     let Some((access_token, project, location, model_id)) =
         (unsafe { parse_four_args(access_token, project, location, model_id) })
     else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = VertexProviderConfig::new(access_token, project, location);
@@ -656,12 +694,13 @@ pub extern "C" fn aimux_vertex_new_with_base(
 pub extern "C" fn aimux_cohere_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
-    intern_or_record_lang(
-        CohereProvider::new(CohereConfig::new(api_key)).language_model(&model_id),
-    )
+    intern_or_record_lang(CohereProvider::new(CohereConfig::new(api_key)).language_model(&model_id))
 }
 
 /// Create a Cohere model instance with a custom base URL.
@@ -673,7 +712,10 @@ pub extern "C" fn aimux_cohere_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = CohereConfig::new(api_key);
@@ -690,7 +732,10 @@ pub extern "C" fn aimux_cohere_new_with_base(
 pub extern "C" fn aimux_mistral_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     intern_or_record_lang(
@@ -707,7 +752,10 @@ pub extern "C" fn aimux_mistral_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = MistralConfig::new(api_key);
@@ -724,7 +772,10 @@ pub extern "C" fn aimux_mistral_new_with_base(
 pub extern "C" fn aimux_xai_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     intern_or_record_lang(XAIProvider::new(XAIConfig::new(api_key)).language_model(&model_id))
@@ -739,7 +790,10 @@ pub extern "C" fn aimux_xai_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = XAIConfig::new(api_key);
@@ -770,11 +824,17 @@ pub extern "C" fn aimux_provider_new(
 ) -> u64 {
     begin_constructor();
     let Some(name) = cstr_to_string(name) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let Some(model_id) = cstr_to_string(model_id) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let key = cstr_to_string(api_key); // None => env var from registry entry
@@ -799,11 +859,17 @@ pub extern "C" fn aimux_provider_new(
 pub extern "C" fn aimux_provider_from_env(name: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some(name) = cstr_to_string(name) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let Some(model_id) = cstr_to_string(model_id) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     intern_or_record_lang(provider(&name, None, &model_id, None))
@@ -998,7 +1064,10 @@ pub extern "C" fn aimux_openai_embedding_new(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).embedding_model(&model_id);
@@ -1013,7 +1082,10 @@ pub extern "C" fn aimux_openai_embedding_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1031,7 +1103,10 @@ pub extern "C" fn aimux_cohere_embedding_new(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = CohereProvider::new(CohereConfig::new(api_key)).embedding_model(&model_id);
@@ -1046,7 +1121,10 @@ pub extern "C" fn aimux_cohere_embedding_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = CohereConfig::new(api_key);
@@ -1064,7 +1142,10 @@ pub extern "C" fn aimux_google_embedding_new(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).embedding_model(&model_id);
@@ -1079,7 +1160,10 @@ pub extern "C" fn aimux_google_embedding_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = GoogleConfig::new(api_key);
@@ -1132,7 +1216,10 @@ pub extern "C" fn aimux_embed(
 pub extern "C" fn aimux_openai_speech_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).speech(&model_id);
@@ -1147,7 +1234,10 @@ pub extern "C" fn aimux_openai_speech_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1180,7 +1270,10 @@ pub extern "C" fn aimux_speech_generate(handle: u64, opts_json: *const c_char) -
 pub extern "C" fn aimux_openai_image_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).image(&model_id);
@@ -1195,7 +1288,10 @@ pub extern "C" fn aimux_openai_image_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1210,7 +1306,10 @@ pub extern "C" fn aimux_openai_image_new_with_base(
 pub extern "C" fn aimux_google_image_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).image(&model_id);
@@ -1225,7 +1324,10 @@ pub extern "C" fn aimux_google_image_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = GoogleConfig::new(api_key);
@@ -1261,7 +1363,10 @@ pub extern "C" fn aimux_openai_transcription_new(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).transcription(&model_id);
@@ -1276,7 +1381,10 @@ pub extern "C" fn aimux_openai_transcription_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1324,7 +1432,10 @@ pub extern "C" fn aimux_transcription_generate(
 pub extern "C" fn aimux_openai_files_new(api_key: *const c_char) -> u64 {
     begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let files = OpenAIProvider::new(OpenAIConfig::new(api_key)).files();
@@ -1338,7 +1449,10 @@ pub extern "C" fn aimux_openai_files_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = OpenAIConfig::new(api_key);
@@ -1389,7 +1503,10 @@ pub extern "C" fn aimux_cohere_reranking_new(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = CohereProvider::new(CohereConfig::new(api_key)).reranking_model(&model_id);
@@ -1404,7 +1521,10 @@ pub extern "C" fn aimux_cohere_reranking_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = CohereConfig::new(api_key);
@@ -1441,7 +1561,10 @@ pub extern "C" fn aimux_rerank(handle: u64, opts_json: *const c_char) -> *mut c_
 pub extern "C" fn aimux_google_video_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).video(&model_id);
@@ -1456,7 +1579,10 @@ pub extern "C" fn aimux_google_video_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = GoogleConfig::new(api_key);
@@ -1494,7 +1620,10 @@ pub extern "C" fn aimux_video_generate(handle: u64, opts_json: *const c_char) ->
 pub extern "C" fn aimux_tavily_search_new(api_key: *const c_char, _model_id: *const c_char) -> u64 {
     begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let model = TavilyProvider::new(TavilyConfig::new(api_key)).search_model();
@@ -1509,7 +1638,10 @@ pub extern "C" fn aimux_tavily_search_new_with_base(
 ) -> u64 {
     begin_constructor();
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg("invalid argument: null or invalid UTF-8 string", "InvalidArgument");
+        record_error_msg(
+            "invalid argument: null or invalid UTF-8 string",
+            "InvalidArgument",
+        );
         return 0;
     };
     let mut config = TavilyConfig::new(api_key);

--- a/aimux-ffi/tests/error_detail_test.rs
+++ b/aimux-ffi/tests/error_detail_test.rs
@@ -97,7 +97,10 @@ extern "C" fn on_done() {}
 
 extern "C" fn on_error(json: *const std::os::raw::c_char) {
     // SAFETY: the FFI layer guarantees the pointer is valid during the call.
-    let s = unsafe { CStr::from_ptr(json) }.to_str().unwrap().to_string();
+    let s = unsafe { CStr::from_ptr(json) }
+        .to_str()
+        .unwrap()
+        .to_string();
     STREAM_ERRORS.lock().unwrap().push(s);
 }
 
@@ -106,7 +109,14 @@ fn stream_text_invalid_prompt_json_carries_serde_detail() {
     let h = valid_handle();
     STREAM_ERRORS.lock().unwrap().clear();
 
-    aimux_stream_text(h, c("hello").as_ptr(), ptr::null(), on_part, on_done, on_error);
+    aimux_stream_text(
+        h,
+        c("hello").as_ptr(),
+        ptr::null(),
+        on_part,
+        on_done,
+        on_error,
+    );
 
     let errors = STREAM_ERRORS.lock().unwrap().clone();
     assert_eq!(errors.len(), 1, "expected exactly one on_error callback");
@@ -116,7 +126,10 @@ fn stream_text_invalid_prompt_json_carries_serde_detail() {
         msg.starts_with("invalid prompt_json:"),
         "expected serde detail in message, got: {msg}"
     );
-    assert!(msg.contains("line"), "expected serde line detail, got: {msg}");
+    assert!(
+        msg.contains("line"),
+        "expected serde line detail, got: {msg}"
+    );
 
     aimux_drop_handle(h);
 }
@@ -152,7 +165,13 @@ fn invalid_config_json_reports_json_error_type() {
     assert_eq!(h, 0, "malformed config_json must fail");
 
     let env = take_envelope().expect("last_error must be set");
-    assert!(env["error"].as_str().unwrap().starts_with("invalid config_json:"), "got: {env}");
+    assert!(
+        env["error"]
+            .as_str()
+            .unwrap()
+            .starts_with("invalid config_json:"),
+        "got: {env}"
+    );
     assert_eq!(env["error_type"], "Json");
 }
 
@@ -164,7 +183,10 @@ fn null_arguments_report_invalid_argument_type() {
     let env = take_envelope().expect("last_error must be set");
     assert_eq!(env["error_type"], "InvalidArgument");
     assert!(
-        env["error"].as_str().unwrap().contains("null or invalid UTF-8"),
+        env["error"]
+            .as_str()
+            .unwrap()
+            .contains("null or invalid UTF-8"),
         "got: {env}"
     );
 }
@@ -175,7 +197,12 @@ fn azure_missing_required_argument_reports_invalid_argument() {
     // boundary with an InvalidArgument envelope (the Azure provider's own
     // InvalidArgument can't be reached from the FFI layer because the
     // argument is mandatory).
-    let h = aimux_azure_new(c("k").as_ptr(), ptr::null(), c("deploy").as_ptr(), ptr::null());
+    let h = aimux_azure_new(
+        c("k").as_ptr(),
+        ptr::null(),
+        c("deploy").as_ptr(),
+        ptr::null(),
+    );
     assert_eq!(h, 0);
 
     let env = take_envelope().expect("last_error must be set");
@@ -214,7 +241,10 @@ fn successful_constructor_clears_previous_error() {
         c("llama-3.3-70b").as_ptr(),
         ptr::null(),
     );
-    assert!(h != 0, "a registered provider with a fake key must construct");
+    assert!(
+        h != 0,
+        "a registered provider with a fake key must construct"
+    );
 
     // 3. The success must have cleared the stale error.
     assert!(
@@ -241,7 +271,10 @@ fn last_error_is_overwritten_and_read_once() {
 
     // Last write wins.
     let env = take_envelope().expect("last_error must be set");
-    assert!(env["error"].as_str().unwrap().contains("no-such-b"), "got: {env}");
+    assert!(
+        env["error"].as_str().unwrap().contains("no-such-b"),
+        "got: {env}"
+    );
 
     // Read-and-clear: a second read returns NULL.
     assert!(take_last_error().is_none(), "second read must be NULL");

--- a/aimux-ffi/tests/error_detail_test.rs
+++ b/aimux-ffi/tests/error_detail_test.rs
@@ -1,0 +1,281 @@
+//! Regression tests for issue #17: FFI constructors and prompt parsing must
+//! preserve detailed error information.
+//!
+//! - Problem A: `prompt_json` parse errors must carry the `serde_json::Error`
+//!   detail (like the adjacent `opts_json` branch already did).
+//! - Problem B: constructor failures (unknown provider, bad config JSON,
+//!   null arguments) are recorded in a thread-local slot and read back with
+//!   `aimux_last_error()` as a full error JSON envelope.
+//!
+//! All tests are offline: they only exercise argument parsing and config
+//! construction, never the network.
+
+use std::ffi::{CStr, CString};
+use std::ptr;
+use std::sync::Mutex;
+
+use serde_json::Value;
+
+use aimux_ffi::{
+    aimux_azure_new, aimux_drop_handle, aimux_free_string, aimux_generate_text, aimux_last_error,
+    aimux_openai_new, aimux_provider_new, aimux_stream_text,
+};
+
+fn c(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+/// Take the last error as an owned `String` (frees the FFI pointer).
+fn take_last_error() -> Option<String> {
+    let p = aimux_last_error();
+    if p.is_null() {
+        return None;
+    }
+    // SAFETY: aimux_last_error returns a NUL-terminated string owned by us.
+    let s = unsafe { CStr::from_ptr(p) }.to_str().unwrap().to_string();
+    // SAFETY: p was produced by CString::into_raw inside aimux_last_error.
+    unsafe { aimux_free_string(p) };
+    Some(s)
+}
+
+fn take_envelope() -> Option<Value> {
+    take_last_error().map(|json| {
+        serde_json::from_str(&json).expect("aimux_last_error must return a valid JSON envelope")
+    })
+}
+
+/// A model handle that can be used with `aimux_generate_text` / `aimux_stream_text`.
+fn valid_handle() -> u64 {
+    let h = aimux_openai_new(c("sk-test-fake-key").as_ptr(), c("gpt-4o-mini").as_ptr());
+    assert!(h != 0, "expected a valid handle for the test fixture");
+    h
+}
+
+// ── Problem A: prompt_json serde detail ─────────────────────────────────────
+
+#[test]
+fn generate_text_invalid_prompt_json_carries_serde_detail() {
+    let h = valid_handle();
+    let out = aimux_generate_text(h, c("hello").as_ptr(), ptr::null());
+    assert!(!out.is_null(), "expected an error JSON string");
+    // SAFETY: aimux_generate_text returns a NUL-terminated string we own.
+    let json = unsafe { CStr::from_ptr(out) }.to_str().unwrap().to_string();
+    unsafe { aimux_free_string(out) };
+
+    let env: Value = serde_json::from_str(&json).expect("error must be a JSON envelope");
+    let msg = env["error"].as_str().expect("envelope has error field");
+    assert!(
+        msg.starts_with("invalid prompt_json:"),
+        "expected serde detail in message, got: {msg}"
+    );
+    assert!(
+        msg.contains("line") && msg.contains("column"),
+        "expected serde line/column detail, got: {msg}"
+    );
+    assert_eq!(env["error_type"], "Other");
+    assert!(env["status_code"].is_null());
+
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn generate_text_null_prompt_json_reports_invalid_prompt() {
+    let h = valid_handle();
+    let out = aimux_generate_text(h, ptr::null(), ptr::null());
+    assert!(!out.is_null());
+    // SAFETY: as above.
+    let json = unsafe { CStr::from_ptr(out) }.to_str().unwrap().to_string();
+    unsafe { aimux_free_string(out) };
+    assert!(json.contains("invalid prompt_json"), "got: {json}");
+    aimux_drop_handle(h);
+}
+
+static STREAM_ERRORS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+extern "C" fn on_part(_json: *const std::os::raw::c_char) {}
+extern "C" fn on_done() {}
+
+extern "C" fn on_error(json: *const std::os::raw::c_char) {
+    // SAFETY: the FFI layer guarantees the pointer is valid during the call.
+    let s = unsafe { CStr::from_ptr(json) }.to_str().unwrap().to_string();
+    STREAM_ERRORS.lock().unwrap().push(s);
+}
+
+#[test]
+fn stream_text_invalid_prompt_json_carries_serde_detail() {
+    let h = valid_handle();
+    STREAM_ERRORS.lock().unwrap().clear();
+
+    aimux_stream_text(h, c("hello").as_ptr(), ptr::null(), on_part, on_done, on_error);
+
+    let errors = STREAM_ERRORS.lock().unwrap().clone();
+    assert_eq!(errors.len(), 1, "expected exactly one on_error callback");
+    let env: Value = serde_json::from_str(&errors[0]).expect("error must be a JSON envelope");
+    let msg = env["error"].as_str().expect("envelope has error field");
+    assert!(
+        msg.starts_with("invalid prompt_json:"),
+        "expected serde detail in message, got: {msg}"
+    );
+    assert!(msg.contains("line"), "expected serde line detail, got: {msg}");
+
+    aimux_drop_handle(h);
+}
+
+// ── Problem B: constructor failures via aimux_last_error ────────────────────
+
+#[test]
+fn unknown_provider_reports_full_error_envelope() {
+    let h = aimux_provider_new(
+        c("this-provider-does-not-exist").as_ptr(),
+        c("sk-x").as_ptr(),
+        c("gpt-4o-mini").as_ptr(),
+        ptr::null(),
+    );
+    assert_eq!(h, 0, "unknown provider must fail");
+
+    let env = take_envelope().expect("last_error must be set after a failed constructor");
+    let msg = env["error"].as_str().unwrap();
+    assert!(msg.contains("unknown provider"), "got: {msg}");
+    assert!(msg.contains("available providers"), "got: {msg}");
+    assert_eq!(env["error_type"], "UnknownProvider");
+    assert!(env["status_code"].is_null());
+}
+
+#[test]
+fn invalid_config_json_reports_json_error_type() {
+    let h = aimux_provider_new(
+        c("openai").as_ptr(),
+        c("sk-x").as_ptr(),
+        c("gpt-4o-mini").as_ptr(),
+        c("{bad json").as_ptr(),
+    );
+    assert_eq!(h, 0, "malformed config_json must fail");
+
+    let env = take_envelope().expect("last_error must be set");
+    assert!(env["error"].as_str().unwrap().starts_with("invalid config_json:"), "got: {env}");
+    assert_eq!(env["error_type"], "Json");
+}
+
+#[test]
+fn null_arguments_report_invalid_argument_type() {
+    let h = aimux_openai_new(ptr::null(), ptr::null());
+    assert_eq!(h, 0);
+
+    let env = take_envelope().expect("last_error must be set");
+    assert_eq!(env["error_type"], "InvalidArgument");
+    assert!(
+        env["error"].as_str().unwrap().contains("null or invalid UTF-8"),
+        "got: {env}"
+    );
+}
+
+#[test]
+fn azure_missing_required_argument_reports_invalid_argument() {
+    // resource_name is a required FFI argument; passing NULL fails at the
+    // boundary with an InvalidArgument envelope (the Azure provider's own
+    // InvalidArgument can't be reached from the FFI layer because the
+    // argument is mandatory).
+    let h = aimux_azure_new(c("k").as_ptr(), ptr::null(), c("deploy").as_ptr(), ptr::null());
+    assert_eq!(h, 0);
+
+    let env = take_envelope().expect("last_error must be set");
+    assert_eq!(env["error_type"], "InvalidArgument");
+}
+
+// ── TLS semantics ───────────────────────────────────────────────────────────
+
+#[test]
+fn successful_constructor_clears_previous_error() {
+    // 1. Fail and leave the error unread.
+    assert_eq!(
+        aimux_provider_new(
+            c("no-such-provider").as_ptr(),
+            c("k").as_ptr(),
+            c("m").as_ptr(),
+            ptr::null(),
+        ),
+        0
+    );
+    assert!(take_last_error().is_some(), "precondition: error recorded");
+
+    // 2. Fail again so the slot is repopulated, then succeed WITHOUT reading.
+    assert_eq!(
+        aimux_provider_new(
+            c("also-no-such").as_ptr(),
+            c("k").as_ptr(),
+            c("m").as_ptr(),
+            ptr::null(),
+        ),
+        0
+    );
+    let h = aimux_provider_new(
+        c("groq").as_ptr(),
+        c("sk-test").as_ptr(),
+        c("llama-3.3-70b").as_ptr(),
+        ptr::null(),
+    );
+    assert!(h != 0, "a registered provider with a fake key must construct");
+
+    // 3. The success must have cleared the stale error.
+    assert!(
+        take_last_error().is_none(),
+        "successful constructor must clear the previous error"
+    );
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn last_error_is_overwritten_and_read_once() {
+    aimux_provider_new(
+        c("no-such-a").as_ptr(),
+        c("k").as_ptr(),
+        c("m").as_ptr(),
+        ptr::null(),
+    );
+    aimux_provider_new(
+        c("no-such-b").as_ptr(),
+        c("k").as_ptr(),
+        c("m").as_ptr(),
+        ptr::null(),
+    );
+
+    // Last write wins.
+    let env = take_envelope().expect("last_error must be set");
+    assert!(env["error"].as_str().unwrap().contains("no-such-b"), "got: {env}");
+
+    // Read-and-clear: a second read returns NULL.
+    assert!(take_last_error().is_none(), "second read must be NULL");
+}
+
+#[test]
+fn last_error_is_thread_local() {
+    let t1 = std::thread::spawn(|| {
+        aimux_provider_new(
+            c("no-such-thread-a").as_ptr(),
+            c("k").as_ptr(),
+            c("m").as_ptr(),
+            ptr::null(),
+        );
+        take_last_error().expect("thread 1 must see its own error")
+    });
+    let t2 = std::thread::spawn(|| {
+        aimux_provider_new(
+            c("no-such-thread-b").as_ptr(),
+            c("k").as_ptr(),
+            c("m").as_ptr(),
+            ptr::null(),
+        );
+        take_last_error().expect("thread 2 must see its own error")
+    });
+
+    let (e1, e2) = (t1.join().unwrap(), t2.join().unwrap());
+    assert!(e1.contains("no-such-thread-a"), "thread 1 got: {e1}");
+    assert!(e2.contains("no-such-thread-b"), "thread 2 got: {e2}");
+}
+
+#[test]
+fn no_error_returns_null_without_a_constructor_call() {
+    // The main thread never failed a constructor here; the slot must be empty
+    // (nothing to read, nothing to free).
+    assert!(take_last_error().is_none());
+}

--- a/bindings/c/example.c
+++ b/bindings/c/example.c
@@ -24,6 +24,18 @@ static void on_error(const char *err_json) {
     fprintf(stderr, "STREAM ERROR: %s\n", err_json);
 }
 
+// Print the thread-local last-constructor error (issue #17), if any, then
+// free it. Call right after a constructor returned 0, on the same thread.
+static void print_last_error(const char *fallback) {
+    char *err = aimux_last_error();
+    if (err) {
+        fprintf(stderr, "%s — %s\n", fallback, err);
+        aimux_free_string(err);
+    } else {
+        fprintf(stderr, "%s\n", fallback);
+    }
+}
+
 int main(void) {
     const char *api_key = getenv("OPENAI_API_KEY");
     if (!api_key) {
@@ -34,7 +46,7 @@ int main(void) {
     // 1. Create model
     uint64_t handle = aimux_openai_new(api_key, "gpt-4o-mini");
     if (handle == 0) {
-        fprintf(stderr, "Failed to create model\n");
+        print_last_error("Failed to create model");
         return 1;
     }
     printf("Model created: handle=%lu\n", (unsigned long)handle);
@@ -59,8 +71,8 @@ int main(void) {
         printf("DeepSeek (registry): handle=%lu\n", (unsigned long)ds_handle);
         aimux_drop_handle(ds_handle);
     } else {
-        fprintf(stderr, "Failed to create DeepSeek via registry "
-                        "(is DEEPSEEK_API_KEY set?)\n");
+        print_last_error("Failed to create DeepSeek via registry "
+                         "(is DEEPSEEK_API_KEY set?)");
     }
 
     // 4. Cleanup

--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -296,6 +296,11 @@ func mustNew(m *Model, err error) *Model {
 }
 
 func newModel(apiKey, modelID, baseURL, kind string) (*Model, error) {
+	// Constructor + last_error read must run on the same OS thread
+	// (aimux_last_error is thread-local). Constructors are pure config
+	// building, so pinning the thread is cheap.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	m := &Model{}
 	cKey := C.CString(apiKey)
 	cModel := C.CString(modelID)
@@ -333,7 +338,7 @@ func newModel(apiKey, modelID, baseURL, kind string) (*Model, error) {
 		}
 	}
 	if h == 0 {
-		return nil, errors.New("aimux: failed to create model (handle=0)")
+		return nil, takeLastError("aimux: failed to create model (handle=0)")
 	}
 	m.handle = uint64(h)
 
@@ -427,8 +432,12 @@ func newAzureModel(apiKey, resourceOrBase, deployment, apiVersion string, useBas
 }
 
 func wrapHandle(m *Model, h C.uint64_t) (*Model, error) {
+	// Constructor + last_error read must run on the same OS thread
+	// (aimux_last_error is thread-local).
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if h == 0 {
-		return nil, errors.New("aimux: failed to create model (handle=0)")
+		return nil, takeLastError("aimux: failed to create model (handle=0)")
 	}
 	m.handle = uint64(h)
 	runtime.SetFinalizer(m, func(m *Model) { m.Close() })
@@ -445,6 +454,10 @@ func Provider(name, apiKey, modelID string) (*Model, error) {
 
 // ProviderWithBase is Provider with a base URL override (config_json).
 func ProviderWithBase(name, apiKey, modelID, baseURL string) (*Model, error) {
+	// Constructor + last_error read must run on the same OS thread
+	// (aimux_last_error is thread-local).
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	m := &Model{}
 	cName := C.CString(name)
 	cModel := C.CString(modelID)
@@ -466,7 +479,7 @@ func ProviderWithBase(name, apiKey, modelID, baseURL string) (*Model, error) {
 
 	h := C.aimux_provider_new(cName, cKey, cModel, cConfig)
 	if h == 0 {
-		return nil, fmt.Errorf("aimux: failed to create provider %q (handle=0)", name)
+		return nil, takeLastError(fmt.Sprintf("aimux: failed to create provider %q (handle=0)", name))
 	}
 	m.handle = uint64(h)
 	runtime.SetFinalizer(m, func(m *Model) { m.Close() })
@@ -527,6 +540,21 @@ func extractError(result string) string {
 		return *envelope.Error
 	}
 	return ""
+}
+
+// takeLastError reads the FFI thread-local last-constructor error (issue #17)
+// and wraps it into a Go error. The failed constructor and this read must run
+// on the same OS thread — callers wrap both in runtime.LockOSThread.
+func takeLastError(fallback string) error {
+	if eptr := C.aimux_last_error(); eptr != nil {
+		defer C.aimux_free_string(eptr)
+		msg := C.GoString(eptr)
+		if extracted := extractError(msg); extracted != "" {
+			return fmt.Errorf("aimux: %s", extracted)
+		}
+		return fmt.Errorf("aimux: %s", msg)
+	}
+	return errors.New(fallback)
 }
 
 // ── Streaming generation ─────────────────────────────────────────────────────

--- a/bindings/go/multimodal.go
+++ b/bindings/go/multimodal.go
@@ -98,9 +98,13 @@ func callFFIString(h *multimodalHandle, fn func(handle C.uint64_t) *C.char) (str
 
 // newMultimodalHandle calls a C constructor and returns a handle wrapper.
 func newMultimodalHandle(fn func() C.uint64_t) (*multimodalHandle, error) {
+	// Constructor + last_error read must run on the same OS thread
+	// (aimux_last_error is thread-local).
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	h := C.uint64_t(fn())
 	if h == 0 {
-		return nil, errors.New("aimux: failed to create model (handle=0)")
+		return nil, takeLastError("aimux: failed to create model (handle=0)")
 	}
 	mh := &multimodalHandle{handle: uint64(h)}
 	return mh, nil

--- a/bindings/java/src/main/java/io/aimux/AimuxFFI.java
+++ b/bindings/java/src/main/java/io/aimux/AimuxFFI.java
@@ -89,6 +89,15 @@ public interface AimuxFFI extends Library {
 
     void aimux_free_string(Pointer ptr);
 
+    /**
+     * Take (read-and-clear) the last constructor error on this thread.
+     *
+     * @return Error JSON envelope {@code {"error","error_type","status_code"}},
+     *         or {@code null} if the last constructor call on this thread
+     *         succeeded. Caller MUST free with {@link #aimux_free_string}.
+     */
+    Pointer aimux_last_error();
+
     // ── Embedding ───────────────────────────────────────────────────────────
 
     long aimux_openai_embedding_new(String apiKey, String modelId);

--- a/bindings/java/src/main/java/io/aimux/Model.java
+++ b/bindings/java/src/main/java/io/aimux/Model.java
@@ -1,5 +1,7 @@
 package io.aimux;
 
+import com.sun.jna.Pointer;
+
 import java.io.Closeable;
 import java.util.Spliterator;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -63,13 +65,42 @@ public class Model implements Closeable {
         return h;
     }
 
+    /**
+     * Build a constructor-failure message from the FFI thread-local error
+     * (issue #17). Must be called immediately after a constructor returned 0.
+     *
+     * @param fallback Message used when the native layer has no detail.
+     */
+    private static String constructorFailure(String fallback) {
+        Pointer ptr = AimuxFFI.INSTANCE.aimux_last_error();
+        if (ptr == null) {
+            return fallback;
+        }
+        String detail;
+        try {
+            detail = ptr.getString(0, "UTF-8");
+        } finally {
+            AimuxFFI.INSTANCE.aimux_free_string(ptr);
+        }
+        // Envelope: {"error":"<msg>","error_type":"<type>","status_code":...}.
+        // Extract the "error" field so the exception message stays readable.
+        Matcher m = ERROR_FIELD.matcher(detail);
+        if (m.find()) {
+            return m.group(1).replace("\\\"", "\"").replace("\\\\", "\\");
+        }
+        return detail;
+    }
+
+    private static final java.util.regex.Pattern ERROR_FIELD = java.util.regex.Pattern.compile(
+        "\"error\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"");
+
     // ── Provider constructors ──────────────────────────────────────────────
 
     /** Create an OpenAI model instance. */
     public static Model openai(String apiKey, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_openai_new(apiKey, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create OpenAI model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create OpenAI model"));
         }
         return new Model(h);
     }
@@ -78,7 +109,7 @@ public class Model implements Closeable {
     public static Model openaiWithBase(String apiKey, String modelId, String baseUrl) {
         long h = AimuxFFI.INSTANCE.aimux_openai_new_with_base(apiKey, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create OpenAI model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create OpenAI model"));
         }
         return new Model(h);
     }
@@ -87,7 +118,7 @@ public class Model implements Closeable {
     public static Model anthropic(String apiKey, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_anthropic_new(apiKey, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Anthropic model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic model"));
         }
         return new Model(h);
     }
@@ -96,7 +127,7 @@ public class Model implements Closeable {
     public static Model anthropicWithBase(String apiKey, String modelId, String baseUrl) {
         long h = AimuxFFI.INSTANCE.aimux_anthropic_new_with_base(apiKey, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Anthropic model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic model"));
         }
         return new Model(h);
     }
@@ -105,7 +136,7 @@ public class Model implements Closeable {
     public static Model cohere(String apiKey, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_cohere_new(apiKey, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Cohere model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Cohere model"));
         }
         return new Model(h);
     }
@@ -114,7 +145,7 @@ public class Model implements Closeable {
     public static Model cohereWithBase(String apiKey, String modelId, String baseUrl) {
         long h = AimuxFFI.INSTANCE.aimux_cohere_new_with_base(apiKey, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Cohere model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Cohere model"));
         }
         return new Model(h);
     }
@@ -123,7 +154,7 @@ public class Model implements Closeable {
     public static Model mistral(String apiKey, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_mistral_new(apiKey, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Mistral model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Mistral model"));
         }
         return new Model(h);
     }
@@ -132,7 +163,7 @@ public class Model implements Closeable {
     public static Model mistralWithBase(String apiKey, String modelId, String baseUrl) {
         long h = AimuxFFI.INSTANCE.aimux_mistral_new_with_base(apiKey, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Mistral model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Mistral model"));
         }
         return new Model(h);
     }
@@ -141,7 +172,7 @@ public class Model implements Closeable {
     public static Model xai(String apiKey, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_xai_new(apiKey, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create xAI model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create xAI model"));
         }
         return new Model(h);
     }
@@ -150,7 +181,7 @@ public class Model implements Closeable {
     public static Model xaiWithBase(String apiKey, String modelId, String baseUrl) {
         long h = AimuxFFI.INSTANCE.aimux_xai_new_with_base(apiKey, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create xAI model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create xAI model"));
         }
         return new Model(h);
     }
@@ -159,7 +190,7 @@ public class Model implements Closeable {
     public static Model bedrock(String accessKeyId, String secretAccessKey, String region, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_bedrock_new(accessKeyId, secretAccessKey, region, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Bedrock model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Bedrock model"));
         }
         return new Model(h);
     }
@@ -170,7 +201,7 @@ public class Model implements Closeable {
         long h = AimuxFFI.INSTANCE.aimux_bedrock_new_with_base(
             accessKeyId, secretAccessKey, region, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Bedrock model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Bedrock model"));
         }
         return new Model(h);
     }
@@ -179,7 +210,7 @@ public class Model implements Closeable {
     public static Model vertex(String accessToken, String project, String location, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_vertex_new(accessToken, project, location, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Vertex model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Vertex model"));
         }
         return new Model(h);
     }
@@ -190,7 +221,7 @@ public class Model implements Closeable {
         long h = AimuxFFI.INSTANCE.aimux_vertex_new_with_base(
             accessToken, project, location, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Vertex model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Vertex model"));
         }
         return new Model(h);
     }
@@ -199,7 +230,7 @@ public class Model implements Closeable {
     public static Model anthropicAws(String apiKey, String region, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_anthropic_aws_new(apiKey, region, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Anthropic AWS model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic AWS model"));
         }
         return new Model(h);
     }
@@ -208,7 +239,7 @@ public class Model implements Closeable {
     public static Model anthropicAwsWithBase(String apiKey, String region, String modelId, String baseUrl) {
         long h = AimuxFFI.INSTANCE.aimux_anthropic_aws_new_with_base(apiKey, region, modelId, baseUrl);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Anthropic AWS model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic AWS model"));
         }
         return new Model(h);
     }
@@ -217,7 +248,7 @@ public class Model implements Closeable {
     public static Model azure(String apiKey, String resourceName, String deployment) {
         long h = AimuxFFI.INSTANCE.aimux_azure_new(apiKey, resourceName, deployment, null);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Azure model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Azure model"));
         }
         return new Model(h);
     }
@@ -227,7 +258,7 @@ public class Model implements Closeable {
                                          String apiVersion) {
         long h = AimuxFFI.INSTANCE.aimux_azure_new(apiKey, resourceName, deployment, apiVersion);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Azure model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Azure model"));
         }
         return new Model(h);
     }
@@ -236,7 +267,7 @@ public class Model implements Closeable {
     public static Model azureWithBase(String apiKey, String baseUrl, String deployment) {
         long h = AimuxFFI.INSTANCE.aimux_azure_new_with_base(apiKey, baseUrl, deployment, null);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create Azure model");
+            throw new IllegalArgumentException(constructorFailure("Failed to create Azure model"));
         }
         return new Model(h);
     }
@@ -258,7 +289,8 @@ public class Model implements Closeable {
     public static Model provider(String name, String apiKey, String modelId, String configJson) {
         long h = AimuxFFI.INSTANCE.aimux_provider_new(name, apiKey, modelId, configJson);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create provider model: " + name);
+            throw new IllegalArgumentException(
+                constructorFailure("Failed to create provider model: " + name));
         }
         return new Model(h);
     }
@@ -270,7 +302,8 @@ public class Model implements Closeable {
     public static Model providerFromEnv(String name, String modelId) {
         long h = AimuxFFI.INSTANCE.aimux_provider_from_env(name, modelId);
         if (h == 0L) {
-            throw new IllegalArgumentException("Failed to create provider model from env: " + name);
+            throw new IllegalArgumentException(
+                constructorFailure("Failed to create provider model from env: " + name));
         }
         return new Model(h);
     }

--- a/bindings/java/src/main/java/io/aimux/Model.java
+++ b/bindings/java/src/main/java/io/aimux/Model.java
@@ -84,7 +84,7 @@ public class Model implements Closeable {
         }
         // Envelope: {"error":"<msg>","error_type":"<type>","status_code":...}.
         // Extract the "error" field so the exception message stays readable.
-        Matcher m = ERROR_FIELD.matcher(detail);
+        java.util.regex.Matcher m = ERROR_FIELD.matcher(detail);
         if (m.find()) {
             return m.group(1).replace("\\\"", "\"").replace("\\\\", "\\");
         }


### PR DESCRIPTION
## Summary

Fixes #17 — the C ABI layer (`aimux-ffi`, shared by Go/Java/Kotlin/Swift/Flutter/C) dropped detailed errors in two places.

### Problem A — `prompt_json` / `config_json` parse errors lost
`aimux_generate_text` / `aimux_stream_text` discarded the `serde_json::Error` from `prompt_json` (callers only saw `"invalid prompt_json"`); `aimux_provider_new` also swallowed `config_json` parse errors (`Err(_) => return 0`). Both now report the serde detail exactly like the adjacent `opts_json` branch already did.

### Problem B — all constructors reduced `AiMuxError` to a bare `0`
20 language-model constructors (and every multimodal constructor for null args) dropped the full `AiMuxError` (e.g. `UnknownProvider` with the available-provider list, missing env var, bad config). Solution without breaking the ABI (55 symbols untouched, 1 added):

- thread-local error slot + `aimux_last_error()`: read-and-clear, returns the existing error JSON envelope `{"error","error_type","status_code"}`, caller frees with `aimux_free_string`
- every `u64` constructor clears the slot on entry, records the envelope on failure, stays empty on success; null/invalid-UTF-8 args record `InvalidArgument`

### Bindings
- **Go**: `takeLastError()` helper; `runtime.LockOSThread()` around constructor+read in `newModel`, `wrapHandle`, `ProviderWithBase`, `newMultimodalHandle` (constructors are pure config building, so pinning is cheap)
- **Java**: JNA `aimux_last_error()` declared as `Pointer` (released via `aimux_free_string`); `constructorFailure()` extracts the `error` field for all 21 model factories
- **C**: `example.c` prints the detailed error on constructor failure

Kotlin/Swift/Flutter call the same symbols and can adopt `aimux_last_error()` the same way (thread-affinity note in the header docs); not changed in this PR.

## Verification

- `cargo test -p aimux-ffi`: **15 passed** (11 new regression tests in `error_detail_test.rs` + 4 existing smoke tests)
- `cargo check --workspace`: clean
- New tests cover: serde detail in prompt errors, `UnknownProvider`/`Json`/`InvalidArgument` envelopes, clear-on-success, last-write-wins, read-once, TLS isolation
- ⚠️ Go and Java bindings could not be compiled on this Windows machine (no gcc for cgo / no JDK) — they are static-only changes following existing patterns; CI will verify

## Notes

- ABI: only `aimux_last_error()` is added; `0` remains the documented failure sentinel
- `aimux_last_error()` semantics (destructive read, same OS thread as the failed constructor, caller-owned pointer) are documented in `aimux-ffi.h`
