### PR TITLE
fix(ffi): constructors return JSON handle/error envelope, replacing aimux_last_error (issue #17)

### DIFF
--- a/aimux-ffi/aimux-ffi.h
+++ b/aimux-ffi/aimux-ffi.h
@@ -7,11 +7,11 @@
  *
  * ## Memory ownership
  *
- * - `aimux_generate_text` returns a `char*` owned by the caller; the caller
- *   MUST free it with `aimux_free_string`.
- * - `aimux_stream_text` callbacks receive `const char*` pointers that are
- *   valid **only for the duration of the callback**. The callback must copy
- *   the data synchronously.
+ * Every function that returns `char*` — constructors included — returns a
+ * string owned by the caller; the caller MUST free it with
+ * `aimux_free_string`. `aimux_stream_text` callbacks receive `const char*`
+ * pointers that are valid **only for the duration of the callback**. The
+ * callback must copy the data synchronously.
  *
  * ## Concurrency
  *
@@ -25,6 +25,9 @@
  * - `opts_json`: serialized GenerateTextOptions (empty/null for defaults)
  * - Results: serialized JSON of GenerateTextResult, or `{"error":"..."}`
  * - Stream parts: serialized JSON of StreamPart
+ * - Constructors: `{"handle":<u64>}` on success, or
+ *   `{"error":"...","error_type":"...","status_code":<u16|null>}` on failure
+ *   (the same envelope shape `aimux_generate_text` returns on failure).
  */
 
 #ifndef AIMUX_FFI_H
@@ -43,9 +46,10 @@ extern "C" {
  *
  * @param api_key  NUL-terminated API key string.
  * @param model_id NUL-terminated model ID (e.g. "gpt-4o").
- * @return Opaque handle (>0 on success, 0 on failure).
+ * @return JSON string (caller MUST free with aimux_free_string):
+ *         `{"handle":<u64>}` on success, `{"error":...}` on failure.
  */
-uint64_t aimux_openai_new(const char *api_key, const char *model_id);
+char *aimux_openai_new(const char *api_key, const char *model_id);
 
 /**
  * Create an OpenAI model instance with a custom base URL.
@@ -53,20 +57,22 @@ uint64_t aimux_openai_new(const char *api_key, const char *model_id);
  * @param api_key  NUL-terminated API key string.
  * @param model_id NUL-terminated model ID (e.g. "gpt-4o").
  * @param base_url NUL-terminated base URL (NULL or empty uses the provider default).
- * @return Opaque handle (>0 on success, 0 on failure).
+ * @return JSON string (caller MUST free with aimux_free_string):
+ *         `{"handle":<u64>}` on success, `{"error":...}` on failure.
  */
-uint64_t aimux_openai_new_with_base(const char *api_key,
-                                    const char *model_id,
-                                    const char *base_url);
+char *aimux_openai_new_with_base(const char *api_key,
+                                 const char *model_id,
+                                 const char *base_url);
 
 /**
  * Create an Anthropic model instance.
  *
  * @param api_key  NUL-terminated API key string.
  * @param model_id NUL-terminated model ID (e.g. "claude-3-5-sonnet-20241022").
- * @return Opaque handle (>0 on success, 0 on failure).
+ * @return JSON string (caller MUST free with aimux_free_string):
+ *         `{"handle":<u64>}` on success, `{"error":...}` on failure.
  */
-uint64_t aimux_anthropic_new(const char *api_key, const char *model_id);
+char *aimux_anthropic_new(const char *api_key, const char *model_id);
 
 /**
  * Create an Anthropic model instance with a custom base URL.
@@ -74,78 +80,93 @@ uint64_t aimux_anthropic_new(const char *api_key, const char *model_id);
  * @param api_key  NUL-terminated API key string.
  * @param model_id NUL-terminated model ID (e.g. "claude-3-5-sonnet-20241022").
  * @param base_url NUL-terminated base URL (NULL or empty uses the provider default).
- * @return Opaque handle (>0 on success, 0 on failure).
+ * @return JSON string (caller MUST free with aimux_free_string):
+ *         `{"handle":<u64>}` on success, `{"error":...}` on failure.
  */
-uint64_t aimux_anthropic_new_with_base(const char *api_key,
-                                       const char *model_id,
-                                       const char *base_url);
-
-/**
- * Create a Cohere model instance (API key + model ID).
- */
-uint64_t aimux_cohere_new(const char *api_key, const char *model_id);
-uint64_t aimux_cohere_new_with_base(const char *api_key,
+char *aimux_anthropic_new_with_base(const char *api_key,
                                     const char *model_id,
                                     const char *base_url);
 
 /**
- * Create a Mistral model instance (API key + model ID).
+ * Create a Cohere model instance (API key + model ID). Returns a JSON
+ * string (caller MUST free with aimux_free_string): `{"handle":<u64>}` on
+ * success, `{"error":...}` on failure.
  */
-uint64_t aimux_mistral_new(const char *api_key, const char *model_id);
-uint64_t aimux_mistral_new_with_base(const char *api_key,
-                                     const char *model_id,
-                                     const char *base_url);
-
-/**
- * Create an xAI model instance (API key + model ID).
- */
-uint64_t aimux_xai_new(const char *api_key, const char *model_id);
-uint64_t aimux_xai_new_with_base(const char *api_key,
+char *aimux_cohere_new(const char *api_key, const char *model_id);
+char *aimux_cohere_new_with_base(const char *api_key,
                                  const char *model_id,
                                  const char *base_url);
 
 /**
- * Create a Bedrock model instance (AWS SigV4 credentials).
+ * Create a Mistral model instance (API key + model ID). Returns a JSON
+ * string (caller MUST free with aimux_free_string): `{"handle":<u64>}` on
+ * success, `{"error":...}` on failure.
  */
-uint64_t aimux_bedrock_new(const char *access_key_id,
-                           const char *secret_access_key,
-                           const char *region,
-                           const char *model_id);
-uint64_t aimux_bedrock_new_with_base(const char *access_key_id,
-                                     const char *secret_access_key,
-                                     const char *region,
-                                     const char *model_id,
-                                     const char *base_url);
+char *aimux_mistral_new(const char *api_key, const char *model_id);
+char *aimux_mistral_new_with_base(const char *api_key,
+                                  const char *model_id,
+                                  const char *base_url);
 
 /**
- * Create a Vertex AI model instance (GCP bearer token).
+ * Create an xAI model instance (API key + model ID). Returns a JSON
+ * string (caller MUST free with aimux_free_string): `{"handle":<u64>}` on
+ * success, `{"error":...}` on failure.
  */
-uint64_t aimux_vertex_new(const char *access_token,
-                          const char *project,
-                          const char *location,
-                          const char *model_id);
-uint64_t aimux_vertex_new_with_base(const char *access_token,
-                                    const char *project,
-                                    const char *location,
-                                    const char *model_id,
-                                    const char *base_url);
+char *aimux_xai_new(const char *api_key, const char *model_id);
+char *aimux_xai_new_with_base(const char *api_key,
+                              const char *model_id,
+                              const char *base_url);
 
 /**
- * Create an Anthropic-on-AWS model instance (API key + region).
+ * Create a Bedrock model instance (AWS SigV4 credentials). Returns a JSON
+ * string (caller MUST free with aimux_free_string): `{"handle":<u64>}` on
+ * success, `{"error":...}` on failure.
  */
-uint64_t aimux_anthropic_aws_new(const char *api_key, const char *region,
-                                 const char *model_id);
-uint64_t aimux_anthropic_aws_new_with_base(const char *api_key, const char *region,
-                                           const char *model_id, const char *base_url);
+char *aimux_bedrock_new(const char *access_key_id,
+                        const char *secret_access_key,
+                        const char *region,
+                        const char *model_id);
+char *aimux_bedrock_new_with_base(const char *access_key_id,
+                                  const char *secret_access_key,
+                                  const char *region,
+                                  const char *model_id,
+                                  const char *base_url);
+
+/**
+ * Create a Vertex AI model instance (GCP bearer token). Returns a JSON
+ * string (caller MUST free with aimux_free_string): `{"handle":<u64>}` on
+ * success, `{"error":...}` on failure.
+ */
+char *aimux_vertex_new(const char *access_token,
+                       const char *project,
+                       const char *location,
+                       const char *model_id);
+char *aimux_vertex_new_with_base(const char *access_token,
+                                 const char *project,
+                                 const char *location,
+                                 const char *model_id,
+                                 const char *base_url);
+
+/**
+ * Create an Anthropic-on-AWS model instance (API key + region). Returns a
+ * JSON string (caller MUST free with aimux_free_string): `{"handle":<u64>}`
+ * on success, `{"error":...}` on failure.
+ */
+char *aimux_anthropic_aws_new(const char *api_key, const char *region,
+                              const char *model_id);
+char *aimux_anthropic_aws_new_with_base(const char *api_key, const char *region,
+                                        const char *model_id, const char *base_url);
 
 /**
  * Create an Azure OpenAI model instance (API key + resource name; deployment
- * passed as model_id; api_version NULL uses the provider default).
+ * passed as model_id; api_version NULL uses the provider default). Returns a
+ * JSON string (caller MUST free with aimux_free_string): `{"handle":<u64>}`
+ * on success, `{"error":...}` on failure.
  */
-uint64_t aimux_azure_new(const char *api_key, const char *resource_name,
-                         const char *deployment, const char *api_version);
-uint64_t aimux_azure_new_with_base(const char *api_key, const char *base_url,
-                                   const char *deployment, const char *api_version);
+char *aimux_azure_new(const char *api_key, const char *resource_name,
+                      const char *deployment, const char *api_version);
+char *aimux_azure_new_with_base(const char *api_key, const char *base_url,
+                                const char *deployment, const char *api_version);
 
 /**
  * Create a model from the provider registry by name (RFC-0017 phase 4).
@@ -158,24 +179,27 @@ uint64_t aimux_azure_new_with_base(const char *api_key, const char *base_url,
  *                    ({"base_url": "...", "headers": {...}, "max_retries": 0,
  *                     "body_overrides": {...}});
  *                    NULL / empty / "null" for defaults.
- * @return Opaque handle (>0 on success, 0 on failure: unknown provider,
- *         bad config, missing env key, or invalid model id).
+ * @return JSON string (caller MUST free with aimux_free_string):
+ *         `{"handle":<u64>}` on success, `{"error":...}` on failure (unknown
+ *         provider, bad config, missing env key, or invalid model id).
  */
-uint64_t aimux_provider_new(const char *name, const char *api_key,
-                            const char *model_id, const char *config_json);
+char *aimux_provider_new(const char *name, const char *api_key,
+                         const char *model_id, const char *config_json);
 
 /**
  * Convenience: create a model by provider name, reading the API key from the
- * provider's env var. Returns 0 on failure.
+ * provider's env var. Returns a JSON string (caller MUST free with
+ * aimux_free_string): `{"handle":<u64>}` on success, `{"error":...}` on
+ * failure.
  */
-uint64_t aimux_provider_from_env(const char *name, const char *model_id);
+char *aimux_provider_from_env(const char *name, const char *model_id);
 
 /* ── Generation ─────────────────────────────────────────────────────────── */
 
 /**
  * Non-streaming text generation.
  *
- * @param handle      Model handle from aimux_*_new.
+ * @param handle      Model handle from aimux_*_new's `{"handle":<u64>}`.
  * @param prompt_json JSON prompt (see wire format above).
  * @param opts_json   JSON options (NULL or empty for defaults).
  * @return JSON result string (caller MUST free with aimux_free_string).
@@ -188,7 +212,7 @@ char *aimux_generate_text(uint64_t handle,
 /**
  * Streaming text generation with push callbacks (blocks until stream ends).
  *
- * @param handle      Model handle from aimux_*_new.
+ * @param handle      Model handle from aimux_*_new's `{"handle":<u64>}`.
  * @param prompt_json JSON prompt (see wire format above).
  * @param opts_json   JSON options (NULL or empty for defaults).
  * @param on_part     Called for each StreamPart (JSON string, valid during call only).
@@ -207,95 +231,70 @@ void aimux_stream_text(uint64_t handle,
 /**
  * Release a model handle. Safe to call with 0 (no-op).
  *
- * @param handle Model handle from aimux_*_new.
+ * @param handle Model handle from aimux_*_new's `{"handle":<u64>}`.
  */
 void aimux_drop_handle(uint64_t handle);
 
 /**
- * Free a string previously returned by aimux_generate_text or other
- * functions returning char*.
+ * Free a string previously returned by aimux_generate_text, any aimux_*_new
+ * constructor, or other functions returning char*.
  *
  * @param ptr Pointer from an aimux_* function (NULL is safe).
  */
 void aimux_free_string(char *ptr);
 
-/**
- * Take (read-and-clear) the last constructor error on this thread.
- *
- * Constructors return a bare handle with 0 reserved for failure, so callers
- * cannot distinguish "unknown provider" from "bad config" from "missing env
- * var". On failure, the constructor records the full error JSON envelope
- * `{"error","error_type","status_code"}`; callers read it back with this
- * function and feed it through their existing error-JSON parser.
- *
- * Semantics:
- * - Returns NULL if the last constructor call on this thread succeeded.
- * - Destructive read: a second call returns NULL.
- * - The returned pointer is owned by the caller; MUST be freed with
- *   aimux_free_string.
- * - Only set by aimux_*_new / aimux_provider_new / aimux_provider_from_env.
- *
- * Threading: the constructor and this read must run on the SAME OS thread,
- * with no other aimux_*_new call in between. Runtimes that can migrate work
- * between OS threads between native calls (Go goroutines, Java virtual
- * threads, Kotlin coroutines) must pin both calls to one thread.
- *
- * @return Error JSON envelope, or NULL (no error).
- */
-char *aimux_last_error(void);
-
 /* ── Embedding ───────────────────────────────────────────────────────────── */
 
-uint64_t aimux_openai_embedding_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
-uint64_t aimux_cohere_embedding_new(const char *api_key, const char *model_id);
-uint64_t aimux_cohere_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
-uint64_t aimux_google_embedding_new(const char *api_key, const char *model_id);
-uint64_t aimux_google_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_embedding_new(const char *api_key, const char *model_id);
+char *aimux_openai_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_cohere_embedding_new(const char *api_key, const char *model_id);
+char *aimux_cohere_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_google_embedding_new(const char *api_key, const char *model_id);
+char *aimux_google_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_embed(uint64_t handle, const char *values_json, const char *opts_json);
 
 /* ── Speech (TTS) ────────────────────────────────────────────────────────── */
 
-uint64_t aimux_openai_speech_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_speech_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_speech_new(const char *api_key, const char *model_id);
+char *aimux_openai_speech_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_speech_generate(uint64_t handle, const char *opts_json);
 
 /* ── Image ──────────────────────────────────────────────────────────────── */
 
-uint64_t aimux_openai_image_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
-uint64_t aimux_google_image_new(const char *api_key, const char *model_id);
-uint64_t aimux_google_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_image_new(const char *api_key, const char *model_id);
+char *aimux_openai_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_google_image_new(const char *api_key, const char *model_id);
+char *aimux_google_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_image_generate(uint64_t handle, const char *opts_json);
 
 /* ── Transcription (STT, non-streaming) ──────────────────────────────────── */
 
-uint64_t aimux_openai_transcription_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_transcription_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_transcription_new(const char *api_key, const char *model_id);
+char *aimux_openai_transcription_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_transcription_generate(uint64_t handle, const char *audio_base64, const char *media_type, const char *opts_json);
 
 /* ── Files ──────────────────────────────────────────────────────────────── */
 
-uint64_t aimux_openai_files_new(const char *api_key);
-uint64_t aimux_openai_files_new_with_base(const char *api_key, const char *base_url);
+char *aimux_openai_files_new(const char *api_key);
+char *aimux_openai_files_new_with_base(const char *api_key, const char *base_url);
 char *aimux_file_upload(uint64_t handle, const char *data_base64, const char *media_type, const char *opts_json);
 
 /* ── Reranking ───────────────────────────────────────────────────────────── */
 
-uint64_t aimux_cohere_reranking_new(const char *api_key, const char *model_id);
-uint64_t aimux_cohere_reranking_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_cohere_reranking_new(const char *api_key, const char *model_id);
+char *aimux_cohere_reranking_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_rerank(uint64_t handle, const char *opts_json);
 
 /* ── Video ───────────────────────────────────────────────────────────────── */
 
-uint64_t aimux_google_video_new(const char *api_key, const char *model_id);
-uint64_t aimux_google_video_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_google_video_new(const char *api_key, const char *model_id);
+char *aimux_google_video_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_video_generate(uint64_t handle, const char *opts_json);
 
 /* ── Search ──────────────────────────────────────────────────────────────── */
 
-uint64_t aimux_tavily_search_new(const char *api_key, const char *model_id);
-uint64_t aimux_tavily_search_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_tavily_search_new(const char *api_key, const char *model_id);
+char *aimux_tavily_search_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_search(uint64_t handle, const char *opts_json);
 
 /* Codex (RFC-0018) */

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -26,7 +26,6 @@
 // design: the C ABI contract requires callers to pass valid pointers (see
 // memory-ownership docs above), so the functions are safe only on the C side.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
@@ -102,19 +101,6 @@ fn intern_handle(h: ModelHandle) -> u64 {
         .expect("aimux-ffi: registry mutex poisoned")
         .insert(handle, h);
     handle
-}
-
-/// Uniform constructor exit (issue #17): on success register the model and
-/// return its handle; on failure record the error in the thread-local slot
-/// (see [`aimux_last_error`]) and return 0.
-fn intern_or_record_lang(result: Result<Box<dyn LanguageModel>, AiMuxError>) -> u64 {
-    match result {
-        Ok(m) => intern_model(Arc::from(m)),
-        Err(e) => {
-            record_error(&e);
-            0
-        }
-    }
 }
 
 /// Look up a model by handle, cloning the `Arc` out of the registry.
@@ -203,77 +189,41 @@ fn into_cstring_raw(s: String) -> *mut c_char {
         .unwrap_or(std::ptr::null_mut())
 }
 
-/// Build an error JSON envelope string.
-///
-/// Output: `{"error":"<message>","error_type":"<variant>","status_code":<u16|null>}`
-fn raw_error_json_string(msg: impl std::fmt::Display) -> String {
+/// Build the error envelope every FFI error path returns:
+/// `{"error":"<message>","error_type":"<variant>","status_code":<u16|null>}`.
+fn error_json(msg: impl std::fmt::Display, error_type: &str, status_code: Option<u16>) -> String {
     serde_json::json!({
         "error": msg.to_string(),
-        "error_type": "Other",
-        "status_code": null,
+        "error_type": error_type,
+        "status_code": status_code,
     })
     .to_string()
 }
 
-/// Build an error JSON envelope string from an `AiMuxError`, preserving the
-/// variant name and HTTP status code for programmatic use by bindings.
-fn error_json_string(err: &AiMuxError) -> String {
-    serde_json::json!({
-        "error": err.to_string(),
-        "error_type": err.error_type(),
-        "status_code": err.status_code(),
-    })
-    .to_string()
-}
-
-/// Build an error JSON string with error type, message, and optional status code.
-///
-/// Output: `{"error":"<message>","error_type":"<variant>","status_code":<u16|null>}`
+/// Build an owned error JSON string for a plain message (`error_type: "Other"`).
 fn error_json_raw(msg: impl std::fmt::Display) -> *mut c_char {
-    into_cstring_raw(raw_error_json_string(msg))
+    into_cstring_raw(error_json(msg, "Other", None))
 }
 
 /// Build an error JSON string from an `AiMuxError`, preserving the variant
 /// name and HTTP status code for programmatic use by bindings.
 fn error_json_from(err: &AiMuxError) -> *mut c_char {
-    into_cstring_raw(error_json_string(err))
+    into_cstring_raw(error_json(err, err.error_type(), err.status_code()))
 }
 
-// Thread-local last-constructor-error slot (issue #17).
-//
-// Constructors return a bare `u64` handle with `0` reserved for failure, so
-// they have no error channel of their own; failures record the full error
-// JSON envelope here and callers read it back with `aimux_last_error`.
-// Always stores a JSON envelope (never plain text) so bindings can parse
-// every value with their existing envelope parser.
-thread_local! {
-    static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+/// Build the success envelope every constructor returns: `{"handle":<u64>}`.
+/// `handle` is always >0 (0 is never interned).
+fn handle_json(handle: u64) -> *mut c_char {
+    into_cstring_raw(serde_json::json!({ "handle": handle }).to_string())
 }
 
-/// Must be called at the entry of every constructor: clears any stale error
-/// left on this thread by a previous failed constructor.
-fn begin_constructor() {
-    LAST_ERROR.with(|slot| *slot.borrow_mut() = None);
-}
+/// Recorded when a constructor's C-string arguments are null or not UTF-8.
+const INVALID_ARGS: &str = "missing or invalid required argument(s): null or invalid UTF-8";
 
-/// Record a constructor failure as an `AiMuxError` envelope.
-fn record_error(err: &AiMuxError) {
-    LAST_ERROR.with(|slot| *slot.borrow_mut() = Some(error_json_string(err)));
-}
-
-/// Record a synthetic constructor failure (null / invalid-UTF-8 arguments,
-/// config JSON parse errors) as an envelope with the given error type.
-fn record_error_msg(msg: impl std::fmt::Display, error_type: &str) {
-    LAST_ERROR.with(|slot| {
-        *slot.borrow_mut() = Some(
-            serde_json::json!({
-                "error": msg.to_string(),
-                "error_type": error_type,
-                "status_code": null,
-            })
-            .to_string(),
-        )
-    });
+/// Error envelope for null / invalid-UTF-8 constructor arguments
+/// (`error_type: "InvalidArgument"`).
+fn invalid_args_json() -> *mut c_char {
+    into_cstring_raw(error_json(INVALID_ARGS, "InvalidArgument", None))
 }
 
 /// Invoke the `on_error` callback with an error JSON string.
@@ -281,14 +231,14 @@ fn record_error_msg(msg: impl std::fmt::Display, error_type: &str) {
 /// The pointer is valid only for the duration of the callback (no leak: the
 /// backing `CString` is freed when this function returns).
 fn fire_error(on_error: extern "C" fn(*const c_char), msg: impl std::fmt::Display) {
-    if let Ok(cstr) = CString::new(raw_error_json_string(msg)) {
+    if let Ok(cstr) = CString::new(error_json(msg, "Other", None)) {
         on_error(cstr.as_ptr());
     }
 }
 
 /// Like `fire_error` but preserves the `AiMuxError` variant name and status code.
 fn fire_error_struct(on_error: extern "C" fn(*const c_char), err: &AiMuxError) {
-    if let Ok(cstr) = CString::new(error_json_string(err)) {
+    if let Ok(cstr) = CString::new(error_json(err, err.error_type(), err.status_code())) {
         on_error(cstr.as_ptr());
     }
 }
@@ -359,100 +309,90 @@ fn parse_json_arg<T: DeserializeOwned>(json: *const c_char, name: &str) -> Resul
 // C ABI: provider constructors
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Create an OpenAI model instance, returning its opaque handle.
+/// Create an OpenAI model instance.
 ///
-/// Returns `0` on failure (null arguments or invalid model id).
+/// Returns `{"handle":<u64>}` on success, `{"error":...}` on failure (null
+/// arguments or invalid model id).
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_openai_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_openai_new(api_key: *const c_char, model_id: *const c_char) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(OpenAIProvider::new(OpenAIConfig::new(api_key)).language_model(&model_id))
+    match OpenAIProvider::new(OpenAIConfig::new(api_key)).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create an OpenAI model instance with a custom base URL.
 ///
 /// `base_url` may be null (defaults to the provider's standard URL).
-/// Returns `0` on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_openai_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = OpenAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(OpenAIProvider::new(config).language_model(&model_id))
+    match OpenAIProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
-/// Create an Anthropic model instance, returning its opaque handle.
+/// Create an Anthropic model instance.
 ///
-/// Returns `0` on failure (null arguments or invalid model id).
+/// Returns `{"handle":<u64>}` on success, `{"error":...}` on failure (null
+/// arguments or invalid model id).
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_anthropic_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_anthropic_new(
+    api_key: *const c_char,
+    model_id: *const c_char,
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(
-        AnthropicProvider::new(AnthropicConfig::new(api_key)).language_model(&model_id),
-    )
+    match AnthropicProvider::new(AnthropicConfig::new(api_key)).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create an Anthropic model instance with a custom base URL.
 ///
 /// `base_url` may be null (defaults to the provider's standard URL).
-/// Returns `0` on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_anthropic_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = AnthropicConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(AnthropicProvider::new(config).language_model(&model_id))
+    match AnthropicProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create an Anthropic-on-AWS model instance (API key + region).
-///
-/// Returns `0` on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_anthropic_aws_new(
     api_key: *const c_char,
     region: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(region),
@@ -462,16 +402,14 @@ pub extern "C" fn aimux_anthropic_aws_new(
         _ => None,
     };
     let Some((api_key, region, model_id)) = parsed else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(
-        AnthropicAwsProvider::new(AnthropicAwsProviderConfig::with_api_key(api_key, region))
-            .language_model(&model_id),
-    )
+    match AnthropicAwsProvider::new(AnthropicAwsProviderConfig::with_api_key(api_key, region))
+        .language_model(&model_id)
+    {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create an Anthropic-on-AWS model instance with a custom base URL.
@@ -481,8 +419,7 @@ pub extern "C" fn aimux_anthropic_aws_new_with_base(
     region: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(region),
@@ -492,31 +429,29 @@ pub extern "C" fn aimux_anthropic_aws_new_with_base(
         _ => None,
     };
     let Some((api_key, region, model_id)) = parsed else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = AnthropicAwsProviderConfig::with_api_key(api_key, region);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(AnthropicAwsProvider::new(config).language_model(&model_id))
+    match AnthropicAwsProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create an Azure OpenAI model instance (API key + resource name).
 ///
-/// `api_version` may be null (uses the provider default). The deployment name
-/// is passed as `model_id`. Returns `0` on failure.
+/// `api_version` may be null (uses the provider default). The deployment
+/// name is passed as `model_id`.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_azure_new(
     api_key: *const c_char,
     resource_name: *const c_char,
     deployment: *const c_char,
     api_version: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(resource_name),
@@ -526,11 +461,7 @@ pub extern "C" fn aimux_azure_new(
         _ => None,
     };
     let Some((api_key, resource_name, deployment)) = parsed else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = AzureConfig::new()
         .with_api_key(api_key)
@@ -538,21 +469,26 @@ pub extern "C" fn aimux_azure_new(
     if let Some(version) = parse_base_url(api_version) {
         config = config.with_api_version(version);
     }
-    intern_or_record_lang(AzureProvider::new(config).and_then(|p| p.language_model(&deployment)))
+    match AzureProvider::new(config) {
+        Ok(p) => match p.language_model(&deployment) {
+            Ok(m) => handle_json(intern_model(Arc::from(m))),
+            Err(e) => error_json_from(&e),
+        },
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create an Azure OpenAI model instance with a custom base URL.
 ///
-/// `api_version` may be null (uses the provider default). The deployment name
-/// is passed as `model_id`. Returns `0` on failure.
+/// `api_version` may be null (uses the provider default). The deployment
+/// name is passed as `model_id`.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_azure_new_with_base(
     api_key: *const c_char,
     base_url: *const c_char,
     deployment: *const c_char,
     api_version: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let parsed = match (
         cstr_to_string(api_key),
         cstr_to_string(base_url),
@@ -562,11 +498,7 @@ pub extern "C" fn aimux_azure_new_with_base(
         _ => None,
     };
     let Some((api_key, base_url, deployment)) = parsed else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = AzureConfig::new()
         .with_api_key(api_key)
@@ -574,38 +506,40 @@ pub extern "C" fn aimux_azure_new_with_base(
     if let Some(version) = parse_base_url(api_version) {
         config = config.with_api_version(version);
     }
-    intern_or_record_lang(AzureProvider::new(config).and_then(|p| p.language_model(&deployment)))
+    match AzureProvider::new(config) {
+        Ok(p) => match p.language_model(&deployment) {
+            Ok(m) => handle_json(intern_model(Arc::from(m))),
+            Err(e) => error_json_from(&e),
+        },
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create a Bedrock model instance (AWS SigV4 credentials).
 ///
 /// `access_key_id` / `secret_access_key` / `region` are required.
-/// Returns `0` on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_bedrock_new(
     access_key_id: *const c_char,
     secret_access_key: *const c_char,
     region: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((access_key_id, secret_access_key, region, model_id)) =
         (unsafe { parse_four_args(access_key_id, secret_access_key, region, model_id) })
     else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(
-        BedrockProvider::new(BedrockProviderConfig::new(
-            access_key_id,
-            secret_access_key,
-            region,
-        ))
-        .language_model(&model_id),
-    )
+    match BedrockProvider::new(BedrockProviderConfig::new(
+        access_key_id,
+        secret_access_key,
+        region,
+    ))
+    .language_model(&model_id)
+    {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create a Bedrock model instance with a custom base URL.
@@ -616,49 +550,43 @@ pub extern "C" fn aimux_bedrock_new_with_base(
     region: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((access_key_id, secret_access_key, region, model_id)) =
         (unsafe { parse_four_args(access_key_id, secret_access_key, region, model_id) })
     else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = BedrockProviderConfig::new(access_key_id, secret_access_key, region);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(BedrockProvider::new(config).language_model(&model_id))
+    match BedrockProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create a Vertex AI model instance (GCP bearer token).
 ///
 /// `access_token` / `project` / `location` are required.
-/// Returns `0` on failure.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_vertex_new(
     access_token: *const c_char,
     project: *const c_char,
     location: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((access_token, project, location, model_id)) =
         (unsafe { parse_four_args(access_token, project, location, model_id) })
     else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(
-        VertexProvider::new(VertexProviderConfig::new(access_token, project, location))
-            .language_model(&model_id),
-    )
+    match VertexProvider::new(VertexProviderConfig::new(access_token, project, location))
+        .language_model(&model_id)
+    {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create a Vertex AI model instance with a custom base URL.
@@ -669,38 +597,35 @@ pub extern "C" fn aimux_vertex_new_with_base(
     location: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((access_token, project, location, model_id)) =
         (unsafe { parse_four_args(access_token, project, location, model_id) })
     else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = VertexProviderConfig::new(access_token, project, location);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(VertexProvider::new(config).language_model(&model_id))
+    match VertexProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
-/// Create a Cohere model instance, returning its opaque handle.
+/// Create a Cohere model instance.
 ///
-/// Returns `0` on failure (null arguments or invalid model id).
+/// Returns `{"handle":<u64>}` on success, `{"error":...}` on failure (null
+/// arguments or invalid model id).
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_cohere_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_cohere_new(api_key: *const c_char, model_id: *const c_char) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(CohereProvider::new(CohereConfig::new(api_key)).language_model(&model_id))
+    match CohereProvider::new(CohereConfig::new(api_key)).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create a Cohere model instance with a custom base URL.
@@ -709,38 +634,36 @@ pub extern "C" fn aimux_cohere_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = CohereConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(CohereProvider::new(config).language_model(&model_id))
+    match CohereProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
-/// Create a Mistral model instance, returning its opaque handle.
+/// Create a Mistral model instance.
 ///
-/// Returns `0` on failure (null arguments or invalid model id).
+/// Returns `{"handle":<u64>}` on success, `{"error":...}` on failure (null
+/// arguments or invalid model id).
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_mistral_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_mistral_new(
+    api_key: *const c_char,
+    model_id: *const c_char,
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(
-        MistralProvider::new(MistralConfig::new(api_key)).language_model(&model_id),
-    )
+    match MistralProvider::new(MistralConfig::new(api_key)).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create a Mistral model instance with a custom base URL.
@@ -749,36 +672,33 @@ pub extern "C" fn aimux_mistral_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = MistralConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(MistralProvider::new(config).language_model(&model_id))
+    match MistralProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
-/// Create an xAI model instance, returning its opaque handle.
+/// Create an xAI model instance.
 ///
-/// Returns `0` on failure (null arguments or invalid model id).
+/// Returns `{"handle":<u64>}` on success, `{"error":...}` on failure (null
+/// arguments or invalid model id).
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_xai_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_xai_new(api_key: *const c_char, model_id: *const c_char) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(XAIProvider::new(XAIConfig::new(api_key)).language_model(&model_id))
+    match XAIProvider::new(XAIConfig::new(api_key)).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create an xAI model instance with a custom base URL.
@@ -787,20 +707,18 @@ pub extern "C" fn aimux_xai_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = XAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
-    intern_or_record_lang(XAIProvider::new(config).language_model(&model_id))
+    match XAIProvider::new(config).language_model(&model_id) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Create a language model from the registry by provider name (RFC-0017 phase 4).
@@ -813,29 +731,20 @@ pub extern "C" fn aimux_xai_new_with_base(
 ///   (`{"base_url": "...", "headers": {...}, "max_retries": 0, "body_overrides": {...}}`);
 ///   NULL / empty / "null" for defaults.
 ///
-/// Returns the opaque handle (0 on failure: unknown provider, bad config,
-/// missing env key, or invalid model id).
+/// Returns `{"handle":<u64>}` on success, `{"error":...}` on failure (unknown
+/// provider, bad config, missing env key, or invalid model id).
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_provider_new(
     name: *const c_char,
     api_key: *const c_char,
     model_id: *const c_char,
     config_json: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some(name) = cstr_to_string(name) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let Some(model_id) = cstr_to_string(model_id) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let key = cstr_to_string(api_key); // None => env var from registry entry
     let opts = match cstr_to_string(config_json) {
@@ -843,36 +752,39 @@ pub extern "C" fn aimux_provider_new(
             match serde_json::from_str::<ProviderOptions>(&s) {
                 Ok(o) => Some(o),
                 Err(e) => {
-                    record_error_msg(format!("invalid config_json: {e}"), "Json");
-                    return 0;
+                    return into_cstring_raw(error_json(
+                        format!("invalid config_json: {e}"),
+                        "Json",
+                        None,
+                    ));
                 }
             }
         }
         _ => None,
     };
-    intern_or_record_lang(provider(&name, key, &model_id, opts))
+    match provider(&name, key, &model_id, opts) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 /// Convenience: create a language model by provider name, reading the API key
-/// from the provider's env var. Returns `0` on failure.
+/// from the provider's env var.
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_provider_from_env(name: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_provider_from_env(
+    name: *const c_char,
+    model_id: *const c_char,
+) -> *mut c_char {
     let Some(name) = cstr_to_string(name) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let Some(model_id) = cstr_to_string(model_id) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
-    intern_or_record_lang(provider(&name, None, &model_id, None))
+    match provider(&name, None, &model_id, None) {
+        Ok(m) => handle_json(intern_model(Arc::from(m))),
+        Err(e) => error_json_from(&e),
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1034,44 +946,21 @@ pub unsafe extern "C" fn aimux_free_string(ptr: *mut c_char) {
     drop(unsafe { CString::from_raw(ptr) });
 }
 
-/// Take (read-and-clear) the last constructor error recorded on this thread.
-///
-/// - Returns the error JSON envelope `{"error","error_type","status_code"}`
-///   from the most recent failed constructor on this thread, or NULL if the
-///   most recent constructor call succeeded.
-/// - The returned pointer is owned by the caller and MUST be freed with
-///   [`aimux_free_string`].
-/// - Destructive read: a second call returns NULL.
-/// - Must be called on the same OS thread as the failed constructor,
-///   immediately after it returned 0. Bindings whose runtime can migrate
-///   work between OS threads (Go goroutines, Java virtual threads, Kotlin
-///   coroutines) must pin both calls to one thread.
-#[unsafe(no_mangle)]
-pub extern "C" fn aimux_last_error() -> *mut c_char {
-    let s = LAST_ERROR.with(|slot| slot.borrow_mut().take());
-    s.map(into_cstring_raw).unwrap_or(std::ptr::null_mut())
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // C ABI: Embedding
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Create an OpenAI embedding model instance. Returns 0 on failure.
+/// Create an OpenAI embedding model instance.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_openai_embedding_new(
     api_key: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).embedding_model(&model_id);
-    intern_handle(ModelHandle::Embedding(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Embedding(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1079,38 +968,28 @@ pub extern "C" fn aimux_openai_embedding_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = OpenAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = OpenAIProvider::new(config).embedding_model(&model_id);
-    intern_handle(ModelHandle::Embedding(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Embedding(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_cohere_embedding_new(
     api_key: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = CohereProvider::new(CohereConfig::new(api_key)).embedding_model(&model_id);
-    intern_handle(ModelHandle::Embedding(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Embedding(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1118,38 +997,28 @@ pub extern "C" fn aimux_cohere_embedding_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = CohereConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = CohereProvider::new(config).embedding_model(&model_id);
-    intern_handle(ModelHandle::Embedding(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Embedding(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_google_embedding_new(
     api_key: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).embedding_model(&model_id);
-    intern_handle(ModelHandle::Embedding(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Embedding(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1157,21 +1026,16 @@ pub extern "C" fn aimux_google_embedding_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = GoogleConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = GoogleProvider::new(config).embedding_model(&model_id);
-    intern_handle(ModelHandle::Embedding(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Embedding(Arc::new(model))))
 }
 
 /// Generate embeddings. `values_json` is a JSON array of strings.
@@ -1213,17 +1077,15 @@ pub extern "C" fn aimux_embed(
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_openai_speech_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_openai_speech_new(
+    api_key: *const c_char,
+    model_id: *const c_char,
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).speech(&model_id);
-    intern_handle(ModelHandle::Speech(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Speech(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1231,21 +1093,16 @@ pub extern "C" fn aimux_openai_speech_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = OpenAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = OpenAIProvider::new(config).speech(&model_id);
-    intern_handle(ModelHandle::Speech(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Speech(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1267,17 +1124,15 @@ pub extern "C" fn aimux_speech_generate(handle: u64, opts_json: *const c_char) -
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_openai_image_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_openai_image_new(
+    api_key: *const c_char,
+    model_id: *const c_char,
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).image(&model_id);
-    intern_handle(ModelHandle::Image(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Image(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1285,35 +1140,28 @@ pub extern "C" fn aimux_openai_image_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = OpenAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = OpenAIProvider::new(config).image(&model_id);
-    intern_handle(ModelHandle::Image(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Image(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_google_image_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_google_image_new(
+    api_key: *const c_char,
+    model_id: *const c_char,
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).image(&model_id);
-    intern_handle(ModelHandle::Image(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Image(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1321,21 +1169,16 @@ pub extern "C" fn aimux_google_image_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = GoogleConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = GoogleProvider::new(config).image(&model_id);
-    intern_handle(ModelHandle::Image(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Image(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1360,17 +1203,12 @@ pub extern "C" fn aimux_image_generate(handle: u64, opts_json: *const c_char) ->
 pub extern "C" fn aimux_openai_transcription_new(
     api_key: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = OpenAIProvider::new(OpenAIConfig::new(api_key)).transcription(&model_id);
-    intern_handle(ModelHandle::Transcription(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Transcription(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1378,21 +1216,16 @@ pub extern "C" fn aimux_openai_transcription_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = OpenAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = OpenAIProvider::new(config).transcription(&model_id);
-    intern_handle(ModelHandle::Transcription(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Transcription(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1429,38 +1262,28 @@ pub extern "C" fn aimux_transcription_generate(
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_openai_files_new(api_key: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_openai_files_new(api_key: *const c_char) -> *mut c_char {
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let files = OpenAIProvider::new(OpenAIConfig::new(api_key)).files();
-    intern_handle(ModelHandle::Files(Arc::new(files)))
+    handle_json(intern_handle(ModelHandle::Files(Arc::new(files))))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_openai_files_new_with_base(
     api_key: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = OpenAIConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let files = OpenAIProvider::new(config).files();
-    intern_handle(ModelHandle::Files(Arc::new(files)))
+    handle_json(intern_handle(ModelHandle::Files(Arc::new(files))))
 }
 
 #[unsafe(no_mangle)]
@@ -1495,22 +1318,17 @@ pub extern "C" fn aimux_file_upload(
 // C ABI: Reranking
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Create a Cohere reranking model instance. Returns 0 on failure.
+/// Create a Cohere reranking model instance.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_cohere_reranking_new(
     api_key: *const c_char,
     model_id: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = CohereProvider::new(CohereConfig::new(api_key)).reranking_model(&model_id);
-    intern_handle(ModelHandle::Reranking(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Reranking(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1518,21 +1336,16 @@ pub extern "C" fn aimux_cohere_reranking_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = CohereConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = CohereProvider::new(config).reranking_model(&model_id);
-    intern_handle(ModelHandle::Reranking(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Reranking(Arc::new(model))))
 }
 
 /// Rerank documents. `opts_json` is JSON-serialized `RerankingCallOptions`
@@ -1556,19 +1369,17 @@ pub extern "C" fn aimux_rerank(handle: u64, opts_json: *const c_char) -> *mut c_
 // C ABI: Video
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Create a Google video model instance. Returns 0 on failure.
+/// Create a Google video model instance.
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_google_video_new(api_key: *const c_char, model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_google_video_new(
+    api_key: *const c_char,
+    model_id: *const c_char,
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = GoogleProvider::new(GoogleConfig::new(api_key)).video(&model_id);
-    intern_handle(ModelHandle::Video(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Video(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1576,21 +1387,16 @@ pub extern "C" fn aimux_google_video_new_with_base(
     api_key: *const c_char,
     model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some((api_key, model_id)) = (unsafe { parse_two_args(api_key, model_id) }) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = GoogleConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = GoogleProvider::new(config).video(&model_id);
-    intern_handle(ModelHandle::Video(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Video(Arc::new(model))))
 }
 
 /// Generate video. `opts_json` is JSON-serialized `VideoCallOptions`
@@ -1615,19 +1421,17 @@ pub extern "C" fn aimux_video_generate(handle: u64, opts_json: *const c_char) ->
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Create a Tavily search model instance. `model_id` is accepted for API
-/// symmetry but ignored (Tavily uses a fixed endpoint). Returns 0 on failure.
+/// symmetry but ignored (Tavily uses a fixed endpoint).
 #[unsafe(no_mangle)]
-pub extern "C" fn aimux_tavily_search_new(api_key: *const c_char, _model_id: *const c_char) -> u64 {
-    begin_constructor();
+pub extern "C" fn aimux_tavily_search_new(
+    api_key: *const c_char,
+    _model_id: *const c_char,
+) -> *mut c_char {
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let model = TavilyProvider::new(TavilyConfig::new(api_key)).search_model();
-    intern_handle(ModelHandle::Search(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Search(Arc::new(model))))
 }
 
 #[unsafe(no_mangle)]
@@ -1635,21 +1439,16 @@ pub extern "C" fn aimux_tavily_search_new_with_base(
     api_key: *const c_char,
     _model_id: *const c_char,
     base_url: *const c_char,
-) -> u64 {
-    begin_constructor();
+) -> *mut c_char {
     let Some(api_key) = cstr_to_string(api_key) else {
-        record_error_msg(
-            "invalid argument: null or invalid UTF-8 string",
-            "InvalidArgument",
-        );
-        return 0;
+        return invalid_args_json();
     };
     let mut config = TavilyConfig::new(api_key);
     if let Some(url) = parse_base_url(base_url) {
         config = config.with_base_url(url);
     }
     let model = TavilyProvider::new(config).search_model();
-    intern_handle(ModelHandle::Search(Arc::new(model)))
+    handle_json(intern_handle(ModelHandle::Search(Arc::new(model))))
 }
 
 /// Execute a search. `opts_json` is JSON-serialized `SearchCallOptions`

--- a/aimux-ffi/tests/error_detail_test.rs
+++ b/aimux-ffi/tests/error_detail_test.rs
@@ -4,51 +4,71 @@
 //! - Problem A: `prompt_json` parse errors must carry the `serde_json::Error`
 //!   detail (like the adjacent `opts_json` branch already did).
 //! - Problem B: constructor failures (unknown provider, bad config JSON,
-//!   null arguments) are recorded in a thread-local slot and read back with
-//!   `aimux_last_error()` as a full error JSON envelope.
+//!   null arguments) are returned directly in the constructor's JSON result
+//!   (`{"handle":<u64>}` on success, the standard error envelope on failure)
+//!   — no side-channel retrieval, so there are no thread-affinity semantics
+//!   to test.
 //!
 //! All tests are offline: they only exercise argument parsing and config
 //! construction, never the network.
 
 use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Mutex;
 
 use serde_json::Value;
 
 use aimux_ffi::{
-    aimux_azure_new, aimux_drop_handle, aimux_free_string, aimux_generate_text, aimux_last_error,
-    aimux_openai_new, aimux_provider_new, aimux_stream_text,
+    aimux_azure_new, aimux_drop_handle, aimux_free_string, aimux_generate_text, aimux_openai_new,
+    aimux_provider_new, aimux_stream_text,
 };
 
 fn c(s: &str) -> CString {
     CString::new(s).unwrap()
 }
 
-/// Take the last error as an owned `String` (frees the FFI pointer).
-fn take_last_error() -> Option<String> {
-    let p = aimux_last_error();
-    if p.is_null() {
-        return None;
-    }
-    // SAFETY: aimux_last_error returns a NUL-terminated string owned by us.
-    let s = unsafe { CStr::from_ptr(p) }.to_str().unwrap().to_string();
-    // SAFETY: p was produced by CString::into_raw inside aimux_last_error.
-    unsafe { aimux_free_string(p) };
-    Some(s)
+/// Copy an FFI JSON result into an owned `String`, freeing the pointer.
+fn take_json(ptr: *mut c_char) -> String {
+    assert!(!ptr.is_null(), "FFI call returned a null result pointer");
+    // SAFETY: FFI functions return NUL-terminated strings owned by us.
+    let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_string();
+    // SAFETY: ptr was produced by CString::into_raw inside the FFI layer.
+    unsafe { aimux_free_string(ptr) };
+    s
 }
 
-fn take_envelope() -> Option<Value> {
-    take_last_error().map(|json| {
-        serde_json::from_str(&json).expect("aimux_last_error must return a valid JSON envelope")
-    })
+/// Parse a constructor result, expecting the error envelope.
+fn expect_error_envelope(ptr: *mut c_char) -> Value {
+    let json = take_json(ptr);
+    let env: Value = serde_json::from_str(&json).expect("result must be a JSON envelope");
+    assert!(
+        env.get("error").is_some(),
+        "expected error envelope, got: {json}"
+    );
+    env
 }
 
-/// A model handle that can be used with `aimux_generate_text` / `aimux_stream_text`.
-fn valid_handle() -> u64 {
-    let h = aimux_openai_new(c("sk-test-fake-key").as_ptr(), c("gpt-4o-mini").as_ptr());
-    assert!(h != 0, "expected a valid handle for the test fixture");
+/// Parse a constructor result, expecting `{"handle":<u64>}`, and return the
+/// handle.
+fn expect_handle(ptr: *mut c_char) -> u64 {
+    let json = take_json(ptr);
+    let env: Value = serde_json::from_str(&json).expect("result must be JSON");
+    assert!(
+        env.get("error").is_none(),
+        "expected success, got error envelope: {json}"
+    );
+    let h = env["handle"].as_u64().expect("handle must be a u64");
+    assert!(h != 0, "handle must never be 0 on success");
     h
+}
+
+/// A model handle usable with `aimux_generate_text` / `aimux_stream_text`.
+fn valid_handle() -> u64 {
+    expect_handle(aimux_openai_new(
+        c("sk-test-fake-key").as_ptr(),
+        c("gpt-4o-mini").as_ptr(),
+    ))
 }
 
 // ── Problem A: prompt_json serde detail ─────────────────────────────────────
@@ -57,12 +77,7 @@ fn valid_handle() -> u64 {
 fn generate_text_invalid_prompt_json_carries_serde_detail() {
     let h = valid_handle();
     let out = aimux_generate_text(h, c("hello").as_ptr(), ptr::null());
-    assert!(!out.is_null(), "expected an error JSON string");
-    // SAFETY: aimux_generate_text returns a NUL-terminated string we own.
-    let json = unsafe { CStr::from_ptr(out) }.to_str().unwrap().to_string();
-    unsafe { aimux_free_string(out) };
-
-    let env: Value = serde_json::from_str(&json).expect("error must be a JSON envelope");
+    let env: Value = serde_json::from_str(&take_json(out)).expect("error must be a JSON envelope");
     let msg = env["error"].as_str().expect("envelope has error field");
     assert!(
         msg.starts_with("invalid prompt_json:"),
@@ -82,20 +97,17 @@ fn generate_text_invalid_prompt_json_carries_serde_detail() {
 fn generate_text_null_prompt_json_reports_invalid_prompt() {
     let h = valid_handle();
     let out = aimux_generate_text(h, ptr::null(), ptr::null());
-    assert!(!out.is_null());
-    // SAFETY: as above.
-    let json = unsafe { CStr::from_ptr(out) }.to_str().unwrap().to_string();
-    unsafe { aimux_free_string(out) };
+    let json = take_json(out);
     assert!(json.contains("invalid prompt_json"), "got: {json}");
     aimux_drop_handle(h);
 }
 
 static STREAM_ERRORS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
-extern "C" fn on_part(_json: *const std::os::raw::c_char) {}
+extern "C" fn on_part(_json: *const c_char) {}
 extern "C" fn on_done() {}
 
-extern "C" fn on_error(json: *const std::os::raw::c_char) {
+extern "C" fn on_error(json: *const c_char) {
     // SAFETY: the FFI layer guarantees the pointer is valid during the call.
     let s = unsafe { CStr::from_ptr(json) }
         .to_str()
@@ -134,19 +146,16 @@ fn stream_text_invalid_prompt_json_carries_serde_detail() {
     aimux_drop_handle(h);
 }
 
-// ── Problem B: constructor failures via aimux_last_error ────────────────────
+// ── Problem B: constructor failures in the returned envelope ────────────────
 
 #[test]
 fn unknown_provider_reports_full_error_envelope() {
-    let h = aimux_provider_new(
+    let env = expect_error_envelope(aimux_provider_new(
         c("this-provider-does-not-exist").as_ptr(),
         c("sk-x").as_ptr(),
         c("gpt-4o-mini").as_ptr(),
         ptr::null(),
-    );
-    assert_eq!(h, 0, "unknown provider must fail");
-
-    let env = take_envelope().expect("last_error must be set after a failed constructor");
+    ));
     let msg = env["error"].as_str().unwrap();
     assert!(msg.contains("unknown provider"), "got: {msg}");
     assert!(msg.contains("available providers"), "got: {msg}");
@@ -156,15 +165,12 @@ fn unknown_provider_reports_full_error_envelope() {
 
 #[test]
 fn invalid_config_json_reports_json_error_type() {
-    let h = aimux_provider_new(
+    let env = expect_error_envelope(aimux_provider_new(
         c("openai").as_ptr(),
         c("sk-x").as_ptr(),
         c("gpt-4o-mini").as_ptr(),
         c("{bad json").as_ptr(),
-    );
-    assert_eq!(h, 0, "malformed config_json must fail");
-
-    let env = take_envelope().expect("last_error must be set");
+    ));
     assert!(
         env["error"]
             .as_str()
@@ -177,10 +183,7 @@ fn invalid_config_json_reports_json_error_type() {
 
 #[test]
 fn null_arguments_report_invalid_argument_type() {
-    let h = aimux_openai_new(ptr::null(), ptr::null());
-    assert_eq!(h, 0);
-
-    let env = take_envelope().expect("last_error must be set");
+    let env = expect_error_envelope(aimux_openai_new(ptr::null(), ptr::null()));
     assert_eq!(env["error_type"], "InvalidArgument");
     assert!(
         env["error"]
@@ -194,121 +197,77 @@ fn null_arguments_report_invalid_argument_type() {
 #[test]
 fn azure_missing_required_argument_reports_invalid_argument() {
     // resource_name is a required FFI argument; passing NULL fails at the
-    // boundary with an InvalidArgument envelope (the Azure provider's own
-    // InvalidArgument can't be reached from the FFI layer because the
-    // argument is mandatory).
-    let h = aimux_azure_new(
+    // boundary with an InvalidArgument envelope.
+    let env = expect_error_envelope(aimux_azure_new(
         c("k").as_ptr(),
         ptr::null(),
         c("deploy").as_ptr(),
         ptr::null(),
-    );
-    assert_eq!(h, 0);
-
-    let env = take_envelope().expect("last_error must be set");
+    ));
     assert_eq!(env["error_type"], "InvalidArgument");
 }
 
-// ── TLS semantics ───────────────────────────────────────────────────────────
+// ── Envelope semantics ──────────────────────────────────────────────────────
 
 #[test]
-fn successful_constructor_clears_previous_error() {
-    // 1. Fail and leave the error unread.
-    assert_eq!(
-        aimux_provider_new(
-            c("no-such-provider").as_ptr(),
-            c("k").as_ptr(),
-            c("m").as_ptr(),
-            ptr::null(),
-        ),
-        0
-    );
-    assert!(take_last_error().is_some(), "precondition: error recorded");
-
-    // 2. Fail again so the slot is repopulated, then succeed WITHOUT reading.
-    assert_eq!(
-        aimux_provider_new(
-            c("also-no-such").as_ptr(),
-            c("k").as_ptr(),
-            c("m").as_ptr(),
-            ptr::null(),
-        ),
-        0
-    );
-    let h = aimux_provider_new(
+fn success_envelope_has_handle_and_no_error() {
+    let h = expect_handle(aimux_provider_new(
         c("groq").as_ptr(),
         c("sk-test").as_ptr(),
         c("llama-3.3-70b").as_ptr(),
         ptr::null(),
-    );
-    assert!(
-        h != 0,
-        "a registered provider with a fake key must construct"
-    );
-
-    // 3. The success must have cleared the stale error.
-    assert!(
-        take_last_error().is_none(),
-        "successful constructor must clear the previous error"
-    );
+    ));
     aimux_drop_handle(h);
 }
 
 #[test]
-fn last_error_is_overwritten_and_read_once() {
-    aimux_provider_new(
+fn each_call_carries_its_own_error() {
+    // Unlike a last-error slot, results cannot be overwritten, cleared, or
+    // consumed by unrelated calls: each return value is self-contained.
+    let a = expect_error_envelope(aimux_provider_new(
         c("no-such-a").as_ptr(),
         c("k").as_ptr(),
         c("m").as_ptr(),
         ptr::null(),
-    );
-    aimux_provider_new(
+    ));
+    let b = expect_error_envelope(aimux_provider_new(
         c("no-such-b").as_ptr(),
         c("k").as_ptr(),
         c("m").as_ptr(),
         ptr::null(),
-    );
-
-    // Last write wins.
-    let env = take_envelope().expect("last_error must be set");
+    ));
     assert!(
-        env["error"].as_str().unwrap().contains("no-such-b"),
-        "got: {env}"
+        a["error"].as_str().unwrap().contains("no-such-a"),
+        "got: {a}"
     );
-
-    // Read-and-clear: a second read returns NULL.
-    assert!(take_last_error().is_none(), "second read must be NULL");
+    assert!(
+        b["error"].as_str().unwrap().contains("no-such-b"),
+        "got: {b}"
+    );
 }
 
 #[test]
-fn last_error_is_thread_local() {
-    let t1 = std::thread::spawn(|| {
-        aimux_provider_new(
-            c("no-such-thread-a").as_ptr(),
-            c("k").as_ptr(),
-            c("m").as_ptr(),
-            ptr::null(),
-        );
-        take_last_error().expect("thread 1 must see its own error")
-    });
-    let t2 = std::thread::spawn(|| {
-        aimux_provider_new(
-            c("no-such-thread-b").as_ptr(),
-            c("k").as_ptr(),
-            c("m").as_ptr(),
-            ptr::null(),
-        );
-        take_last_error().expect("thread 2 must see its own error")
-    });
-
-    let (e1, e2) = (t1.join().unwrap(), t2.join().unwrap());
-    assert!(e1.contains("no-such-thread-a"), "thread 1 got: {e1}");
-    assert!(e2.contains("no-such-thread-b"), "thread 2 got: {e2}");
-}
-
-#[test]
-fn no_error_returns_null_without_a_constructor_call() {
-    // The main thread never failed a constructor here; the slot must be empty
-    // (nothing to read, nothing to free).
-    assert!(take_last_error().is_none());
+fn concurrent_constructors_see_their_own_results() {
+    // The failure-detail path needs no thread pinning: spawn constructors on
+    // separate threads and verify each observes exactly its own error.
+    let threads: Vec<_> = (0..8)
+        .map(|i| {
+            std::thread::spawn(move || {
+                let name = format!("no-such-thread-{i}");
+                let env = expect_error_envelope(aimux_provider_new(
+                    c(&name).as_ptr(),
+                    c("k").as_ptr(),
+                    c("m").as_ptr(),
+                    ptr::null(),
+                ));
+                assert!(
+                    env["error"].as_str().unwrap().contains(&name),
+                    "thread {i} got: {env}"
+                );
+            })
+        })
+        .collect();
+    for t in threads {
+        t.join().unwrap();
+    }
 }

--- a/aimux-ffi/tests/native_constructors_test.rs
+++ b/aimux-ffi/tests/native_constructors_test.rs
@@ -2,25 +2,66 @@
 //! (cohere / mistral / xai / bedrock / vertex / anthropic_aws / azure).
 //!
 //! Constructing a model only builds a config + provider — no network is
-//! touched, so fake keys are fine. A non-zero handle means the constructor
-//! wired the provider correctly.
+//! touched, so fake keys are fine. Constructors return a JSON string
+//! (`{"handle":<u64>}` on success, `{"error":...}` on failure).
 
 use std::ffi::CString;
+use std::os::raw::c_char;
 
 use aimux_ffi::{
     aimux_anthropic_aws_new, aimux_anthropic_aws_new_with_base, aimux_azure_new,
     aimux_azure_new_with_base, aimux_bedrock_new, aimux_bedrock_new_with_base, aimux_cohere_new,
-    aimux_cohere_new_with_base, aimux_drop_handle, aimux_mistral_new, aimux_mistral_new_with_base,
-    aimux_vertex_new, aimux_vertex_new_with_base, aimux_xai_new, aimux_xai_new_with_base,
+    aimux_cohere_new_with_base, aimux_drop_handle, aimux_free_string, aimux_mistral_new,
+    aimux_mistral_new_with_base, aimux_vertex_new, aimux_vertex_new_with_base, aimux_xai_new,
+    aimux_xai_new_with_base,
 };
 
 fn c(s: &str) -> CString {
     CString::new(s).unwrap()
 }
 
-fn expect_handle(h: u64, name: &str) {
-    assert!(h != 0, "{name}: expected non-zero handle");
-    aimux_drop_handle(h);
+/// Copy a constructor's JSON result into an owned `String`, freeing the
+/// native pointer.
+fn take_json(json_ptr: *mut c_char, name: &str) -> String {
+    assert!(!json_ptr.is_null(), "{name}: null result pointer");
+    let json = unsafe { std::ffi::CStr::from_ptr(json_ptr) }
+        .to_str()
+        .unwrap()
+        .to_string();
+    unsafe { aimux_free_string(json_ptr) };
+    json
+}
+
+/// Assert a constructor's JSON result is `{"handle":<u64>}` (not an error
+/// envelope) and release the handle.
+fn expect_handle(json_ptr: *mut c_char, name: &str) {
+    let json = take_json(json_ptr, name);
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap_or_else(|e| {
+        panic!("{name}: result is not valid JSON ({e}): {json}");
+    });
+    assert!(
+        value.get("error").is_none(),
+        "{name}: expected success, got error envelope: {json}"
+    );
+    let handle = value
+        .get("handle")
+        .and_then(|h| h.as_u64())
+        .unwrap_or_else(|| panic!("{name}: expected {{\"handle\":<u64>}}, got {json}"));
+    assert!(handle != 0, "{name}: handle should never be 0 on success");
+    aimux_drop_handle(handle);
+}
+
+/// Assert a constructor's JSON result is an error envelope
+/// (`{"error":...}`), not a handle.
+fn expect_error(json_ptr: *mut c_char, name: &str) {
+    let json = take_json(json_ptr, name);
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap_or_else(|e| {
+        panic!("{name}: result is not valid JSON ({e}): {json}");
+    });
+    assert!(
+        value.get("error").is_some(),
+        "{name}: expected error envelope, got {json}"
+    );
 }
 
 #[test]
@@ -157,12 +198,15 @@ fn azure_constructors() {
 }
 
 #[test]
-fn invalid_args_return_zero() {
-    // Null model_id must fail cleanly (returns 0, no panic).
+fn invalid_args_return_error() {
+    // Null model_id must fail cleanly (error envelope, no panic).
     let key = c("sk-test-fake-key");
-    assert_eq!(aimux_cohere_new(key.as_ptr(), std::ptr::null()), 0);
-    assert_eq!(
+    expect_error(
+        aimux_cohere_new(key.as_ptr(), std::ptr::null()),
+        "cohere_new(null model_id)",
+    );
+    expect_error(
         aimux_bedrock_new(key.as_ptr(), key.as_ptr(), key.as_ptr(), std::ptr::null()),
-        0
+        "bedrock_new(null model_id)",
     );
 }

--- a/bindings/c/example.c
+++ b/bindings/c/example.c
@@ -24,16 +24,24 @@ static void on_error(const char *err_json) {
     fprintf(stderr, "STREAM ERROR: %s\n", err_json);
 }
 
-// Print the thread-local last-constructor error (issue #17), if any, then
-// free it. Call right after a constructor returned 0, on the same thread.
-static void print_last_error(const char *fallback) {
-    char *err = aimux_last_error();
-    if (err) {
-        fprintf(stderr, "%s — %s\n", fallback, err);
-        aimux_free_string(err);
-    } else {
-        fprintf(stderr, "%s\n", fallback);
+// Parse a constructor's JSON result (`{"handle":<u64>}` on success,
+// `{"error":"..."}` on failure). Frees the string. On failure, prints the
+// detailed engine error to stderr (the whole point of the JSON envelope vs.
+// the old bare-u64-handle ABI, which had no room for one) and returns 0.
+static uint64_t extract_handle(char *json) {
+    if (!json) {
+        fprintf(stderr, "constructor returned null\n");
+        return 0;
     }
+    uint64_t handle = 0;
+    if (strstr(json, "\"error\":")) {
+        fprintf(stderr, "construction failed: %s\n", json);
+    } else {
+        const char *h = strstr(json, "\"handle\":");
+        if (h) handle = strtoull(h + strlen("\"handle\":"), NULL, 10);
+    }
+    aimux_free_string(json);
+    return handle;
 }
 
 int main(void) {
@@ -44,9 +52,9 @@ int main(void) {
     }
 
     // 1. Create model
-    uint64_t handle = aimux_openai_new(api_key, "gpt-4o-mini");
+    uint64_t handle = extract_handle(aimux_openai_new(api_key, "gpt-4o-mini"));
     if (handle == 0) {
-        print_last_error("Failed to create model");
+        fprintf(stderr, "Failed to create model\n");
         return 1;
     }
     printf("Model created: handle=%lu\n", (unsigned long)handle);
@@ -66,14 +74,13 @@ int main(void) {
 
     // 3.5 Registry provider (RFC-0017 phase 4): construct DeepSeek via the
     // provider registry. NULL api_key reads DEEPSEEK_API_KEY from the env.
-    uint64_t ds_handle = aimux_provider_new("deepseek", NULL, "deepseek-chat", NULL);
+    uint64_t ds_handle = extract_handle(aimux_provider_new("deepseek", NULL, "deepseek-chat", NULL));
     if (ds_handle != 0) {
         printf("DeepSeek (registry): handle=%lu\n", (unsigned long)ds_handle);
         aimux_drop_handle(ds_handle);
-    } else {
-        print_last_error("Failed to create DeepSeek via registry "
-                         "(is DEEPSEEK_API_KEY set?)");
     }
+    // On failure extract_handle already printed the detailed engine error
+    // (e.g. "is DEEPSEEK_API_KEY set?" is now part of that message).
 
     // 4. Cleanup
     aimux_drop_handle(handle);

--- a/bindings/c/example.cpp
+++ b/bindings/c/example.cpp
@@ -3,8 +3,11 @@
 // Build: g++ -std=c++17 -o example_cpp example.cpp -L../../target/debug -laimux_ffi -lpthread -ldl -lm
 // Run:   OPENAI_API_KEY=sk-... ./example_cpp
 
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <functional>
 
@@ -16,22 +19,37 @@ thread_local const std::function<void()> *current_on_done = nullptr;
 thread_local const std::function<void(const std::string &)> *current_on_error = nullptr;
 }
 
+// Parse a constructor's JSON result (`{"handle":<u64>}` on success,
+// `{"error":"..."}` on failure). Frees the string via aimux_free_string and
+// throws std::runtime_error carrying the detailed engine error on failure
+// (a crude substring scan, not a JSON parse -- avoids a JSON dependency for
+// this demo; production bindings use a real JSON library).
+static uint64_t extract_handle(char *json, const std::string &what) {
+    if (!json) {
+        throw std::runtime_error(what + ": constructor returned null");
+    }
+    std::string result(json);
+    aimux_free_string(json);
+    if (result.find("\"error\":") != std::string::npos) {
+        throw std::runtime_error(what + ": " + result);
+    }
+    auto h_pos = result.find("\"handle\":");
+    if (h_pos == std::string::npos) {
+        throw std::runtime_error(what + ": invalid constructor response: " + result);
+    }
+    return std::strtoull(result.c_str() + h_pos + std::strlen("\"handle\":"), nullptr, 10);
+}
+
 // RAII wrapper for model handle
 class AimuxModel {
 public:
     static AimuxModel openai(const std::string &api_key, const std::string &model_id) {
-        auto handle = aimux_openai_new(api_key.c_str(), model_id.c_str());
-        if (handle == 0) {
-            throw std::runtime_error("Failed to create OpenAI model");
-        }
+        auto handle = extract_handle(aimux_openai_new(api_key.c_str(), model_id.c_str()), "openai");
         return AimuxModel(handle);
     }
 
     static AimuxModel anthropic(const std::string &api_key, const std::string &model_id) {
-        auto handle = aimux_anthropic_new(api_key.c_str(), model_id.c_str());
-        if (handle == 0) {
-            throw std::runtime_error("Failed to create Anthropic model");
-        }
+        auto handle = extract_handle(aimux_anthropic_new(api_key.c_str(), model_id.c_str()), "anthropic");
         return AimuxModel(handle);
     }
 
@@ -41,10 +59,8 @@ public:
     static AimuxModel provider(const std::string &name, const std::string &model_id,
                                const char *api_key = nullptr,
                                const char *config_json = nullptr) {
-        auto handle = aimux_provider_new(name.c_str(), api_key, model_id.c_str(), config_json);
-        if (handle == 0) {
-            throw std::runtime_error("Failed to create provider model: " + name);
-        }
+        auto handle = extract_handle(
+            aimux_provider_new(name.c_str(), api_key, model_id.c_str(), config_json), "provider '" + name + "'");
         return AimuxModel(handle);
     }
 

--- a/bindings/flutter/lib/aimux.dart
+++ b/bindings/flutter/lib/aimux.dart
@@ -16,23 +16,25 @@ import 'package:ffi/ffi.dart';
 // FFI type aliases
 // ─────────────────────────────────────────────────────────────────────────────
 
-typedef _OpenaiNewC = Uint64 Function(Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
-typedef _OpenaiNewDart = int Function(Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
+typedef _OpenaiNewC = Pointer<Utf8> Function(
+    Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
+typedef _OpenaiNewDart = Pointer<Utf8> Function(
+    Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
 
 // Constructors with a custom base URL (aimux_*_new_with_base). The same
 // signature covers both OpenAI and Anthropic.
-typedef _NewWithBaseC = Uint64 Function(
+typedef _NewWithBaseC = Pointer<Utf8> Function(
     Pointer<Utf8> apiKey, Pointer<Utf8> modelId, Pointer<Utf8> baseUrl);
-typedef _NewWithBaseDart = int Function(
+typedef _NewWithBaseDart = Pointer<Utf8> Function(
     Pointer<Utf8> apiKey, Pointer<Utf8> modelId, Pointer<Utf8> baseUrl);
 
 // Registry provider constructor (aimux_provider_new, RFC-0017 phase 4).
 // name/model_id are required; apiKey (null → provider env var from the
 // registry entry) and configJson (null → defaults) are optional.
-typedef _ProviderNewC = Uint64 Function(
-    Pointer<Utf8> name, Pointer<Utf8>? apiKey, Pointer<Utf8> modelId, Pointer<Utf8>? configJson);
-typedef _ProviderNewDart = int Function(
-    Pointer<Utf8> name, Pointer<Utf8>? apiKey, Pointer<Utf8> modelId, Pointer<Utf8>? configJson);
+typedef _ProviderNewC = Pointer<Utf8> Function(Pointer<Utf8> name,
+    Pointer<Utf8>? apiKey, Pointer<Utf8> modelId, Pointer<Utf8>? configJson);
+typedef _ProviderNewDart = Pointer<Utf8> Function(Pointer<Utf8> name,
+    Pointer<Utf8>? apiKey, Pointer<Utf8> modelId, Pointer<Utf8>? configJson);
 
 typedef _GenerateTextC = Pointer<Utf8> Function(
     Uint64 handle, Pointer<Utf8> promptJson, Pointer<Utf8>? optsJson);
@@ -46,14 +48,20 @@ typedef _FreeStringC = Void Function(Pointer<Utf8>);
 typedef _FreeStringDart = void Function(Pointer<Utf8>);
 
 // Multi-arg constructor C signatures (bedrock/vertex/azure).
-typedef _FourStrC = Uint64 Function(
+typedef _FourStrC = Pointer<Utf8> Function(
     Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
-typedef _FourStrDart = int Function(
+typedef _FourStrDart = Pointer<Utf8> Function(
     Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
-typedef _FiveStrC = Uint64 Function(
+typedef _FiveStrC = Pointer<Utf8> Function(
     Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
-typedef _FiveStrDart = int Function(
+typedef _FiveStrDart = Pointer<Utf8> Function(
     Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>);
+// Azure constructor C signatures: 3 required strings + a nullable
+// api_version (the C ABI's `const char *api_version` may be NULL).
+typedef _FourStrOptC = Pointer<Utf8> Function(
+    Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>?);
+typedef _FourStrOptDart = Pointer<Utf8> Function(
+    Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>?);
 
 // Stream callback C signatures
 typedef _OnPartC = Void Function(Pointer<Utf8>);
@@ -66,14 +74,21 @@ typedef _OnErrorC = Void Function(Pointer<Utf8>);
 
 final class _AimuxFFI {
   final DynamicLibrary _lib;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) openaiNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) anthropicNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) openaiNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) anthropicNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>?, Pointer<Utf8>, Pointer<Utf8>?) providerNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) openaiNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) anthropicNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+      openaiNewWithBase;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+      anthropicNewWithBase;
+  final Pointer<Utf8> Function(
+      Pointer<Utf8>, Pointer<Utf8>?, Pointer<Utf8>, Pointer<Utf8>?) providerNew;
   final Pointer<Utf8> Function(int, Pointer<Utf8>, Pointer<Utf8>?) generateText;
-  final void Function(int, Pointer<Utf8>, Pointer<Utf8>?,
-      Pointer<NativeFunction<_OnPartC>>, Pointer<NativeFunction<_OnDoneC>>,
+  final void Function(
+      int,
+      Pointer<Utf8>,
+      Pointer<Utf8>?,
+      Pointer<NativeFunction<_OnPartC>>,
+      Pointer<NativeFunction<_OnDoneC>>,
       Pointer<NativeFunction<_OnErrorC>>) streamText;
   final void Function(int) dropHandle;
   final void Function(Pointer<Utf8>) freeString;
@@ -98,13 +113,15 @@ final class _AimuxFFI {
       dylib,
       dylib.lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_openai_new'),
       dylib.lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_anthropic_new'),
-      dylib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>('aimux_openai_new_with_base'),
-      dylib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>('aimux_anthropic_new_with_base'),
-      dylib.lookupFunction<_ProviderNewC, _ProviderNewDart>('aimux_provider_new'),
-      dylib.lookupFunction<_GenerateTextC, _GenerateTextDart>('aimux_generate_text'),
-      dylib.lookupFunction<
-          _StreamTextC,
-          _StreamTextDart>('aimux_stream_text'),
+      dylib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>(
+          'aimux_openai_new_with_base'),
+      dylib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>(
+          'aimux_anthropic_new_with_base'),
+      dylib.lookupFunction<_ProviderNewC, _ProviderNewDart>(
+          'aimux_provider_new'),
+      dylib.lookupFunction<_GenerateTextC, _GenerateTextDart>(
+          'aimux_generate_text'),
+      dylib.lookupFunction<_StreamTextC, _StreamTextDart>('aimux_stream_text'),
       dylib.lookupFunction<_DropHandleC, _DropHandleDart>('aimux_drop_handle'),
       dylib.lookupFunction<_FreeStringC, _FreeStringDart>('aimux_free_string'),
     );
@@ -119,39 +136,58 @@ final class _AimuxFFI {
 
   // ── Native protocol constructors (C ABI 0.2.0) ──────────────────────────
 
-  int cohereNew(Pointer<Utf8> key, Pointer<Utf8> model) =>
-      _lib.lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_cohere_new')(key, model);
-  int cohereNewWithBase(Pointer<Utf8> key, Pointer<Utf8> model, Pointer<Utf8> base) =>
-      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>('aimux_cohere_new_with_base')(key, model, base);
-  int mistralNew(Pointer<Utf8> key, Pointer<Utf8> model) =>
-      _lib.lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_mistral_new')(key, model);
-  int mistralNewWithBase(Pointer<Utf8> key, Pointer<Utf8> model, Pointer<Utf8> base) =>
-      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>('aimux_mistral_new_with_base')(key, model, base);
-  int xaiNew(Pointer<Utf8> key, Pointer<Utf8> model) =>
-      _lib.lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_xai_new')(key, model);
-  int xaiNewWithBase(Pointer<Utf8> key, Pointer<Utf8> model, Pointer<Utf8> base) =>
-      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>('aimux_xai_new_with_base')(key, model, base);
-  int bedrockNew(Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8> c, Pointer<Utf8> model) =>
-      _lib.lookupFunction<_FourStrC, _FourStrDart>('aimux_bedrock_new')(a, b, c, model);
-  int bedrockNewWithBase(
-          Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8> c, Pointer<Utf8> model, Pointer<Utf8> base) =>
-      _lib.lookupFunction<_FiveStrC, _FiveStrDart>('aimux_bedrock_new_with_base')(a, b, c, model, base);
-  int vertexNew(Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8> c, Pointer<Utf8> model) =>
-      _lib.lookupFunction<_FourStrC, _FourStrDart>('aimux_vertex_new')(a, b, c, model);
-  int vertexNewWithBase(
-          Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8> c, Pointer<Utf8> model, Pointer<Utf8> base) =>
-      _lib.lookupFunction<_FiveStrC, _FiveStrDart>('aimux_vertex_new_with_base')(a, b, c, model, base);
-  int anthropicAwsNew(Pointer<Utf8> key, Pointer<Utf8> region, Pointer<Utf8> model) =>
-      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>('aimux_anthropic_aws_new')(key, region, model);
-  int anthropicAwsNewWithBase(
-          Pointer<Utf8> key, Pointer<Utf8> region, Pointer<Utf8> model, Pointer<Utf8> base) =>
-      _lib.lookupFunction<_FourStrC, _FourStrDart>('aimux_anthropic_aws_new_with_base')(key, region, model, base);
-  int azureNew(
-          Pointer<Utf8> key, Pointer<Utf8> resource, Pointer<Utf8> deployment, Pointer<Utf8>? version) =>
-      _lib.lookupFunction<_FourStrC, _FourStrDart>('aimux_azure_new')(key, resource, deployment, version);
-  int azureNewWithBase(
-          Pointer<Utf8> key, Pointer<Utf8> base, Pointer<Utf8> deployment, Pointer<Utf8>? version) =>
-      _lib.lookupFunction<_FourStrC, _FourStrDart>('aimux_azure_new_with_base')(key, base, deployment, version);
+  Pointer<Utf8> cohereNew(Pointer<Utf8> key, Pointer<Utf8> model) =>
+      _lib.lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_cohere_new')(
+          key, model);
+  Pointer<Utf8> cohereNewWithBase(
+          Pointer<Utf8> key, Pointer<Utf8> model, Pointer<Utf8> base) =>
+      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>(
+          'aimux_cohere_new_with_base')(key, model, base);
+  Pointer<Utf8> mistralNew(Pointer<Utf8> key, Pointer<Utf8> model) =>
+      _lib.lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_mistral_new')(
+          key, model);
+  Pointer<Utf8> mistralNewWithBase(
+          Pointer<Utf8> key, Pointer<Utf8> model, Pointer<Utf8> base) =>
+      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>(
+          'aimux_mistral_new_with_base')(key, model, base);
+  Pointer<Utf8> xaiNew(Pointer<Utf8> key, Pointer<Utf8> model) => _lib
+      .lookupFunction<_OpenaiNewC, _OpenaiNewDart>('aimux_xai_new')(key, model);
+  Pointer<Utf8> xaiNewWithBase(
+          Pointer<Utf8> key, Pointer<Utf8> model, Pointer<Utf8> base) =>
+      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>(
+          'aimux_xai_new_with_base')(key, model, base);
+  Pointer<Utf8> bedrockNew(Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8> c,
+          Pointer<Utf8> model) =>
+      _lib.lookupFunction<_FourStrC, _FourStrDart>('aimux_bedrock_new')(
+          a, b, c, model);
+  Pointer<Utf8> bedrockNewWithBase(Pointer<Utf8> a, Pointer<Utf8> b,
+          Pointer<Utf8> c, Pointer<Utf8> model, Pointer<Utf8> base) =>
+      _lib.lookupFunction<_FiveStrC, _FiveStrDart>(
+          'aimux_bedrock_new_with_base')(a, b, c, model, base);
+  Pointer<Utf8> vertexNew(Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8> c,
+          Pointer<Utf8> model) =>
+      _lib.lookupFunction<_FourStrC, _FourStrDart>('aimux_vertex_new')(
+          a, b, c, model);
+  Pointer<Utf8> vertexNewWithBase(Pointer<Utf8> a, Pointer<Utf8> b,
+          Pointer<Utf8> c, Pointer<Utf8> model, Pointer<Utf8> base) =>
+      _lib.lookupFunction<_FiveStrC, _FiveStrDart>(
+          'aimux_vertex_new_with_base')(a, b, c, model, base);
+  Pointer<Utf8> anthropicAwsNew(
+          Pointer<Utf8> key, Pointer<Utf8> region, Pointer<Utf8> model) =>
+      _lib.lookupFunction<_NewWithBaseC, _NewWithBaseDart>(
+          'aimux_anthropic_aws_new')(key, region, model);
+  Pointer<Utf8> anthropicAwsNewWithBase(Pointer<Utf8> key, Pointer<Utf8> region,
+          Pointer<Utf8> model, Pointer<Utf8> base) =>
+      _lib.lookupFunction<_FourStrC, _FourStrDart>(
+          'aimux_anthropic_aws_new_with_base')(key, region, model, base);
+  Pointer<Utf8> azureNew(Pointer<Utf8> key, Pointer<Utf8> resource,
+          Pointer<Utf8> deployment, Pointer<Utf8>? version) =>
+      _lib.lookupFunction<_FourStrOptC, _FourStrOptDart>('aimux_azure_new')(
+          key, resource, deployment, version);
+  Pointer<Utf8> azureNewWithBase(Pointer<Utf8> key, Pointer<Utf8> base,
+          Pointer<Utf8> deployment, Pointer<Utf8>? version) =>
+      _lib.lookupFunction<_FourStrOptC, _FourStrOptDart>(
+          'aimux_azure_new_with_base')(key, base, deployment, version);
 }
 
 // Stream ABI type (can't use typedef with Pointer<NativeFunction> inline easily)
@@ -201,6 +237,22 @@ void _onError(Pointer<Utf8> errPtr) {
 // Model
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Parse a constructor's JSON result (`{"handle":<u64>}` on success,
+// `{"error":"..."}` on failure), free the pointer, and return the handle.
+int _extractHandle(_AimuxFFI ffi, Pointer<Utf8> ptr) {
+  if (ptr == nullptr) throw StateError('constructor returned null');
+  final result = ptr.toDartString();
+  ffi.freeString(ptr);
+  final decoded = jsonDecode(result);
+  if (decoded is Map<String, dynamic>) {
+    final error = decoded['error'];
+    if (error is String) throw StateError(error);
+    final handle = decoded['handle'];
+    if (handle is int) return handle;
+  }
+  throw StateError('invalid constructor response: $result');
+}
+
 /// A model instance backed by a Rust `Arc<dyn LanguageModel>`.
 ///
 /// Call [close] to release the native handle.
@@ -218,7 +270,7 @@ class Model {
   /// used via `aimux_openai_new`.
   factory Model.openai(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.openaiNew(keyPtr, idPtr);
@@ -227,8 +279,7 @@ class Model {
             (basePtr) => ffi.openaiNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create OpenAI model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create an Anthropic model instance.
@@ -237,7 +288,7 @@ class Model {
   /// null, the provider's standard URL is used via `aimux_anthropic_new`.
   factory Model.anthropic(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.anthropicNew(keyPtr, idPtr);
@@ -246,14 +297,13 @@ class Model {
             (basePtr) => ffi.anthropicNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Anthropic model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a Cohere model instance.
   factory Model.cohere(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.cohereNew(keyPtr, idPtr);
@@ -262,14 +312,13 @@ class Model {
             (basePtr) => ffi.cohereNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Cohere model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a Mistral model instance.
   factory Model.mistral(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.mistralNew(keyPtr, idPtr);
@@ -278,24 +327,22 @@ class Model {
             (basePtr) => ffi.mistralNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Mistral model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create an xAI model instance.
   factory Model.xai(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.xaiNew(keyPtr, idPtr);
         }
-        return _withUtf8(baseUrl,
-            (basePtr) => ffi.xaiNewWithBase(keyPtr, idPtr, basePtr));
+        return _withUtf8(
+            baseUrl, (basePtr) => ffi.xaiNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create xAI model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a Bedrock model instance (AWS SigV4 credentials).
@@ -303,7 +350,7 @@ class Model {
       String accessKeyId, String secretAccessKey, String region, String modelId,
       {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(accessKeyId, (aPtr) {
+    final ptr = _withUtf8(accessKeyId, (aPtr) {
       return _withUtf8(secretAccessKey, (bPtr) {
         return _withUtf8(region, (cPtr) {
           return _withUtf8(modelId, (idPtr) {
@@ -311,13 +358,14 @@ class Model {
               return ffi.bedrockNew(aPtr, bPtr, cPtr, idPtr);
             }
             return _withUtf8(
-                baseUrl, (basePtr) => ffi.bedrockNewWithBase(aPtr, bPtr, cPtr, idPtr, basePtr));
+                baseUrl,
+                (basePtr) =>
+                    ffi.bedrockNewWithBase(aPtr, bPtr, cPtr, idPtr, basePtr));
           });
         });
       });
     });
-    if (h == 0) throw StateError('Failed to create Bedrock model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a Vertex AI model instance (GCP bearer token).
@@ -325,7 +373,7 @@ class Model {
       String accessToken, String project, String location, String modelId,
       {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(accessToken, (aPtr) {
+    final ptr = _withUtf8(accessToken, (aPtr) {
       return _withUtf8(project, (bPtr) {
         return _withUtf8(location, (cPtr) {
           return _withUtf8(modelId, (idPtr) {
@@ -333,31 +381,34 @@ class Model {
               return ffi.vertexNew(aPtr, bPtr, cPtr, idPtr);
             }
             return _withUtf8(
-                baseUrl, (basePtr) => ffi.vertexNewWithBase(aPtr, bPtr, cPtr, idPtr, basePtr));
+                baseUrl,
+                (basePtr) =>
+                    ffi.vertexNewWithBase(aPtr, bPtr, cPtr, idPtr, basePtr));
           });
         });
       });
     });
-    if (h == 0) throw StateError('Failed to create Vertex model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create an Anthropic-on-AWS model instance (API key + region).
-  factory Model.anthropicAws(String apiKey, String region, String modelId, {String? baseUrl}) {
+  factory Model.anthropicAws(String apiKey, String region, String modelId,
+      {String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(region, (rPtr) {
         return _withUtf8(modelId, (idPtr) {
           if (baseUrl == null) {
             return ffi.anthropicAwsNew(keyPtr, rPtr, idPtr);
           }
           return _withUtf8(
-              baseUrl, (basePtr) => ffi.anthropicAwsNewWithBase(keyPtr, rPtr, idPtr, basePtr));
+              baseUrl,
+              (basePtr) =>
+                  ffi.anthropicAwsNewWithBase(keyPtr, rPtr, idPtr, basePtr));
         });
       });
     });
-    if (h == 0) throw StateError('Failed to create Anthropic AWS model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create an Azure OpenAI model instance (API key + resource name).
@@ -365,7 +416,7 @@ class Model {
   factory Model.azure(String apiKey, String resourceName, String deployment,
       {String? apiVersion, String? baseUrl}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(deployment, (dPtr) {
         final vPtr = apiVersion != null ? apiVersion.toNativeUtf8() : nullptr;
         try {
@@ -373,15 +424,14 @@ class Model {
             return _withUtf8(
                 resourceName, (rPtr) => ffi.azureNew(keyPtr, rPtr, dPtr, vPtr));
           }
-          return _withUtf8(
-              baseUrl, (bPtr) => ffi.azureNewWithBase(keyPtr, bPtr, dPtr, vPtr));
+          return _withUtf8(baseUrl,
+              (bPtr) => ffi.azureNewWithBase(keyPtr, bPtr, dPtr, vPtr));
         } finally {
           if (vPtr != nullptr) calloc.free(vPtr);
         }
       });
     });
-    if (h == 0) throw StateError('Failed to create Azure model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a model from the provider registry by name (RFC-0017 phase 4).
@@ -392,7 +442,7 @@ class Model {
   factory Model.provider(String name, String modelId,
       {String? apiKey, String? configJson}) {
     final ffi = _AimuxFFI();
-    final h = _withUtf8(name, (namePtr) {
+    final ptr = _withUtf8(name, (namePtr) {
       return _withUtf8(modelId, (idPtr) {
         final keyPtr = apiKey != null ? apiKey.toNativeUtf8() : nullptr;
         final cfgPtr = configJson != null ? configJson.toNativeUtf8() : nullptr;
@@ -404,8 +454,7 @@ class Model {
         }
       });
     });
-    if (h == 0) throw StateError('Failed to create provider model');
-    return Model._(h, ffi);
+    return Model._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Generate text (non-streaming).
@@ -425,7 +474,8 @@ class Model {
       final optsPtr = optsJson != null ? optsJson.toNativeUtf8() : nullptr;
       try {
         final resultPtr = _ffi.generateText(_handle, promptPtr, optsPtr);
-        if (resultPtr == nullptr) throw StateError('generate_text returned null');
+        if (resultPtr == nullptr)
+          throw StateError('generate_text returned null');
         final result = resultPtr.toDartString();
         _ffi.freeString(resultPtr);
         return result;

--- a/bindings/flutter/lib/multimodal.dart
+++ b/bindings/flutter/lib/multimodal.dart
@@ -23,24 +23,26 @@ import 'package:ffi/ffi.dart';
 
 // Constructors taking (api_key, model_id) → handle. Shared by every embedding,
 // speech, image, transcription, reranking, video, and search provider.
-typedef _NewC = Uint64 Function(Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
-typedef _NewDart = int Function(Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
+typedef _NewC = Pointer<Utf8> Function(
+    Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
+typedef _NewDart = Pointer<Utf8> Function(
+    Pointer<Utf8> apiKey, Pointer<Utf8> modelId);
 
 // Constructors taking (api_key, model_id, base_url) → handle (the _with_base
 // variants). Same signature for every provider.
-typedef _NewWithBaseC = Uint64 Function(
+typedef _NewWithBaseC = Pointer<Utf8> Function(
     Pointer<Utf8> apiKey, Pointer<Utf8> modelId, Pointer<Utf8> baseUrl);
-typedef _NewWithBaseDart = int Function(
+typedef _NewWithBaseDart = Pointer<Utf8> Function(
     Pointer<Utf8> apiKey, Pointer<Utf8> modelId, Pointer<Utf8> baseUrl);
 
 // Files constructors take only (api_key) — no model_id.
-typedef _FilesNewC = Uint64 Function(Pointer<Utf8> apiKey);
-typedef _FilesNewDart = int Function(Pointer<Utf8> apiKey);
+typedef _FilesNewC = Pointer<Utf8> Function(Pointer<Utf8> apiKey);
+typedef _FilesNewDart = Pointer<Utf8> Function(Pointer<Utf8> apiKey);
 
 // Files constructors with a custom base URL: (api_key, base_url).
-typedef _FilesNewWithBaseC = Uint64 Function(
+typedef _FilesNewWithBaseC = Pointer<Utf8> Function(
     Pointer<Utf8> apiKey, Pointer<Utf8> baseUrl);
-typedef _FilesNewWithBaseDart = int Function(
+typedef _FilesNewWithBaseDart = Pointer<Utf8> Function(
     Pointer<Utf8> apiKey, Pointer<Utf8> baseUrl);
 
 // aimux_embed(handle, values_json, opts_json) — opts nullable.
@@ -58,10 +60,10 @@ typedef _GenerateOpts1Dart = Pointer<Utf8> Function(
 
 // Three-arg generate functions: (handle, a, b, opts_json) → string, opts
 // nullable. Covers transcription_generate and file_upload.
-typedef _GenerateOpts3C = Pointer<Utf8> Function(Uint64 handle, Pointer<Utf8> a,
-    Pointer<Utf8> b, Pointer<Utf8>? optsJson);
-typedef _GenerateOpts3Dart = Pointer<Utf8> Function(int handle, Pointer<Utf8> a,
-    Pointer<Utf8> b, Pointer<Utf8>? optsJson);
+typedef _GenerateOpts3C = Pointer<Utf8> Function(
+    Uint64 handle, Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8>? optsJson);
+typedef _GenerateOpts3Dart = Pointer<Utf8> Function(
+    int handle, Pointer<Utf8> a, Pointer<Utf8> b, Pointer<Utf8>? optsJson);
 
 // Resource management (same as aimux.dart).
 typedef _DropHandleC = Void Function(Uint64);
@@ -75,42 +77,44 @@ typedef _FreeStringDart = void Function(Pointer<Utf8>);
 
 final class _MultimodalFFI {
   // Constructors — (api_key, model_id)
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) openaiEmbeddingNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) cohereEmbeddingNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) googleEmbeddingNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) openaiSpeechNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) openaiImageNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) googleImageNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) openaiTranscriptionNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) cohereRerankingNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) googleVideoNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) tavilySearchNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) openaiEmbeddingNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) cohereEmbeddingNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) googleEmbeddingNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) openaiSpeechNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) openaiImageNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) googleImageNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)
+      openaiTranscriptionNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) cohereRerankingNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) googleVideoNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>) tavilySearchNew;
 
   // Constructors — (api_key, model_id, base_url)
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       openaiEmbeddingNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       cohereEmbeddingNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       googleEmbeddingNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       openaiSpeechNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       openaiImageNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       googleImageNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       openaiTranscriptionNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       cohereRerankingNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       googleVideoNewWithBase;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
       tavilySearchNewWithBase;
 
   // Files constructors
-  final int Function(Pointer<Utf8>) openaiFilesNew;
-  final int Function(Pointer<Utf8>, Pointer<Utf8>) openaiFilesNewWithBase;
+  final Pointer<Utf8> Function(Pointer<Utf8>) openaiFilesNew;
+  final Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>)
+      openaiFilesNewWithBase;
 
   // Generate / embed / rerank / search / upload
   final Pointer<Utf8> Function(int, Pointer<Utf8>, Pointer<Utf8>?) embed;
@@ -119,10 +123,10 @@ final class _MultimodalFFI {
   final Pointer<Utf8> Function(int, Pointer<Utf8>) videoGenerate;
   final Pointer<Utf8> Function(int, Pointer<Utf8>) rerank;
   final Pointer<Utf8> Function(int, Pointer<Utf8>) search;
-  final Pointer<Utf8> Function(int, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>?)
-      transcriptionGenerate;
-  final Pointer<Utf8> Function(int, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>?)
-      fileUpload;
+  final Pointer<Utf8> Function(
+      int, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>?) transcriptionGenerate;
+  final Pointer<Utf8> Function(
+      int, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>?) fileUpload;
 
   // Resource management
   final void Function(int) dropHandle;
@@ -265,6 +269,24 @@ String _readResult(_MultimodalFFI ffi, Pointer<Utf8> ptr) {
   return result;
 }
 
+// Parse a constructor's JSON result (`{"handle":<u64>}` on success,
+// `{"error":"..."}` on failure), free the pointer, and return the handle.
+// Mirrors aimux.dart's `_extractHandle` (duplicated here to keep this file
+// self-contained, same as `_withUtf8`).
+int _extractHandle(_MultimodalFFI ffi, Pointer<Utf8> ptr) {
+  if (ptr == nullptr) throw StateError('constructor returned null');
+  final result = ptr.toDartString();
+  ffi.freeString(ptr);
+  final decoded = jsonDecode(result);
+  if (decoded is Map<String, dynamic>) {
+    final error = decoded['error'];
+    if (error is String) throw StateError(error);
+    final handle = decoded['handle'];
+    if (handle is int) return handle;
+  }
+  throw StateError('invalid constructor response: $result');
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // EmbeddingModel
 // ─────────────────────────────────────────────────────────────────────────────
@@ -286,51 +308,54 @@ class EmbeddingModel {
   factory EmbeddingModel.openai(String apiKey, String modelId,
       {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.openaiEmbeddingNew(keyPtr, idPtr);
         }
-        return _withUtf8(baseUrl,
-            (basePtr) => ffi.openaiEmbeddingNewWithBase(keyPtr, idPtr, basePtr));
+        return _withUtf8(
+            baseUrl,
+            (basePtr) =>
+                ffi.openaiEmbeddingNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create OpenAI embedding model');
-    return EmbeddingModel._(h, ffi);
+    return EmbeddingModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a Cohere embedding model (e.g. embed-english-v3.0).
   factory EmbeddingModel.cohere(String apiKey, String modelId,
       {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.cohereEmbeddingNew(keyPtr, idPtr);
         }
-        return _withUtf8(baseUrl,
-            (basePtr) => ffi.cohereEmbeddingNewWithBase(keyPtr, idPtr, basePtr));
+        return _withUtf8(
+            baseUrl,
+            (basePtr) =>
+                ffi.cohereEmbeddingNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Cohere embedding model');
-    return EmbeddingModel._(h, ffi);
+    return EmbeddingModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a Google embedding model (e.g. gemini-embedding-001).
   factory EmbeddingModel.google(String apiKey, String modelId,
       {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.googleEmbeddingNew(keyPtr, idPtr);
         }
-        return _withUtf8(baseUrl,
-            (basePtr) => ffi.googleEmbeddingNewWithBase(keyPtr, idPtr, basePtr));
+        return _withUtf8(
+            baseUrl,
+            (basePtr) =>
+                ffi.googleEmbeddingNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Google embedding model');
-    return EmbeddingModel._(h, ffi);
+    return EmbeddingModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Generate embeddings for [valuesJson] (a JSON array of strings).
@@ -378,10 +403,9 @@ class SpeechModel {
   SpeechModel._(this._handle, this._ffi);
 
   /// Create an OpenAI speech (TTS) model.
-  factory SpeechModel.openai(String apiKey, String modelId,
-      {String? baseUrl}) {
+  factory SpeechModel.openai(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.openaiSpeechNew(keyPtr, idPtr);
@@ -390,8 +414,7 @@ class SpeechModel {
             (basePtr) => ffi.openaiSpeechNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create OpenAI speech model');
-    return SpeechModel._(h, ffi);
+    return SpeechModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Generate speech audio from [optsJson] (serialized SpeechCallOptions).
@@ -436,17 +459,18 @@ class TranscriptionModel {
   factory TranscriptionModel.openai(String apiKey, String modelId,
       {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.openaiTranscriptionNew(keyPtr, idPtr);
         }
-        return _withUtf8(baseUrl,
-            (basePtr) => ffi.openaiTranscriptionNewWithBase(keyPtr, idPtr, basePtr));
+        return _withUtf8(
+            baseUrl,
+            (basePtr) =>
+                ffi.openaiTranscriptionNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create OpenAI transcription model');
-    return TranscriptionModel._(h, ffi);
+    return TranscriptionModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Transcribe audio to text.
@@ -501,7 +525,7 @@ class ImageModel {
   /// Create an OpenAI image model (e.g. dall-e-3).
   factory ImageModel.openai(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.openaiImageNew(keyPtr, idPtr);
@@ -510,14 +534,13 @@ class ImageModel {
             (basePtr) => ffi.openaiImageNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create OpenAI image model');
-    return ImageModel._(h, ffi);
+    return ImageModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Create a Google image model (e.g. gemini-2.5-flash-image).
   factory ImageModel.google(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.googleImageNew(keyPtr, idPtr);
@@ -526,8 +549,7 @@ class ImageModel {
             (basePtr) => ffi.googleImageNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Google image model');
-    return ImageModel._(h, ffi);
+    return ImageModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Generate images from [optsJson] (serialized ImageCallOptions).
@@ -571,7 +593,7 @@ class VideoModel {
   /// Create a Google video model (e.g. veo-3.0).
   factory VideoModel.google(String apiKey, String modelId, {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.googleVideoNew(keyPtr, idPtr);
@@ -580,8 +602,7 @@ class VideoModel {
             (basePtr) => ffi.googleVideoNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Google video model');
-    return VideoModel._(h, ffi);
+    return VideoModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Generate videos from [optsJson] (serialized VideoCallOptions).
@@ -626,17 +647,18 @@ class RerankingModel {
   factory RerankingModel.cohere(String apiKey, String modelId,
       {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8(modelId, (idPtr) {
         if (baseUrl == null) {
           return ffi.cohereRerankingNew(keyPtr, idPtr);
         }
-        return _withUtf8(baseUrl,
-            (basePtr) => ffi.cohereRerankingNewWithBase(keyPtr, idPtr, basePtr));
+        return _withUtf8(
+            baseUrl,
+            (basePtr) =>
+                ffi.cohereRerankingNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Cohere reranking model');
-    return RerankingModel._(h, ffi);
+    return RerankingModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Rerank documents against a query.
@@ -682,7 +704,7 @@ class SearchModel {
   /// ID is needed — an empty string is passed (the C ABI ignores it).
   factory SearchModel.tavily(String apiKey, {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       return _withUtf8('', (idPtr) {
         if (baseUrl == null) {
           return ffi.tavilySearchNew(keyPtr, idPtr);
@@ -691,8 +713,7 @@ class SearchModel {
             (basePtr) => ffi.tavilySearchNewWithBase(keyPtr, idPtr, basePtr));
       });
     });
-    if (h == 0) throw StateError('Failed to create Tavily search model');
-    return SearchModel._(h, ffi);
+    return SearchModel._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Perform a web search.
@@ -737,15 +758,14 @@ class Files {
   /// Create an OpenAI files manager. Files take only an API key (no model ID).
   factory Files.openai(String apiKey, {String? baseUrl}) {
     final ffi = _MultimodalFFI();
-    final h = _withUtf8(apiKey, (keyPtr) {
+    final ptr = _withUtf8(apiKey, (keyPtr) {
       if (baseUrl == null) {
         return ffi.openaiFilesNew(keyPtr);
       }
       return _withUtf8(
           baseUrl, (basePtr) => ffi.openaiFilesNewWithBase(keyPtr, basePtr));
     });
-    if (h == 0) throw StateError('Failed to create OpenAI files manager');
-    return Files._(h, ffi);
+    return Files._(_extractHandle(ffi, ptr), ffi);
   }
 
   /// Upload a file to the provider.

--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -57,53 +57,53 @@ static void do_stream(uint64_t handle, const char* prompt, const char* opts, int
 //    exported as C symbols from libaimux_ffi.a) ────────────────────────────
 
 // Embedding
-uint64_t aimux_openai_embedding_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
-uint64_t aimux_cohere_embedding_new(const char *api_key, const char *model_id);
-uint64_t aimux_cohere_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
-uint64_t aimux_google_embedding_new(const char *api_key, const char *model_id);
-uint64_t aimux_google_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_embedding_new(const char *api_key, const char *model_id);
+char *aimux_openai_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_cohere_embedding_new(const char *api_key, const char *model_id);
+char *aimux_cohere_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_google_embedding_new(const char *api_key, const char *model_id);
+char *aimux_google_embedding_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_embed(uint64_t handle, const char *values_json, const char *opts_json);
 
 // Registry provider (RFC-0017 phase 4): name + optional api_key/env + config JSON
-uint64_t aimux_provider_new(const char *name, const char *api_key, const char *model_id, const char *config_json);
-uint64_t aimux_provider_from_env(const char *name, const char *model_id);
+char *aimux_provider_new(const char *name, const char *api_key, const char *model_id, const char *config_json);
+char *aimux_provider_from_env(const char *name, const char *model_id);
 
 // Speech (TTS)
-uint64_t aimux_openai_speech_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_speech_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_speech_new(const char *api_key, const char *model_id);
+char *aimux_openai_speech_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_speech_generate(uint64_t handle, const char *opts_json);
 
 // Image
-uint64_t aimux_openai_image_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
-uint64_t aimux_google_image_new(const char *api_key, const char *model_id);
-uint64_t aimux_google_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_image_new(const char *api_key, const char *model_id);
+char *aimux_openai_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_google_image_new(const char *api_key, const char *model_id);
+char *aimux_google_image_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_image_generate(uint64_t handle, const char *opts_json);
 
 // Transcription (STT)
-uint64_t aimux_openai_transcription_new(const char *api_key, const char *model_id);
-uint64_t aimux_openai_transcription_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_openai_transcription_new(const char *api_key, const char *model_id);
+char *aimux_openai_transcription_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_transcription_generate(uint64_t handle, const char *audio_base64, const char *media_type, const char *opts_json);
 
 // Files
-uint64_t aimux_openai_files_new(const char *api_key);
-uint64_t aimux_openai_files_new_with_base(const char *api_key, const char *base_url);
+char *aimux_openai_files_new(const char *api_key);
+char *aimux_openai_files_new_with_base(const char *api_key, const char *base_url);
 char *aimux_file_upload(uint64_t handle, const char *data_base64, const char *media_type, const char *opts_json);
 
 // Reranking
-uint64_t aimux_cohere_reranking_new(const char *api_key, const char *model_id);
-uint64_t aimux_cohere_reranking_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_cohere_reranking_new(const char *api_key, const char *model_id);
+char *aimux_cohere_reranking_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_rerank(uint64_t handle, const char *opts_json);
 
 // Video
-uint64_t aimux_google_video_new(const char *api_key, const char *model_id);
-uint64_t aimux_google_video_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_google_video_new(const char *api_key, const char *model_id);
+char *aimux_google_video_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_video_generate(uint64_t handle, const char *opts_json);
 
 // Search
-uint64_t aimux_tavily_search_new(const char *api_key, const char *model_id);
-uint64_t aimux_tavily_search_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_tavily_search_new(const char *api_key, const char *model_id);
+char *aimux_tavily_search_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_search(uint64_t handle, const char *opts_json);
 */
 import "C"
@@ -295,56 +295,68 @@ func mustNew(m *Model, err error) *Model {
 	return m
 }
 
+// parseHandleJSON parses a constructor's JSON result
+// (`{"handle":<u64>}` on success, `{"error":...}` on failure), freeing the
+// C string. Mirrors extractError, which does the same for GenerateText.
+func parseHandleJSON(ptr *C.char) (uint64, error) {
+	if ptr == nil {
+		return 0, errors.New("aimux: constructor returned null")
+	}
+	defer C.aimux_free_string(ptr)
+	result := C.GoString(ptr)
+	if msg := extractError(result); msg != "" {
+		return 0, fmt.Errorf("aimux: %s", msg)
+	}
+	var envelope struct {
+		Handle uint64 `json:"handle"`
+	}
+	if err := json.Unmarshal([]byte(result), &envelope); err != nil {
+		return 0, fmt.Errorf("aimux: failed to parse constructor result: %w", err)
+	}
+	if envelope.Handle == 0 {
+		return 0, fmt.Errorf("aimux: constructor returned neither handle nor error: %s", result)
+	}
+	return envelope.Handle, nil
+}
+
 func newModel(apiKey, modelID, baseURL, kind string) (*Model, error) {
-	// Constructor + last_error read must run on the same OS thread
-	// (aimux_last_error is thread-local). Constructors are pure config
-	// building, so pinning the thread is cheap.
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	m := &Model{}
 	cKey := C.CString(apiKey)
 	cModel := C.CString(modelID)
 	defer C.free(unsafe.Pointer(cKey))
 	defer C.free(unsafe.Pointer(cModel))
 
-	var h C.uint64_t
+	var ptr *C.char
 	if baseURL == "" {
 		switch kind {
 		case "anthropic":
-			h = C.aimux_anthropic_new(cKey, cModel)
+			ptr = C.aimux_anthropic_new(cKey, cModel)
 		case "cohere":
-			h = C.aimux_cohere_new(cKey, cModel)
+			ptr = C.aimux_cohere_new(cKey, cModel)
 		case "mistral":
-			h = C.aimux_mistral_new(cKey, cModel)
+			ptr = C.aimux_mistral_new(cKey, cModel)
 		case "xai":
-			h = C.aimux_xai_new(cKey, cModel)
+			ptr = C.aimux_xai_new(cKey, cModel)
 		default:
-			h = C.aimux_openai_new(cKey, cModel)
+			ptr = C.aimux_openai_new(cKey, cModel)
 		}
 	} else {
 		cBase := C.CString(baseURL)
 		defer C.free(unsafe.Pointer(cBase))
 		switch kind {
 		case "anthropic":
-			h = C.aimux_anthropic_new_with_base(cKey, cModel, cBase)
+			ptr = C.aimux_anthropic_new_with_base(cKey, cModel, cBase)
 		case "cohere":
-			h = C.aimux_cohere_new_with_base(cKey, cModel, cBase)
+			ptr = C.aimux_cohere_new_with_base(cKey, cModel, cBase)
 		case "mistral":
-			h = C.aimux_mistral_new_with_base(cKey, cModel, cBase)
+			ptr = C.aimux_mistral_new_with_base(cKey, cModel, cBase)
 		case "xai":
-			h = C.aimux_xai_new_with_base(cKey, cModel, cBase)
+			ptr = C.aimux_xai_new_with_base(cKey, cModel, cBase)
 		default:
-			h = C.aimux_openai_new_with_base(cKey, cModel, cBase)
+			ptr = C.aimux_openai_new_with_base(cKey, cModel, cBase)
 		}
 	}
-	if h == 0 {
-		return nil, takeLastError("aimux: failed to create model (handle=0)")
-	}
-	m.handle = uint64(h)
-
-	// Set finalizer as a safety net; callers should still use Close().
-	runtime.SetFinalizer(m, func(m *Model) { m.Close() })
-	return m, nil
+	return wrapHandle(m, ptr)
 }
 
 func newBedrockModel(accessKeyID, secretAccessKey, region, modelID, baseURL string) (*Model, error) {
@@ -358,15 +370,15 @@ func newBedrockModel(accessKeyID, secretAccessKey, region, modelID, baseURL stri
 	defer C.free(unsafe.Pointer(cRegion))
 	defer C.free(unsafe.Pointer(cModel))
 
-	var h C.uint64_t
+	var ptr *C.char
 	if baseURL == "" {
-		h = C.aimux_bedrock_new(cAccess, cSecret, cRegion, cModel)
+		ptr = C.aimux_bedrock_new(cAccess, cSecret, cRegion, cModel)
 	} else {
 		cBase := C.CString(baseURL)
 		defer C.free(unsafe.Pointer(cBase))
-		h = C.aimux_bedrock_new_with_base(cAccess, cSecret, cRegion, cModel, cBase)
+		ptr = C.aimux_bedrock_new_with_base(cAccess, cSecret, cRegion, cModel, cBase)
 	}
-	return wrapHandle(m, h)
+	return wrapHandle(m, ptr)
 }
 
 func newVertexModel(accessToken, project, location, modelID, baseURL string) (*Model, error) {
@@ -380,15 +392,15 @@ func newVertexModel(accessToken, project, location, modelID, baseURL string) (*M
 	defer C.free(unsafe.Pointer(cLocation))
 	defer C.free(unsafe.Pointer(cModel))
 
-	var h C.uint64_t
+	var ptr *C.char
 	if baseURL == "" {
-		h = C.aimux_vertex_new(cToken, cProject, cLocation, cModel)
+		ptr = C.aimux_vertex_new(cToken, cProject, cLocation, cModel)
 	} else {
 		cBase := C.CString(baseURL)
 		defer C.free(unsafe.Pointer(cBase))
-		h = C.aimux_vertex_new_with_base(cToken, cProject, cLocation, cModel, cBase)
+		ptr = C.aimux_vertex_new_with_base(cToken, cProject, cLocation, cModel, cBase)
 	}
-	return wrapHandle(m, h)
+	return wrapHandle(m, ptr)
 }
 
 func newAnthropicAwsModel(apiKey, region, modelID, baseURL string) (*Model, error) {
@@ -400,15 +412,15 @@ func newAnthropicAwsModel(apiKey, region, modelID, baseURL string) (*Model, erro
 	defer C.free(unsafe.Pointer(cRegion))
 	defer C.free(unsafe.Pointer(cModel))
 
-	var h C.uint64_t
+	var ptr *C.char
 	if baseURL == "" {
-		h = C.aimux_anthropic_aws_new(cKey, cRegion, cModel)
+		ptr = C.aimux_anthropic_aws_new(cKey, cRegion, cModel)
 	} else {
 		cBase := C.CString(baseURL)
 		defer C.free(unsafe.Pointer(cBase))
-		h = C.aimux_anthropic_aws_new_with_base(cKey, cRegion, cModel, cBase)
+		ptr = C.aimux_anthropic_aws_new_with_base(cKey, cRegion, cModel, cBase)
 	}
-	return wrapHandle(m, h)
+	return wrapHandle(m, ptr)
 }
 
 func newAzureModel(apiKey, resourceOrBase, deployment, apiVersion string, useBase bool) (*Model, error) {
@@ -422,24 +434,23 @@ func newAzureModel(apiKey, resourceOrBase, deployment, apiVersion string, useBas
 	defer C.free(unsafe.Pointer(cDeployment))
 	defer C.free(unsafe.Pointer(cVersion))
 
-	var h C.uint64_t
+	var ptr *C.char
 	if useBase {
-		h = C.aimux_azure_new_with_base(cKey, cResource, cDeployment, cVersion)
+		ptr = C.aimux_azure_new_with_base(cKey, cResource, cDeployment, cVersion)
 	} else {
-		h = C.aimux_azure_new(cKey, cResource, cDeployment, cVersion)
+		ptr = C.aimux_azure_new(cKey, cResource, cDeployment, cVersion)
 	}
-	return wrapHandle(m, h)
+	return wrapHandle(m, ptr)
 }
 
-func wrapHandle(m *Model, h C.uint64_t) (*Model, error) {
-	// Constructor + last_error read must run on the same OS thread
-	// (aimux_last_error is thread-local).
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	if h == 0 {
-		return nil, takeLastError("aimux: failed to create model (handle=0)")
+// wrapHandle parses a constructor's JSON result into m, with a finalizer as
+// a safety net (callers should still use Close).
+func wrapHandle(m *Model, ptr *C.char) (*Model, error) {
+	h, err := parseHandleJSON(ptr)
+	if err != nil {
+		return nil, err
 	}
-	m.handle = uint64(h)
+	m.handle = h
 	runtime.SetFinalizer(m, func(m *Model) { m.Close() })
 	return m, nil
 }
@@ -454,10 +465,6 @@ func Provider(name, apiKey, modelID string) (*Model, error) {
 
 // ProviderWithBase is Provider with a base URL override (config_json).
 func ProviderWithBase(name, apiKey, modelID, baseURL string) (*Model, error) {
-	// Constructor + last_error read must run on the same OS thread
-	// (aimux_last_error is thread-local).
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	m := &Model{}
 	cName := C.CString(name)
 	cModel := C.CString(modelID)
@@ -477,13 +484,8 @@ func ProviderWithBase(name, apiKey, modelID, baseURL string) (*Model, error) {
 		defer C.free(unsafe.Pointer(cConfig))
 	}
 
-	h := C.aimux_provider_new(cName, cKey, cModel, cConfig)
-	if h == 0 {
-		return nil, takeLastError(fmt.Sprintf("aimux: failed to create provider %q (handle=0)", name))
-	}
-	m.handle = uint64(h)
-	runtime.SetFinalizer(m, func(m *Model) { m.Close() })
-	return m, nil
+	ptr := C.aimux_provider_new(cName, cKey, cModel, cConfig)
+	return wrapHandle(m, ptr)
 }
 
 // ── Non-streaming generation ────────────────────────────────────────────────
@@ -542,21 +544,6 @@ func extractError(result string) string {
 	return ""
 }
 
-// takeLastError reads the FFI thread-local last-constructor error (issue #17)
-// and wraps it into a Go error. The failed constructor and this read must run
-// on the same OS thread — callers wrap both in runtime.LockOSThread.
-func takeLastError(fallback string) error {
-	if eptr := C.aimux_last_error(); eptr != nil {
-		defer C.aimux_free_string(eptr)
-		msg := C.GoString(eptr)
-		if extracted := extractError(msg); extracted != "" {
-			return fmt.Errorf("aimux: %s", extracted)
-		}
-		return fmt.Errorf("aimux: %s", msg)
-	}
-	return errors.New(fallback)
-}
-
 // ── Streaming generation ─────────────────────────────────────────────────────
 
 // streamEntry holds the channel and error for an active stream.
@@ -608,8 +595,12 @@ func (e *streamEntry) closeParts() {
 // Consume parts via the Parts() channel; check Err() after the channel closes.
 //
 // The channel is buffered (256). If the caller stops consuming, the native
-// stream will block on the 257th part — always drain the channel or use
-// StreamTextContext with a context to cancel.
+// stream will block on the 257th part and the stream goroutine (plus the
+// underlying model call) will stall until the stream ends or times out —
+// always drain the channel. There is no context-cancel API (the C ABI
+// stream is synchronous and has no abort hook); the only interruption
+// mechanism is a per-call timeout via GenerateTextOptions.Timeout
+// (RFC-0016 H3).
 type Stream struct {
 	parts <-chan string
 	entry *streamEntry
@@ -639,9 +630,12 @@ func (s *Stream) Err() error {
 //	    log.Fatal(err)
 //	}
 //
-// You MUST drain the Parts() channel (or cancel via StreamTextContext).
-// If you stop reading, the native callback blocks once the 256-part buffer
-// fills, stalling the stream goroutine and the model.
+// You MUST drain the Parts() channel. If you stop reading, the native
+// callback blocks once the 256-part buffer fills, stalling the stream
+// goroutine and the model until the stream ends or the per-call timeout
+// fires (GenerateTextOptions.Timeout, RFC-0016 H3). There is no
+// context-cancel API — the C ABI stream is synchronous and has no abort
+// hook.
 func (m *Model) StreamText(promptJson, optsJson string) *Stream {
 	entry, id := registerStream()
 

--- a/bindings/go/multimodal.go
+++ b/bindings/go/multimodal.go
@@ -19,14 +19,14 @@ package aimux
 #include "aimux-ffi.h"
 
 // Functions exported by libaimux_ffi.a but not yet declared in aimux-ffi.h.
-uint64_t aimux_cohere_reranking_new(const char *api_key, const char *model_id);
-uint64_t aimux_cohere_reranking_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_cohere_reranking_new(const char *api_key, const char *model_id);
+char *aimux_cohere_reranking_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_rerank(uint64_t handle, const char *opts_json);
-uint64_t aimux_google_video_new(const char *api_key, const char *model_id);
-uint64_t aimux_google_video_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_google_video_new(const char *api_key, const char *model_id);
+char *aimux_google_video_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_video_generate(uint64_t handle, const char *opts_json);
-uint64_t aimux_tavily_search_new(const char *api_key, const char *model_id);
-uint64_t aimux_tavily_search_new_with_base(const char *api_key, const char *model_id, const char *base_url);
+char *aimux_tavily_search_new(const char *api_key, const char *model_id);
+char *aimux_tavily_search_new_with_base(const char *api_key, const char *model_id, const char *base_url);
 char *aimux_search(uint64_t handle, const char *opts_json);
 */
 import "C"
@@ -96,18 +96,14 @@ func callFFIString(h *multimodalHandle, fn func(handle C.uint64_t) *C.char) (str
 	return result, nil
 }
 
-// newMultimodalHandle calls a C constructor and returns a handle wrapper.
-func newMultimodalHandle(fn func() C.uint64_t) (*multimodalHandle, error) {
-	// Constructor + last_error read must run on the same OS thread
-	// (aimux_last_error is thread-local).
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	h := C.uint64_t(fn())
-	if h == 0 {
-		return nil, takeLastError("aimux: failed to create model (handle=0)")
+// newMultimodalHandle calls a C constructor and parses its JSON result
+// (`{"handle":<u64>}` on success, `{"error":...}` on failure).
+func newMultimodalHandle(fn func() *C.char) (*multimodalHandle, error) {
+	h, err := parseHandleJSON(fn())
+	if err != nil {
+		return nil, err
 	}
-	mh := &multimodalHandle{handle: uint64(h)}
-	return mh, nil
+	return &multimodalHandle{handle: h}, nil
 }
 
 // cstringPair creates two C strings and returns them with a cleanup func.
@@ -137,34 +133,34 @@ func cstringTriple(a, b, c string) (*C.char, *C.char, *C.char, func()) {
 // empty, the no-base C constructor is used; otherwise the _with_base variant.
 func newMultimodalModelWithBase(
 	apiKey, modelID, baseURL string,
-	plain func(ca, cb *C.char) C.uint64_t,
-	withBase func(ca, cb, cbase *C.char) C.uint64_t,
+	plain func(ca, cb *C.char) *C.char,
+	withBase func(ca, cb, cbase *C.char) *C.char,
 ) (*multimodalHandle, error) {
 	if baseURL == "" {
 		ca, cb, cleanup := cstringPair(apiKey, modelID)
 		defer cleanup()
-		return newMultimodalHandle(func() C.uint64_t { return plain(ca, cb) })
+		return newMultimodalHandle(func() *C.char { return plain(ca, cb) })
 	}
 	ca, cb, cbase, cleanup := cstringTriple(apiKey, modelID, baseURL)
 	defer cleanup()
-	return newMultimodalHandle(func() C.uint64_t { return withBase(ca, cb, cbase) })
+	return newMultimodalHandle(func() *C.char { return withBase(ca, cb, cbase) })
 }
 
 // newMultimodalModelFiles is the constructor for the Files manager, which
 // takes only an api_key (no model_id) and optionally a base_url.
 func newMultimodalModelFiles(
 	apiKey, baseURL string,
-	plain func(ca *C.char) C.uint64_t,
-	withBase func(ca, cbase *C.char) C.uint64_t,
+	plain func(ca *C.char) *C.char,
+	withBase func(ca, cbase *C.char) *C.char,
 ) (*multimodalHandle, error) {
 	ca := C.CString(apiKey)
 	defer C.free(unsafe.Pointer(ca))
 	if baseURL == "" {
-		return newMultimodalHandle(func() C.uint64_t { return plain(ca) })
+		return newMultimodalHandle(func() *C.char { return plain(ca) })
 	}
 	cbase := C.CString(baseURL)
 	defer C.free(unsafe.Pointer(cbase))
-	return newMultimodalHandle(func() C.uint64_t { return withBase(ca, cbase) })
+	return newMultimodalHandle(func() *C.char { return withBase(ca, cbase) })
 }
 
 // ── EmbeddingModel ──────────────────────────────────────────────────────────
@@ -242,8 +238,8 @@ func NewOpenAIEmbedding(apiKey, modelID string) (*EmbeddingModel, error) {
 // NewOpenAIEmbeddingWithBase creates an OpenAI embedding model with a custom base URL.
 func NewOpenAIEmbeddingWithBase(apiKey, modelID, baseURL string) (*EmbeddingModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_openai_embedding_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_openai_embedding_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_openai_embedding_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_openai_embedding_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -261,8 +257,8 @@ func NewCohereEmbedding(apiKey, modelID string) (*EmbeddingModel, error) {
 // NewCohereEmbeddingWithBase creates a Cohere embedding model with a custom base URL.
 func NewCohereEmbeddingWithBase(apiKey, modelID, baseURL string) (*EmbeddingModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_cohere_embedding_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_cohere_embedding_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_cohere_embedding_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_cohere_embedding_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -280,8 +276,8 @@ func NewGoogleEmbedding(apiKey, modelID string) (*EmbeddingModel, error) {
 // NewGoogleEmbeddingWithBase creates a Google embedding model with a custom base URL.
 func NewGoogleEmbeddingWithBase(apiKey, modelID, baseURL string) (*EmbeddingModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_google_embedding_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_google_embedding_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_google_embedding_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_google_embedding_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -333,8 +329,8 @@ func NewOpenAISpeech(apiKey, modelID string) (*SpeechModel, error) {
 // NewOpenAISpeechWithBase creates an OpenAI speech model with a custom base URL.
 func NewOpenAISpeechWithBase(apiKey, modelID, baseURL string) (*SpeechModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_openai_speech_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_openai_speech_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_openai_speech_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_openai_speech_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -385,8 +381,8 @@ func NewOpenAIImage(apiKey, modelID string) (*ImageModel, error) {
 // NewOpenAIImageWithBase creates an OpenAI image model with a custom base URL.
 func NewOpenAIImageWithBase(apiKey, modelID, baseURL string) (*ImageModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_openai_image_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_openai_image_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_openai_image_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_openai_image_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -404,8 +400,8 @@ func NewGoogleImage(apiKey, modelID string) (*ImageModel, error) {
 // NewGoogleImageWithBase creates a Google image model with a custom base URL.
 func NewGoogleImageWithBase(apiKey, modelID, baseURL string) (*ImageModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_google_image_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_google_image_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_google_image_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_google_image_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -477,8 +473,8 @@ func NewOpenAITranscription(apiKey, modelID string) (*TranscriptionModel, error)
 // NewOpenAITranscriptionWithBase creates an OpenAI transcription model with a custom base URL.
 func NewOpenAITranscriptionWithBase(apiKey, modelID, baseURL string) (*TranscriptionModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_openai_transcription_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_openai_transcription_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_openai_transcription_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_openai_transcription_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -550,8 +546,8 @@ func NewOpenAIFiles(apiKey string) (*Files, error) {
 // NewOpenAIFilesWithBase creates an OpenAI files manager with a custom base URL.
 func NewOpenAIFilesWithBase(apiKey, baseURL string) (*Files, error) {
 	mh, err := newMultimodalModelFiles(apiKey, baseURL,
-		func(ca *C.char) C.uint64_t { return C.aimux_openai_files_new(ca) },
-		func(ca, cbase *C.char) C.uint64_t { return C.aimux_openai_files_new_with_base(ca, cbase) },
+		func(ca *C.char) *C.char { return C.aimux_openai_files_new(ca) },
+		func(ca, cbase *C.char) *C.char { return C.aimux_openai_files_new_with_base(ca, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -603,8 +599,8 @@ func NewCohereReranking(apiKey, modelID string) (*RerankingModel, error) {
 // NewCohereRerankingWithBase creates a Cohere reranking model with a custom base URL.
 func NewCohereRerankingWithBase(apiKey, modelID, baseURL string) (*RerankingModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_cohere_reranking_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_cohere_reranking_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_cohere_reranking_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_cohere_reranking_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -655,8 +651,8 @@ func NewGoogleVideo(apiKey, modelID string) (*VideoModel, error) {
 // NewGoogleVideoWithBase creates a Google video model with a custom base URL.
 func NewGoogleVideoWithBase(apiKey, modelID, baseURL string) (*VideoModel, error) {
 	mh, err := newMultimodalModelWithBase(apiKey, modelID, baseURL,
-		func(ca, cb *C.char) C.uint64_t { return C.aimux_google_video_new(ca, cb) },
-		func(ca, cb, cbase *C.char) C.uint64_t { return C.aimux_google_video_new_with_base(ca, cb, cbase) },
+		func(ca, cb *C.char) *C.char { return C.aimux_google_video_new(ca, cb) },
+		func(ca, cb, cbase *C.char) *C.char { return C.aimux_google_video_new_with_base(ca, cb, cbase) },
 	)
 	if err != nil {
 		return nil, err
@@ -711,7 +707,7 @@ func NewTavilySearchWithBase(apiKey, baseURL string) (*SearchModel, error) {
 	ca := C.CString(apiKey)
 	defer C.free(unsafe.Pointer(ca))
 	if baseURL == "" {
-		mh, err := newMultimodalHandle(func() C.uint64_t {
+		mh, err := newMultimodalHandle(func() *C.char {
 			return C.aimux_tavily_search_new(ca, nil)
 		})
 		if err != nil {
@@ -723,7 +719,7 @@ func NewTavilySearchWithBase(apiKey, baseURL string) (*SearchModel, error) {
 	}
 	cbase := C.CString(baseURL)
 	defer C.free(unsafe.Pointer(cbase))
-	mh, err := newMultimodalHandle(func() C.uint64_t {
+	mh, err := newMultimodalHandle(func() *C.char {
 		return C.aimux_tavily_search_new_with_base(ca, nil, cbase)
 	})
 	if err != nil {

--- a/bindings/java/src/main/java/io/aimux/AimuxFFI.java
+++ b/bindings/java/src/main/java/io/aimux/AimuxFFI.java
@@ -28,51 +28,51 @@ public interface AimuxFFI extends Library {
 
     AimuxFFI INSTANCE = Native.load("aimux_ffi", AimuxFFI.class);
 
-    // ── Provider constructors (return opaque handle, >0 on success, 0 on failure) ──
+    // ── Provider constructors (return JSON envelope: {"handle":N} on success, {"error":...} on failure; free with aimux_free_string) ──
 
-    long aimux_openai_new(String apiKey, String modelId);
+    Pointer aimux_openai_new(String apiKey, String modelId);
 
-    long aimux_openai_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_openai_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_anthropic_new(String apiKey, String modelId);
+    Pointer aimux_anthropic_new(String apiKey, String modelId);
 
-    long aimux_anthropic_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_anthropic_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_cohere_new(String apiKey, String modelId);
+    Pointer aimux_cohere_new(String apiKey, String modelId);
 
-    long aimux_cohere_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_cohere_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_mistral_new(String apiKey, String modelId);
+    Pointer aimux_mistral_new(String apiKey, String modelId);
 
-    long aimux_mistral_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_mistral_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_xai_new(String apiKey, String modelId);
+    Pointer aimux_xai_new(String apiKey, String modelId);
 
-    long aimux_xai_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_xai_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_bedrock_new(String accessKeyId, String secretAccessKey, String region, String modelId);
+    Pointer aimux_bedrock_new(String accessKeyId, String secretAccessKey, String region, String modelId);
 
-    long aimux_bedrock_new_with_base(String accessKeyId, String secretAccessKey, String region, String modelId, String baseUrl);
+    Pointer aimux_bedrock_new_with_base(String accessKeyId, String secretAccessKey, String region, String modelId, String baseUrl);
 
-    long aimux_vertex_new(String accessToken, String project, String location, String modelId);
+    Pointer aimux_vertex_new(String accessToken, String project, String location, String modelId);
 
-    long aimux_vertex_new_with_base(String accessToken, String project, String location, String modelId, String baseUrl);
+    Pointer aimux_vertex_new_with_base(String accessToken, String project, String location, String modelId, String baseUrl);
 
-    long aimux_anthropic_aws_new(String apiKey, String region, String modelId);
+    Pointer aimux_anthropic_aws_new(String apiKey, String region, String modelId);
 
-    long aimux_anthropic_aws_new_with_base(String apiKey, String region, String modelId, String baseUrl);
+    Pointer aimux_anthropic_aws_new_with_base(String apiKey, String region, String modelId, String baseUrl);
 
-    long aimux_azure_new(String apiKey, String resourceName, String deployment, String apiVersion);
+    Pointer aimux_azure_new(String apiKey, String resourceName, String deployment, String apiVersion);
 
-    long aimux_azure_new_with_base(String apiKey, String baseUrl, String deployment, String apiVersion);
+    Pointer aimux_azure_new_with_base(String apiKey, String baseUrl, String deployment, String apiVersion);
 
     // ── Registry provider (RFC-0017 phase 4) ──────────────────────────────────
     // apiKey may be null (read the provider's env var from the registry entry);
     // configJson may be null (defaults) or a JSON object of ProviderOptions.
 
-    long aimux_provider_new(String name, String apiKey, String modelId, String configJson);
+    Pointer aimux_provider_new(String name, String apiKey, String modelId, String configJson);
 
-    long aimux_provider_from_env(String name, String modelId);
+    Pointer aimux_provider_from_env(String name, String modelId);
 
     // ── Generation ──────────────────────────────────────────────────────────
 
@@ -89,90 +89,81 @@ public interface AimuxFFI extends Library {
 
     void aimux_free_string(Pointer ptr);
 
-    /**
-     * Take (read-and-clear) the last constructor error on this thread.
-     *
-     * @return Error JSON envelope {@code {"error","error_type","status_code"}},
-     *         or {@code null} if the last constructor call on this thread
-     *         succeeded. Caller MUST free with {@link #aimux_free_string}.
-     */
-    Pointer aimux_last_error();
-
     // ── Embedding ───────────────────────────────────────────────────────────
 
-    long aimux_openai_embedding_new(String apiKey, String modelId);
+    Pointer aimux_openai_embedding_new(String apiKey, String modelId);
 
-    long aimux_openai_embedding_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_openai_embedding_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_cohere_embedding_new(String apiKey, String modelId);
+    Pointer aimux_cohere_embedding_new(String apiKey, String modelId);
 
-    long aimux_cohere_embedding_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_cohere_embedding_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_google_embedding_new(String apiKey, String modelId);
+    Pointer aimux_google_embedding_new(String apiKey, String modelId);
 
-    long aimux_google_embedding_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_google_embedding_new_with_base(String apiKey, String modelId, String baseUrl);
 
     Pointer aimux_embed(long handle, String valuesJson, String optsJson);
 
     // ── Speech (TTS) ────────────────────────────────────────────────────────
 
-    long aimux_openai_speech_new(String apiKey, String modelId);
+    Pointer aimux_openai_speech_new(String apiKey, String modelId);
 
-    long aimux_openai_speech_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_openai_speech_new_with_base(String apiKey, String modelId, String baseUrl);
 
     Pointer aimux_speech_generate(long handle, String optsJson);
 
     // ── Image ───────────────────────────────────────────────────────────────
 
-    long aimux_openai_image_new(String apiKey, String modelId);
+    Pointer aimux_openai_image_new(String apiKey, String modelId);
 
-    long aimux_openai_image_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_openai_image_new_with_base(String apiKey, String modelId, String baseUrl);
 
-    long aimux_google_image_new(String apiKey, String modelId);
+    Pointer aimux_google_image_new(String apiKey, String modelId);
 
-    long aimux_google_image_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_google_image_new_with_base(String apiKey, String modelId, String baseUrl);
 
     Pointer aimux_image_generate(long handle, String optsJson);
 
     // ── Transcription (STT, non-streaming) ──────────────────────────────────
 
-    long aimux_openai_transcription_new(String apiKey, String modelId);
+    Pointer aimux_openai_transcription_new(String apiKey, String modelId);
 
-    long aimux_openai_transcription_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_openai_transcription_new_with_base(String apiKey, String modelId, String baseUrl);
 
     Pointer aimux_transcription_generate(long handle, String audioBase64,
                                          String mediaType, String optsJson);
 
     // ── Files ───────────────────────────────────────────────────────────────
 
-    long aimux_openai_files_new(String apiKey);
+    Pointer aimux_openai_files_new(String apiKey);
 
-    long aimux_openai_files_new_with_base(String apiKey, String baseUrl);
+    Pointer aimux_openai_files_new_with_base(String apiKey, String baseUrl);
 
     Pointer aimux_file_upload(long handle, String dataBase64,
                               String mediaType, String optsJson);
 
     // ── Reranking ───────────────────────────────────────────────────────────
 
-    long aimux_cohere_reranking_new(String apiKey, String modelId);
+    Pointer aimux_cohere_reranking_new(String apiKey, String modelId);
 
-    long aimux_cohere_reranking_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_cohere_reranking_new_with_base(String apiKey, String modelId, String baseUrl);
 
     Pointer aimux_rerank(long handle, String optsJson);
 
     // ── Video ───────────────────────────────────────────────────────────────
 
-    long aimux_google_video_new(String apiKey, String modelId);
+    Pointer aimux_google_video_new(String apiKey, String modelId);
 
-    long aimux_google_video_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_google_video_new_with_base(String apiKey, String modelId, String baseUrl);
 
     Pointer aimux_video_generate(long handle, String optsJson);
 
     // ── Search ──────────────────────────────────────────────────────────────
 
-    long aimux_tavily_search_new(String apiKey, String modelId);
+    Pointer aimux_tavily_search_new(String apiKey, String modelId);
 
-    long aimux_tavily_search_new_with_base(String apiKey, String modelId, String baseUrl);
+    Pointer aimux_tavily_search_new_with_base(String apiKey, String modelId, String baseUrl);
 
     Pointer aimux_search(long handle, String optsJson);
 }

--- a/bindings/java/src/main/java/io/aimux/AimuxResult.java
+++ b/bindings/java/src/main/java/io/aimux/AimuxResult.java
@@ -36,6 +36,48 @@ final class AimuxResult {
     }
 
     /**
+     * Read a constructor's JSON result ({@code {"handle":<u64>}} on success,
+     * {@code {"error":"..."}} on failure), free the pointer, and return the
+     * native handle.
+     *
+     * @param ptr     the pointer returned by an {@code aimux_*_new*} function
+     *                (may be null)
+     * @param context description of what was being constructed, used to
+     *                prefix the thrown message (e.g. "Failed to create OpenAI
+     *                model")
+     * @return the non-zero handle
+     * @throws IllegalArgumentException if construction failed, with the
+     *         underlying engine error appended when available
+     */
+    static long extractHandle(com.sun.jna.Pointer ptr, String context) {
+        if (ptr == null) {
+            throw new IllegalArgumentException(context + ": constructor returned null");
+        }
+        String result;
+        try {
+            result = ptr.getString(0, "UTF-8");
+        } finally {
+            AimuxFFI.INSTANCE.aimux_free_string(ptr);
+        }
+        try {
+            JsonNode node = Types.AimuxJson.MAPPER.readTree(result);
+            JsonNode err = node.get("error");
+            if (err != null && err.isTextual()) {
+                throw new IllegalArgumentException(context + ": " + err.asText());
+            }
+            JsonNode handle = node.get("handle");
+            if (handle != null && handle.isIntegralNumber()) {
+                return handle.asLong();
+            }
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception ignored) {
+            // Not valid JSON — fall through to the generic error below.
+        }
+        throw new IllegalArgumentException(context + ": invalid constructor response: " + result);
+    }
+
+    /**
      * If {@code result} is a {@code {"error":"..."}} envelope, throw
      * {@link AimuxException} with the message. Otherwise return.
      */

--- a/bindings/java/src/main/java/io/aimux/EmbeddingModel.java
+++ b/bindings/java/src/main/java/io/aimux/EmbeddingModel.java
@@ -49,38 +49,41 @@ public final class EmbeddingModel implements Closeable {
     // ── Provider constructors ──────────────────────────────────────────────
 
     public static EmbeddingModel openai(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_embedding_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI embedding model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_embedding_new(apiKey, modelId), "Failed to create OpenAI embedding model");
         return new EmbeddingModel(h);
     }
 
     public static EmbeddingModel openaiWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_embedding_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI embedding model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_embedding_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create OpenAI embedding model");
         return new EmbeddingModel(h);
     }
 
     public static EmbeddingModel cohere(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_cohere_embedding_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Cohere embedding model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_cohere_embedding_new(apiKey, modelId), "Failed to create Cohere embedding model");
         return new EmbeddingModel(h);
     }
 
     public static EmbeddingModel cohereWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_cohere_embedding_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Cohere embedding model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_cohere_embedding_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create Cohere embedding model");
         return new EmbeddingModel(h);
     }
 
     public static EmbeddingModel google(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_google_embedding_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Google embedding model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_google_embedding_new(apiKey, modelId), "Failed to create Google embedding model");
         return new EmbeddingModel(h);
     }
 
     public static EmbeddingModel googleWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_google_embedding_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Google embedding model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_google_embedding_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create Google embedding model");
         return new EmbeddingModel(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/Files.java
+++ b/bindings/java/src/main/java/io/aimux/Files.java
@@ -50,8 +50,8 @@ public final class Files implements Closeable {
      * @return a new Files; throws {@link IllegalArgumentException} on failure.
      */
     public static Files openai(String apiKey) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_files_new(apiKey);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI files manager");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_files_new(apiKey), "Failed to create OpenAI files manager");
         return new Files(h);
     }
 
@@ -63,8 +63,9 @@ public final class Files implements Closeable {
      * @return a new Files; throws {@link IllegalArgumentException} on failure.
      */
     public static Files openaiWithBase(String apiKey, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_files_new_with_base(apiKey, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI files manager");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_files_new_with_base(apiKey, baseUrl),
+            "Failed to create OpenAI files manager");
         return new Files(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/ImageModel.java
+++ b/bindings/java/src/main/java/io/aimux/ImageModel.java
@@ -51,8 +51,8 @@ public final class ImageModel implements Closeable {
      * @return a new ImageModel; throws {@link IllegalArgumentException} on failure.
      */
     public static ImageModel openai(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_image_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI image model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_image_new(apiKey, modelId), "Failed to create OpenAI image model");
         return new ImageModel(h);
     }
 
@@ -65,8 +65,9 @@ public final class ImageModel implements Closeable {
      * @return a new ImageModel; throws {@link IllegalArgumentException} on failure.
      */
     public static ImageModel openaiWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_image_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI image model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_image_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create OpenAI image model");
         return new ImageModel(h);
     }
 
@@ -78,8 +79,8 @@ public final class ImageModel implements Closeable {
      * @return a new ImageModel; throws {@link IllegalArgumentException} on failure.
      */
     public static ImageModel google(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_google_image_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Google image model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_google_image_new(apiKey, modelId), "Failed to create Google image model");
         return new ImageModel(h);
     }
 
@@ -92,8 +93,9 @@ public final class ImageModel implements Closeable {
      * @return a new ImageModel; throws {@link IllegalArgumentException} on failure.
      */
     public static ImageModel googleWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_google_image_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Google image model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_google_image_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create Google image model");
         return new ImageModel(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/Model.java
+++ b/bindings/java/src/main/java/io/aimux/Model.java
@@ -1,7 +1,5 @@
 package io.aimux;
 
-import com.sun.jna.Pointer;
-
 import java.io.Closeable;
 import java.util.Spliterator;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -65,210 +63,152 @@ public class Model implements Closeable {
         return h;
     }
 
-    /**
-     * Build a constructor-failure message from the FFI thread-local error
-     * (issue #17). Must be called immediately after a constructor returned 0.
-     *
-     * @param fallback Message used when the native layer has no detail.
-     */
-    private static String constructorFailure(String fallback) {
-        Pointer ptr = AimuxFFI.INSTANCE.aimux_last_error();
-        if (ptr == null) {
-            return fallback;
-        }
-        String detail;
-        try {
-            detail = ptr.getString(0, "UTF-8");
-        } finally {
-            AimuxFFI.INSTANCE.aimux_free_string(ptr);
-        }
-        // Envelope: {"error":"<msg>","error_type":"<type>","status_code":...}.
-        // Extract the "error" field so the exception message stays readable.
-        java.util.regex.Matcher m = ERROR_FIELD.matcher(detail);
-        if (m.find()) {
-            return m.group(1).replace("\\\"", "\"").replace("\\\\", "\\");
-        }
-        return detail;
-    }
-
-    private static final java.util.regex.Pattern ERROR_FIELD = java.util.regex.Pattern.compile(
-        "\"error\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"");
-
     // ── Provider constructors ──────────────────────────────────────────────
 
     /** Create an OpenAI model instance. */
     public static Model openai(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_new(apiKey, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create OpenAI model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_new(apiKey, modelId), "Failed to create OpenAI model");
         return new Model(h);
     }
 
     /** Create an OpenAI model instance with a custom base URL. */
     public static Model openaiWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create OpenAI model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_new_with_base(apiKey, modelId, baseUrl), "Failed to create OpenAI model");
         return new Model(h);
     }
 
     /** Create an Anthropic model instance. */
     public static Model anthropic(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_anthropic_new(apiKey, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_anthropic_new(apiKey, modelId), "Failed to create Anthropic model");
         return new Model(h);
     }
 
     /** Create an Anthropic model instance with a custom base URL. */
     public static Model anthropicWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_anthropic_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_anthropic_new_with_base(apiKey, modelId, baseUrl), "Failed to create Anthropic model");
         return new Model(h);
     }
 
     /** Create a Cohere model instance. */
     public static Model cohere(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_cohere_new(apiKey, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Cohere model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_cohere_new(apiKey, modelId), "Failed to create Cohere model");
         return new Model(h);
     }
 
     /** Create a Cohere model instance with a custom base URL. */
     public static Model cohereWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_cohere_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Cohere model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_cohere_new_with_base(apiKey, modelId, baseUrl), "Failed to create Cohere model");
         return new Model(h);
     }
 
     /** Create a Mistral model instance. */
     public static Model mistral(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_mistral_new(apiKey, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Mistral model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_mistral_new(apiKey, modelId), "Failed to create Mistral model");
         return new Model(h);
     }
 
     /** Create a Mistral model instance with a custom base URL. */
     public static Model mistralWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_mistral_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Mistral model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_mistral_new_with_base(apiKey, modelId, baseUrl), "Failed to create Mistral model");
         return new Model(h);
     }
 
     /** Create an xAI model instance. */
     public static Model xai(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_xai_new(apiKey, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create xAI model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_xai_new(apiKey, modelId), "Failed to create xAI model");
         return new Model(h);
     }
 
     /** Create an xAI model instance with a custom base URL. */
     public static Model xaiWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_xai_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create xAI model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_xai_new_with_base(apiKey, modelId, baseUrl), "Failed to create xAI model");
         return new Model(h);
     }
 
     /** Create a Bedrock model instance (AWS SigV4 credentials). */
     public static Model bedrock(String accessKeyId, String secretAccessKey, String region, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_bedrock_new(accessKeyId, secretAccessKey, region, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Bedrock model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_bedrock_new(accessKeyId, secretAccessKey, region, modelId),
+            "Failed to create Bedrock model");
         return new Model(h);
     }
 
     /** Create a Bedrock model instance with a custom base URL. */
     public static Model bedrockWithBase(String accessKeyId, String secretAccessKey, String region,
                                         String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_bedrock_new_with_base(
-            accessKeyId, secretAccessKey, region, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Bedrock model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_bedrock_new_with_base(
+                accessKeyId, secretAccessKey, region, modelId, baseUrl),
+            "Failed to create Bedrock model");
         return new Model(h);
     }
 
     /** Create a Vertex AI model instance (GCP bearer token). */
     public static Model vertex(String accessToken, String project, String location, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_vertex_new(accessToken, project, location, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Vertex model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_vertex_new(accessToken, project, location, modelId),
+            "Failed to create Vertex model");
         return new Model(h);
     }
 
     /** Create a Vertex AI model instance with a custom base URL. */
     public static Model vertexWithBase(String accessToken, String project, String location,
                                        String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_vertex_new_with_base(
-            accessToken, project, location, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Vertex model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_vertex_new_with_base(
+                accessToken, project, location, modelId, baseUrl),
+            "Failed to create Vertex model");
         return new Model(h);
     }
 
     /** Create an Anthropic-on-AWS model instance (API key + region). */
     public static Model anthropicAws(String apiKey, String region, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_anthropic_aws_new(apiKey, region, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic AWS model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_anthropic_aws_new(apiKey, region, modelId),
+            "Failed to create Anthropic AWS model");
         return new Model(h);
     }
 
     /** Create an Anthropic-on-AWS model instance with a custom base URL. */
     public static Model anthropicAwsWithBase(String apiKey, String region, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_anthropic_aws_new_with_base(apiKey, region, modelId, baseUrl);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Anthropic AWS model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_anthropic_aws_new_with_base(apiKey, region, modelId, baseUrl),
+            "Failed to create Anthropic AWS model");
         return new Model(h);
     }
 
     /** Create an Azure OpenAI model instance (API key + resource name). */
     public static Model azure(String apiKey, String resourceName, String deployment) {
-        long h = AimuxFFI.INSTANCE.aimux_azure_new(apiKey, resourceName, deployment, null);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Azure model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_azure_new(apiKey, resourceName, deployment, null),
+            "Failed to create Azure model");
         return new Model(h);
     }
 
     /** Create an Azure OpenAI model instance with an explicit api-version. */
     public static Model azureWithVersion(String apiKey, String resourceName, String deployment,
                                          String apiVersion) {
-        long h = AimuxFFI.INSTANCE.aimux_azure_new(apiKey, resourceName, deployment, apiVersion);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Azure model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_azure_new(apiKey, resourceName, deployment, apiVersion),
+            "Failed to create Azure model");
         return new Model(h);
     }
 
     /** Create an Azure OpenAI model instance with a custom base URL. */
     public static Model azureWithBase(String apiKey, String baseUrl, String deployment) {
-        long h = AimuxFFI.INSTANCE.aimux_azure_new_with_base(apiKey, baseUrl, deployment, null);
-        if (h == 0L) {
-            throw new IllegalArgumentException(constructorFailure("Failed to create Azure model"));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_azure_new_with_base(apiKey, baseUrl, deployment, null),
+            "Failed to create Azure model");
         return new Model(h);
     }
 
@@ -287,11 +227,9 @@ public class Model implements Closeable {
      *                                  (unknown provider, bad config, missing env key).
      */
     public static Model provider(String name, String apiKey, String modelId, String configJson) {
-        long h = AimuxFFI.INSTANCE.aimux_provider_new(name, apiKey, modelId, configJson);
-        if (h == 0L) {
-            throw new IllegalArgumentException(
-                constructorFailure("Failed to create provider model: " + name));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_provider_new(name, apiKey, modelId, configJson),
+            "Failed to create provider model: " + name);
         return new Model(h);
     }
 
@@ -300,11 +238,9 @@ public class Model implements Closeable {
      * provider's env var (RFC-0017 phase 4).
      */
     public static Model providerFromEnv(String name, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_provider_from_env(name, modelId);
-        if (h == 0L) {
-            throw new IllegalArgumentException(
-                constructorFailure("Failed to create provider model from env: " + name));
-        }
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_provider_from_env(name, modelId),
+            "Failed to create provider model from env: " + name);
         return new Model(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/RerankingModel.java
+++ b/bindings/java/src/main/java/io/aimux/RerankingModel.java
@@ -52,8 +52,8 @@ public final class RerankingModel implements Closeable {
      * @return a new RerankingModel; throws {@link IllegalArgumentException} on failure.
      */
     public static RerankingModel cohere(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_cohere_reranking_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Cohere reranking model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_cohere_reranking_new(apiKey, modelId), "Failed to create Cohere reranking model");
         return new RerankingModel(h);
     }
 
@@ -66,8 +66,9 @@ public final class RerankingModel implements Closeable {
      * @return a new RerankingModel; throws {@link IllegalArgumentException} on failure.
      */
     public static RerankingModel cohereWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_cohere_reranking_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Cohere reranking model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_cohere_reranking_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create Cohere reranking model");
         return new RerankingModel(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/SearchModel.java
+++ b/bindings/java/src/main/java/io/aimux/SearchModel.java
@@ -52,8 +52,8 @@ public final class SearchModel implements Closeable {
      * @return a new SearchModel; throws {@link IllegalArgumentException} on failure.
      */
     public static SearchModel tavily(String apiKey) {
-        long h = AimuxFFI.INSTANCE.aimux_tavily_search_new(apiKey, "");
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Tavily search model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_tavily_search_new(apiKey, ""), "Failed to create Tavily search model");
         return new SearchModel(h);
     }
 
@@ -65,8 +65,9 @@ public final class SearchModel implements Closeable {
      * @return a new SearchModel; throws {@link IllegalArgumentException} on failure.
      */
     public static SearchModel tavilyWithBase(String apiKey, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_tavily_search_new_with_base(apiKey, "", baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Tavily search model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_tavily_search_new_with_base(apiKey, "", baseUrl),
+            "Failed to create Tavily search model");
         return new SearchModel(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/SpeechModel.java
+++ b/bindings/java/src/main/java/io/aimux/SpeechModel.java
@@ -52,8 +52,8 @@ public final class SpeechModel implements Closeable {
      *         native constructor fails (handle == 0).
      */
     public static SpeechModel openai(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_speech_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI speech model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_speech_new(apiKey, modelId), "Failed to create OpenAI speech model");
         return new SpeechModel(h);
     }
 
@@ -66,8 +66,9 @@ public final class SpeechModel implements Closeable {
      * @return a new SpeechModel; throws {@link IllegalArgumentException} on failure.
      */
     public static SpeechModel openaiWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_speech_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI speech model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_speech_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create OpenAI speech model");
         return new SpeechModel(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/TranscriptionModel.java
+++ b/bindings/java/src/main/java/io/aimux/TranscriptionModel.java
@@ -51,8 +51,9 @@ public final class TranscriptionModel implements Closeable {
      * @return a new TranscriptionModel; throws {@link IllegalArgumentException} on failure.
      */
     public static TranscriptionModel openai(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_transcription_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI transcription model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_transcription_new(apiKey, modelId),
+            "Failed to create OpenAI transcription model");
         return new TranscriptionModel(h);
     }
 
@@ -65,8 +66,9 @@ public final class TranscriptionModel implements Closeable {
      * @return a new TranscriptionModel; throws {@link IllegalArgumentException} on failure.
      */
     public static TranscriptionModel openaiWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_openai_transcription_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create OpenAI transcription model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_openai_transcription_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create OpenAI transcription model");
         return new TranscriptionModel(h);
     }
 

--- a/bindings/java/src/main/java/io/aimux/VideoModel.java
+++ b/bindings/java/src/main/java/io/aimux/VideoModel.java
@@ -51,8 +51,8 @@ public final class VideoModel implements Closeable {
      * @return a new VideoModel; throws {@link IllegalArgumentException} on failure.
      */
     public static VideoModel google(String apiKey, String modelId) {
-        long h = AimuxFFI.INSTANCE.aimux_google_video_new(apiKey, modelId);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Google video model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_google_video_new(apiKey, modelId), "Failed to create Google video model");
         return new VideoModel(h);
     }
 
@@ -65,8 +65,9 @@ public final class VideoModel implements Closeable {
      * @return a new VideoModel; throws {@link IllegalArgumentException} on failure.
      */
     public static VideoModel googleWithBase(String apiKey, String modelId, String baseUrl) {
-        long h = AimuxFFI.INSTANCE.aimux_google_video_new_with_base(apiKey, modelId, baseUrl);
-        if (h == 0L) throw new IllegalArgumentException("Failed to create Google video model");
+        long h = AimuxResult.extractHandle(
+            AimuxFFI.INSTANCE.aimux_google_video_new_with_base(apiKey, modelId, baseUrl),
+            "Failed to create Google video model");
         return new VideoModel(h);
     }
 

--- a/bindings/kotlin/src/main/kotlin/aimux/Model.kt
+++ b/bindings/kotlin/src/main/kotlin/aimux/Model.kt
@@ -13,40 +13,43 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicLong
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.longOrNull
 
 // ─────────────────────────────────────────────────────────────────────────────
 // JNA interface — direct mapping to the C ABI.
 // ─────────────────────────────────────────────────────────────────────────────
 
 internal interface AimuxFFI : Library {
-    fun aimux_openai_new(apiKey: String, modelId: String): Long
-    fun aimux_anthropic_new(apiKey: String, modelId: String): Long
-    fun aimux_openai_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_anthropic_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_cohere_new(apiKey: String, modelId: String): Long
-    fun aimux_cohere_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_mistral_new(apiKey: String, modelId: String): Long
-    fun aimux_mistral_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_xai_new(apiKey: String, modelId: String): Long
-    fun aimux_xai_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_bedrock_new(accessKeyId: String, secretAccessKey: String, region: String, modelId: String): Long
+    fun aimux_openai_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_anthropic_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_openai_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_anthropic_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_cohere_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_cohere_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_mistral_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_mistral_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_xai_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_xai_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_bedrock_new(accessKeyId: String, secretAccessKey: String, region: String, modelId: String): Pointer?
     fun aimux_bedrock_new_with_base(
         accessKeyId: String, secretAccessKey: String, region: String, modelId: String, baseUrl: String
-    ): Long
-    fun aimux_vertex_new(accessToken: String, project: String, location: String, modelId: String): Long
+    ): Pointer?
+    fun aimux_vertex_new(accessToken: String, project: String, location: String, modelId: String): Pointer?
     fun aimux_vertex_new_with_base(
         accessToken: String, project: String, location: String, modelId: String, baseUrl: String
-    ): Long
-    fun aimux_anthropic_aws_new(apiKey: String, region: String, modelId: String): Long
-    fun aimux_anthropic_aws_new_with_base(apiKey: String, region: String, modelId: String, baseUrl: String): Long
-    fun aimux_azure_new(apiKey: String, resourceName: String, deployment: String, apiVersion: String?): Long
-    fun aimux_azure_new_with_base(apiKey: String, baseUrl: String, deployment: String, apiVersion: String?): Long
+    ): Pointer?
+    fun aimux_anthropic_aws_new(apiKey: String, region: String, modelId: String): Pointer?
+    fun aimux_anthropic_aws_new_with_base(apiKey: String, region: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_azure_new(apiKey: String, resourceName: String, deployment: String, apiVersion: String?): Pointer?
+    fun aimux_azure_new_with_base(apiKey: String, baseUrl: String, deployment: String, apiVersion: String?): Pointer?
 
     // ── Registry provider (RFC-0017 phase 4) ───────────────────────────────
     // apiKey may be null (read the provider's env var from the registry entry);
     // configJson may be null (defaults) or a JSON object of ProviderOptions.
-    fun aimux_provider_new(name: String, apiKey: String?, modelId: String, configJson: String?): Long
-    fun aimux_provider_from_env(name: String, modelId: String): Long
+    fun aimux_provider_new(name: String, apiKey: String?, modelId: String, configJson: String?): Pointer?
+    fun aimux_provider_from_env(name: String, modelId: String): Pointer?
 
     fun aimux_generate_text(handle: Long, promptJson: String, optsJson: String?): Pointer?
     fun aimux_stream_text(
@@ -62,54 +65,78 @@ internal interface AimuxFFI : Library {
     fun aimux_free_string(ptr: Pointer?)
 
     // ── Embedding ──────────────────────────────────────────────────────────
-    fun aimux_openai_embedding_new(apiKey: String, modelId: String): Long
-    fun aimux_openai_embedding_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_cohere_embedding_new(apiKey: String, modelId: String): Long
-    fun aimux_cohere_embedding_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_google_embedding_new(apiKey: String, modelId: String): Long
-    fun aimux_google_embedding_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
+    fun aimux_openai_embedding_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_openai_embedding_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_cohere_embedding_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_cohere_embedding_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_google_embedding_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_google_embedding_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
     fun aimux_embed(handle: Long, valuesJson: String, optsJson: String?): Pointer?
 
     // ── Speech (TTS) ───────────────────────────────────────────────────────
-    fun aimux_openai_speech_new(apiKey: String, modelId: String): Long
-    fun aimux_openai_speech_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
+    fun aimux_openai_speech_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_openai_speech_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
     fun aimux_speech_generate(handle: Long, optsJson: String): Pointer?
 
     // ── Image ──────────────────────────────────────────────────────────────
-    fun aimux_openai_image_new(apiKey: String, modelId: String): Long
-    fun aimux_openai_image_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
-    fun aimux_google_image_new(apiKey: String, modelId: String): Long
-    fun aimux_google_image_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
+    fun aimux_openai_image_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_openai_image_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
+    fun aimux_google_image_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_google_image_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
     fun aimux_image_generate(handle: Long, optsJson: String): Pointer?
 
     // ── Transcription (STT) ────────────────────────────────────────────────
-    fun aimux_openai_transcription_new(apiKey: String, modelId: String): Long
-    fun aimux_openai_transcription_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
+    fun aimux_openai_transcription_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_openai_transcription_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
     fun aimux_transcription_generate(handle: Long, audioBase64: String, mediaType: String, optsJson: String?): Pointer?
 
     // ── Files ──────────────────────────────────────────────────────────────
-    fun aimux_openai_files_new(apiKey: String): Long
-    fun aimux_openai_files_new_with_base(apiKey: String, baseUrl: String): Long
+    fun aimux_openai_files_new(apiKey: String): Pointer?
+    fun aimux_openai_files_new_with_base(apiKey: String, baseUrl: String): Pointer?
     fun aimux_file_upload(handle: Long, dataBase64: String, mediaType: String, optsJson: String?): Pointer?
 
     // ── Reranking ──────────────────────────────────────────────────────────
-    fun aimux_cohere_reranking_new(apiKey: String, modelId: String): Long
-    fun aimux_cohere_reranking_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
+    fun aimux_cohere_reranking_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_cohere_reranking_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
     fun aimux_rerank(handle: Long, optsJson: String): Pointer?
 
     // ── Video ──────────────────────────────────────────────────────────────
-    fun aimux_google_video_new(apiKey: String, modelId: String): Long
-    fun aimux_google_video_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
+    fun aimux_google_video_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_google_video_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
     fun aimux_video_generate(handle: Long, optsJson: String): Pointer?
 
     // ── Search ─────────────────────────────────────────────────────────────
-    fun aimux_tavily_search_new(apiKey: String, modelId: String): Long
-    fun aimux_tavily_search_new_with_base(apiKey: String, modelId: String, baseUrl: String): Long
+    fun aimux_tavily_search_new(apiKey: String, modelId: String): Pointer?
+    fun aimux_tavily_search_new_with_base(apiKey: String, modelId: String, baseUrl: String): Pointer?
     fun aimux_search(handle: Long, optsJson: String): Pointer?
 }
 
 internal object FFI {
     val lib: AimuxFFI = Native.load("aimux_ffi", AimuxFFI::class.java)
+}
+
+/**
+ * Read a constructor's JSON result (`{"handle":<u64>}` on success,
+ * `{"error":"..."}` on failure), free the pointer, and return the handle.
+ *
+ * @param ptr     Pointer returned by an `aimux_*_new*` function (null = fatal FFI failure).
+ * @param context Description of what was being constructed, used to prefix the
+ *                thrown message (e.g. `"Failed to create OpenAI model"`).
+ */
+internal fun extractHandle(ptr: Pointer?, context: String): Long {
+    if (ptr == null) throw IllegalArgumentException("$context: constructor returned null")
+    val result = try {
+        ptr.getString(0, "UTF-8")
+    } finally {
+        FFI.lib.aimux_free_string(ptr)
+    }
+    val obj = runCatching { AimuxJson.parseToJsonElement(result).jsonObject }.getOrNull()
+    val err = obj?.get("error")
+    if (err is JsonPrimitive && err.isString) {
+        throw IllegalArgumentException("$context: ${err.content}")
+    }
+    (obj?.get("handle") as? JsonPrimitive)?.longOrNull?.let { return it }
+    throw IllegalArgumentException("$context: invalid constructor response: $result")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -151,78 +178,74 @@ class Model private constructor(handle: Long) : Closeable {
     companion object {
         /** Create an OpenAI model instance. */
         fun openai(apiKey: String, modelId: String): Model {
-            val h = FFI.lib.aimux_openai_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create OpenAI model" }
+            val h = extractHandle(FFI.lib.aimux_openai_new(apiKey, modelId), "Failed to create OpenAI model")
             return Model(h)
         }
 
         /** Create an Anthropic model instance. */
         fun anthropic(apiKey: String, modelId: String): Model {
-            val h = FFI.lib.aimux_anthropic_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Anthropic model" }
+            val h = extractHandle(FFI.lib.aimux_anthropic_new(apiKey, modelId), "Failed to create Anthropic model")
             return Model(h)
         }
 
         /** Create an OpenAI model instance with a custom base URL. */
         fun openai(apiKey: String, modelId: String, baseUrl: String): Model {
-            val h = FFI.lib.aimux_openai_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create OpenAI model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_new_with_base(apiKey, modelId, baseUrl), "Failed to create OpenAI model")
             return Model(h)
         }
 
         /** Create an Anthropic model instance with a custom base URL. */
         fun anthropic(apiKey: String, modelId: String, baseUrl: String): Model {
-            val h = FFI.lib.aimux_anthropic_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Anthropic model" }
+            val h = extractHandle(
+                FFI.lib.aimux_anthropic_new_with_base(apiKey, modelId, baseUrl), "Failed to create Anthropic model")
             return Model(h)
         }
 
         /** Create a Cohere model instance. */
         fun cohere(apiKey: String, modelId: String): Model {
-            val h = FFI.lib.aimux_cohere_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Cohere model" }
+            val h = extractHandle(FFI.lib.aimux_cohere_new(apiKey, modelId), "Failed to create Cohere model")
             return Model(h)
         }
 
         /** Create a Cohere model instance with a custom base URL. */
         fun cohere(apiKey: String, modelId: String, baseUrl: String): Model {
-            val h = FFI.lib.aimux_cohere_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Cohere model" }
+            val h = extractHandle(
+                FFI.lib.aimux_cohere_new_with_base(apiKey, modelId, baseUrl), "Failed to create Cohere model")
             return Model(h)
         }
 
         /** Create a Mistral model instance. */
         fun mistral(apiKey: String, modelId: String): Model {
-            val h = FFI.lib.aimux_mistral_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Mistral model" }
+            val h = extractHandle(FFI.lib.aimux_mistral_new(apiKey, modelId), "Failed to create Mistral model")
             return Model(h)
         }
 
         /** Create a Mistral model instance with a custom base URL. */
         fun mistral(apiKey: String, modelId: String, baseUrl: String): Model {
-            val h = FFI.lib.aimux_mistral_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Mistral model" }
+            val h = extractHandle(
+                FFI.lib.aimux_mistral_new_with_base(apiKey, modelId, baseUrl), "Failed to create Mistral model")
             return Model(h)
         }
 
         /** Create an xAI model instance. */
         fun xai(apiKey: String, modelId: String): Model {
-            val h = FFI.lib.aimux_xai_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create xAI model" }
+            val h = extractHandle(FFI.lib.aimux_xai_new(apiKey, modelId), "Failed to create xAI model")
             return Model(h)
         }
 
         /** Create an xAI model instance with a custom base URL. */
         fun xai(apiKey: String, modelId: String, baseUrl: String): Model {
-            val h = FFI.lib.aimux_xai_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create xAI model" }
+            val h = extractHandle(
+                FFI.lib.aimux_xai_new_with_base(apiKey, modelId, baseUrl), "Failed to create xAI model")
             return Model(h)
         }
 
         /** Create a Bedrock model instance (AWS SigV4 credentials). */
         fun bedrock(accessKeyId: String, secretAccessKey: String, region: String, modelId: String): Model {
-            val h = FFI.lib.aimux_bedrock_new(accessKeyId, secretAccessKey, region, modelId)
-            require(h != 0L) { "Failed to create Bedrock model" }
+            val h = extractHandle(
+                FFI.lib.aimux_bedrock_new(accessKeyId, secretAccessKey, region, modelId),
+                "Failed to create Bedrock model")
             return Model(h)
         }
 
@@ -230,15 +253,16 @@ class Model private constructor(handle: Long) : Closeable {
         fun bedrock(
             accessKeyId: String, secretAccessKey: String, region: String, modelId: String, baseUrl: String
         ): Model {
-            val h = FFI.lib.aimux_bedrock_new_with_base(accessKeyId, secretAccessKey, region, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Bedrock model" }
+            val h = extractHandle(
+                FFI.lib.aimux_bedrock_new_with_base(accessKeyId, secretAccessKey, region, modelId, baseUrl),
+                "Failed to create Bedrock model")
             return Model(h)
         }
 
         /** Create a Vertex AI model instance (GCP bearer token). */
         fun vertex(accessToken: String, project: String, location: String, modelId: String): Model {
-            val h = FFI.lib.aimux_vertex_new(accessToken, project, location, modelId)
-            require(h != 0L) { "Failed to create Vertex model" }
+            val h = extractHandle(
+                FFI.lib.aimux_vertex_new(accessToken, project, location, modelId), "Failed to create Vertex model")
             return Model(h)
         }
 
@@ -246,43 +270,45 @@ class Model private constructor(handle: Long) : Closeable {
         fun vertex(
             accessToken: String, project: String, location: String, modelId: String, baseUrl: String
         ): Model {
-            val h = FFI.lib.aimux_vertex_new_with_base(accessToken, project, location, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Vertex model" }
+            val h = extractHandle(
+                FFI.lib.aimux_vertex_new_with_base(accessToken, project, location, modelId, baseUrl),
+                "Failed to create Vertex model")
             return Model(h)
         }
 
         /** Create an Anthropic-on-AWS model instance (API key + region). */
         fun anthropicAws(apiKey: String, region: String, modelId: String): Model {
-            val h = FFI.lib.aimux_anthropic_aws_new(apiKey, region, modelId)
-            require(h != 0L) { "Failed to create Anthropic AWS model" }
+            val h = extractHandle(
+                FFI.lib.aimux_anthropic_aws_new(apiKey, region, modelId), "Failed to create Anthropic AWS model")
             return Model(h)
         }
 
         /** Create an Anthropic-on-AWS model instance with a custom base URL. */
         fun anthropicAws(apiKey: String, region: String, modelId: String, baseUrl: String): Model {
-            val h = FFI.lib.aimux_anthropic_aws_new_with_base(apiKey, region, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Anthropic AWS model" }
+            val h = extractHandle(
+                FFI.lib.aimux_anthropic_aws_new_with_base(apiKey, region, modelId, baseUrl),
+                "Failed to create Anthropic AWS model")
             return Model(h)
         }
 
         /** Create an Azure OpenAI model instance (API key + resource name). */
         fun azure(apiKey: String, resourceName: String, deployment: String): Model {
-            val h = FFI.lib.aimux_azure_new(apiKey, resourceName, deployment, null)
-            require(h != 0L) { "Failed to create Azure model" }
+            val h = extractHandle(
+                FFI.lib.aimux_azure_new(apiKey, resourceName, deployment, null), "Failed to create Azure model")
             return Model(h)
         }
 
         /** Create an Azure OpenAI model instance with an explicit api-version. */
         fun azureWithVersion(apiKey: String, resourceName: String, deployment: String, apiVersion: String): Model {
-            val h = FFI.lib.aimux_azure_new(apiKey, resourceName, deployment, apiVersion)
-            require(h != 0L) { "Failed to create Azure model" }
+            val h = extractHandle(
+                FFI.lib.aimux_azure_new(apiKey, resourceName, deployment, apiVersion), "Failed to create Azure model")
             return Model(h)
         }
 
         /** Create an Azure OpenAI model instance with a custom base URL. */
         fun azureWithBase(apiKey: String, baseUrl: String, deployment: String): Model {
-            val h = FFI.lib.aimux_azure_new_with_base(apiKey, baseUrl, deployment, null)
-            require(h != 0L) { "Failed to create Azure model" }
+            val h = extractHandle(
+                FFI.lib.aimux_azure_new_with_base(apiKey, baseUrl, deployment, null), "Failed to create Azure model")
             return Model(h)
         }
 
@@ -298,15 +324,15 @@ class Model private constructor(handle: Long) : Closeable {
          *                   "body_overrides": {...}}`); null for defaults.
          */
         fun provider(name: String, apiKey: String? = null, modelId: String, configJson: String? = null): Model {
-            val h = FFI.lib.aimux_provider_new(name, apiKey, modelId, configJson)
-            require(h != 0L) { "Failed to create provider model '$name'" }
+            val h = extractHandle(
+                FFI.lib.aimux_provider_new(name, apiKey, modelId, configJson), "Failed to create provider model '$name'")
             return Model(h)
         }
 
         /** Create a model from the provider registry, reading the API key from the provider's env var. */
         fun providerFromEnv(name: String, modelId: String): Model {
-            val h = FFI.lib.aimux_provider_from_env(name, modelId)
-            require(h != 0L) { "Failed to create provider model '$name' from env" }
+            val h = extractHandle(
+                FFI.lib.aimux_provider_from_env(name, modelId), "Failed to create provider model '$name' from env")
             return Model(h)
         }
     }

--- a/bindings/kotlin/src/main/kotlin/aimux/Multimodal.kt
+++ b/bindings/kotlin/src/main/kotlin/aimux/Multimodal.kt
@@ -101,43 +101,46 @@ class EmbeddingModel private constructor(handle: Long) : Closeable {
     companion object {
         /** Create an OpenAI embedding model (e.g. `text-embedding-3-small`). */
         fun openai(apiKey: String, modelId: String): EmbeddingModel {
-            val h = FFI.lib.aimux_openai_embedding_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create OpenAI embedding model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_embedding_new(apiKey, modelId), "Failed to create OpenAI embedding model")
             return EmbeddingModel(h)
         }
 
         /** Create an OpenAI embedding model with a custom base URL. */
         fun openai(apiKey: String, modelId: String, baseUrl: String): EmbeddingModel {
-            val h = FFI.lib.aimux_openai_embedding_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create OpenAI embedding model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_embedding_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create OpenAI embedding model")
             return EmbeddingModel(h)
         }
 
         /** Create a Cohere embedding model (e.g. `embed-english-v3.0`). */
         fun cohere(apiKey: String, modelId: String): EmbeddingModel {
-            val h = FFI.lib.aimux_cohere_embedding_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Cohere embedding model" }
+            val h = extractHandle(
+                FFI.lib.aimux_cohere_embedding_new(apiKey, modelId), "Failed to create Cohere embedding model")
             return EmbeddingModel(h)
         }
 
         /** Create a Cohere embedding model with a custom base URL. */
         fun cohere(apiKey: String, modelId: String, baseUrl: String): EmbeddingModel {
-            val h = FFI.lib.aimux_cohere_embedding_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Cohere embedding model" }
+            val h = extractHandle(
+                FFI.lib.aimux_cohere_embedding_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create Cohere embedding model")
             return EmbeddingModel(h)
         }
 
         /** Create a Google embedding model (e.g. `gemini-embedding-001`). */
         fun google(apiKey: String, modelId: String): EmbeddingModel {
-            val h = FFI.lib.aimux_google_embedding_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Google embedding model" }
+            val h = extractHandle(
+                FFI.lib.aimux_google_embedding_new(apiKey, modelId), "Failed to create Google embedding model")
             return EmbeddingModel(h)
         }
 
         /** Create a Google embedding model with a custom base URL. */
         fun google(apiKey: String, modelId: String, baseUrl: String): EmbeddingModel {
-            val h = FFI.lib.aimux_google_embedding_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Google embedding model" }
+            val h = extractHandle(
+                FFI.lib.aimux_google_embedding_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create Google embedding model")
             return EmbeddingModel(h)
         }
     }
@@ -187,15 +190,16 @@ class SpeechModel private constructor(handle: Long) : Closeable {
     companion object {
         /** Create an OpenAI speech (TTS) model. */
         fun openai(apiKey: String, modelId: String): SpeechModel {
-            val h = FFI.lib.aimux_openai_speech_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create OpenAI speech model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_speech_new(apiKey, modelId), "Failed to create OpenAI speech model")
             return SpeechModel(h)
         }
 
         /** Create an OpenAI speech model with a custom base URL. */
         fun openai(apiKey: String, modelId: String, baseUrl: String): SpeechModel {
-            val h = FFI.lib.aimux_openai_speech_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create OpenAI speech model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_speech_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create OpenAI speech model")
             return SpeechModel(h)
         }
     }
@@ -242,15 +246,17 @@ class TranscriptionModel private constructor(handle: Long) : Closeable {
     companion object {
         /** Create an OpenAI transcription (STT) model. */
         fun openai(apiKey: String, modelId: String): TranscriptionModel {
-            val h = FFI.lib.aimux_openai_transcription_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create OpenAI transcription model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_transcription_new(apiKey, modelId),
+                "Failed to create OpenAI transcription model")
             return TranscriptionModel(h)
         }
 
         /** Create an OpenAI transcription model with a custom base URL. */
         fun openai(apiKey: String, modelId: String, baseUrl: String): TranscriptionModel {
-            val h = FFI.lib.aimux_openai_transcription_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create OpenAI transcription model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_transcription_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create OpenAI transcription model")
             return TranscriptionModel(h)
         }
     }
@@ -299,29 +305,31 @@ class ImageModel private constructor(handle: Long) : Closeable {
     companion object {
         /** Create an OpenAI image model (e.g. `dall-e-3`). */
         fun openai(apiKey: String, modelId: String): ImageModel {
-            val h = FFI.lib.aimux_openai_image_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create OpenAI image model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_image_new(apiKey, modelId), "Failed to create OpenAI image model")
             return ImageModel(h)
         }
 
         /** Create an OpenAI image model with a custom base URL. */
         fun openai(apiKey: String, modelId: String, baseUrl: String): ImageModel {
-            val h = FFI.lib.aimux_openai_image_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create OpenAI image model" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_image_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create OpenAI image model")
             return ImageModel(h)
         }
 
         /** Create a Google image model (e.g. `gemini-2.5-flash-image`). */
         fun google(apiKey: String, modelId: String): ImageModel {
-            val h = FFI.lib.aimux_google_image_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Google image model" }
+            val h = extractHandle(
+                FFI.lib.aimux_google_image_new(apiKey, modelId), "Failed to create Google image model")
             return ImageModel(h)
         }
 
         /** Create a Google image model with a custom base URL. */
         fun google(apiKey: String, modelId: String, baseUrl: String): ImageModel {
-            val h = FFI.lib.aimux_google_image_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Google image model" }
+            val h = extractHandle(
+                FFI.lib.aimux_google_image_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create Google image model")
             return ImageModel(h)
         }
     }
@@ -368,15 +376,16 @@ class VideoModel private constructor(handle: Long) : Closeable {
     companion object {
         /** Create a Google video model (e.g. `veo-3.0`). */
         fun google(apiKey: String, modelId: String): VideoModel {
-            val h = FFI.lib.aimux_google_video_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Google video model" }
+            val h = extractHandle(
+                FFI.lib.aimux_google_video_new(apiKey, modelId), "Failed to create Google video model")
             return VideoModel(h)
         }
 
         /** Create a Google video model with a custom base URL. */
         fun google(apiKey: String, modelId: String, baseUrl: String): VideoModel {
-            val h = FFI.lib.aimux_google_video_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Google video model" }
+            val h = extractHandle(
+                FFI.lib.aimux_google_video_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create Google video model")
             return VideoModel(h)
         }
     }
@@ -423,15 +432,16 @@ class RerankingModel private constructor(handle: Long) : Closeable {
     companion object {
         /** Create a Cohere reranking model (e.g. `rerank-v3.0`). */
         fun cohere(apiKey: String, modelId: String): RerankingModel {
-            val h = FFI.lib.aimux_cohere_reranking_new(apiKey, modelId)
-            require(h != 0L) { "Failed to create Cohere reranking model" }
+            val h = extractHandle(
+                FFI.lib.aimux_cohere_reranking_new(apiKey, modelId), "Failed to create Cohere reranking model")
             return RerankingModel(h)
         }
 
         /** Create a Cohere reranking model with a custom base URL. */
         fun cohere(apiKey: String, modelId: String, baseUrl: String): RerankingModel {
-            val h = FFI.lib.aimux_cohere_reranking_new_with_base(apiKey, modelId, baseUrl)
-            require(h != 0L) { "Failed to create Cohere reranking model" }
+            val h = extractHandle(
+                FFI.lib.aimux_cohere_reranking_new_with_base(apiKey, modelId, baseUrl),
+                "Failed to create Cohere reranking model")
             return RerankingModel(h)
         }
     }
@@ -482,15 +492,16 @@ class SearchModel private constructor(handle: Long) : Closeable {
          * passed and ignored).
          */
         fun tavily(apiKey: String): SearchModel {
-            val h = FFI.lib.aimux_tavily_search_new(apiKey, "")
-            require(h != 0L) { "Failed to create Tavily search model" }
+            val h = extractHandle(
+                FFI.lib.aimux_tavily_search_new(apiKey, ""), "Failed to create Tavily search model")
             return SearchModel(h)
         }
 
         /** Create a Tavily search model with a custom base URL (e.g. for mocks). */
         fun tavily(apiKey: String, baseUrl: String): SearchModel {
-            val h = FFI.lib.aimux_tavily_search_new_with_base(apiKey, "", baseUrl)
-            require(h != 0L) { "Failed to create Tavily search model" }
+            val h = extractHandle(
+                FFI.lib.aimux_tavily_search_new_with_base(apiKey, "", baseUrl),
+                "Failed to create Tavily search model")
             return SearchModel(h)
         }
     }
@@ -537,15 +548,14 @@ class Files private constructor(handle: Long) : Closeable {
     companion object {
         /** Create an OpenAI files manager. */
         fun openai(apiKey: String): Files {
-            val h = FFI.lib.aimux_openai_files_new(apiKey)
-            require(h != 0L) { "Failed to create OpenAI files manager" }
+            val h = extractHandle(FFI.lib.aimux_openai_files_new(apiKey), "Failed to create OpenAI files manager")
             return Files(h)
         }
 
         /** Create an OpenAI files manager with a custom base URL. */
         fun openai(apiKey: String, baseUrl: String): Files {
-            val h = FFI.lib.aimux_openai_files_new_with_base(apiKey, baseUrl)
-            require(h != 0L) { "Failed to create OpenAI files manager" }
+            val h = extractHandle(
+                FFI.lib.aimux_openai_files_new_with_base(apiKey, baseUrl), "Failed to create OpenAI files manager")
             return Files(h)
         }
     }

--- a/bindings/swift/Sources/Aimux/Aimux.swift
+++ b/bindings/swift/Sources/Aimux/Aimux.swift
@@ -53,23 +53,39 @@ public final class Model: @unchecked Sendable {
         }
     }
 
+    /// Parse a constructor's JSON result (`{"handle":<u64>}` on success,
+    /// `{"error":"..."}` on failure), free the pointer, and return the handle.
+    static func extractHandle(_ ptr: UnsafeMutablePointer<CChar>?) throws -> UInt64 {
+        guard let ptr = ptr else {
+            throw AimuxError.serializationError("constructor returned null")
+        }
+        let result = String(cString: ptr)
+        aimux_free_string(ptr)
+
+        guard let data = result.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AimuxError.serializationError("invalid constructor response: \(result)")
+        }
+        if let error = json["error"] as? String {
+            throw AimuxError.providerError(error)
+        }
+        if let handle = json["handle"] as? NSNumber {
+            return handle.uint64Value
+        }
+        throw AimuxError.serializationError("invalid constructor response: \(result)")
+    }
+
     // ── Provider constructors ──────────────────────────────────────────────
 
     /// Create an OpenAI model instance.
     public static func openai(apiKey: String, modelId: String) throws -> Model {
-        let handle = aimux_openai_new(apiKey, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_openai_new(apiKey, modelId))
         return Model(handle: handle)
     }
 
     /// Create an Anthropic model instance.
     public static func anthropic(apiKey: String, modelId: String) throws -> Model {
-        let handle = aimux_anthropic_new(apiKey, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_anthropic_new(apiKey, modelId))
         return Model(handle: handle)
     }
 
@@ -78,73 +94,49 @@ public final class Model: @unchecked Sendable {
     /// An empty `baseUrl` falls back to the provider's standard URL
     /// (see `aimux_openai_new_with_base`).
     public static func openai(apiKey: String, modelId: String, baseUrl: String) throws -> Model {
-        let handle = aimux_openai_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_openai_new_with_base(apiKey, modelId, baseUrl))
         return Model(handle: handle)
     }
 
     /// Create an Anthropic model instance with a custom base URL.
     public static func anthropic(apiKey: String, modelId: String, baseUrl: String) throws -> Model {
-        let handle = aimux_anthropic_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_anthropic_new_with_base(apiKey, modelId, baseUrl))
         return Model(handle: handle)
     }
 
     /// Create a Cohere model instance.
     public static func cohere(apiKey: String, modelId: String) throws -> Model {
-        let handle = aimux_cohere_new(apiKey, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_cohere_new(apiKey, modelId))
         return Model(handle: handle)
     }
 
     /// Create a Cohere model instance with a custom base URL.
     public static func cohere(apiKey: String, modelId: String, baseUrl: String) throws -> Model {
-        let handle = aimux_cohere_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_cohere_new_with_base(apiKey, modelId, baseUrl))
         return Model(handle: handle)
     }
 
     /// Create a Mistral model instance.
     public static func mistral(apiKey: String, modelId: String) throws -> Model {
-        let handle = aimux_mistral_new(apiKey, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_mistral_new(apiKey, modelId))
         return Model(handle: handle)
     }
 
     /// Create a Mistral model instance with a custom base URL.
     public static func mistral(apiKey: String, modelId: String, baseUrl: String) throws -> Model {
-        let handle = aimux_mistral_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_mistral_new_with_base(apiKey, modelId, baseUrl))
         return Model(handle: handle)
     }
 
     /// Create an xAI model instance.
     public static func xai(apiKey: String, modelId: String) throws -> Model {
-        let handle = aimux_xai_new(apiKey, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_xai_new(apiKey, modelId))
         return Model(handle: handle)
     }
 
     /// Create an xAI model instance with a custom base URL.
     public static func xai(apiKey: String, modelId: String, baseUrl: String) throws -> Model {
-        let handle = aimux_xai_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_xai_new_with_base(apiKey, modelId, baseUrl))
         return Model(handle: handle)
     }
 
@@ -152,10 +144,7 @@ public final class Model: @unchecked Sendable {
     public static func bedrock(
         accessKeyId: String, secretAccessKey: String, region: String, modelId: String
     ) throws -> Model {
-        let handle = aimux_bedrock_new(accessKeyId, secretAccessKey, region, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_bedrock_new(accessKeyId, secretAccessKey, region, modelId))
         return Model(handle: handle)
     }
 
@@ -163,10 +152,8 @@ public final class Model: @unchecked Sendable {
     public static func bedrock(
         accessKeyId: String, secretAccessKey: String, region: String, modelId: String, baseUrl: String
     ) throws -> Model {
-        let handle = aimux_bedrock_new_with_base(accessKeyId, secretAccessKey, region, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(
+            aimux_bedrock_new_with_base(accessKeyId, secretAccessKey, region, modelId, baseUrl))
         return Model(handle: handle)
     }
 
@@ -174,10 +161,7 @@ public final class Model: @unchecked Sendable {
     public static func vertex(
         accessToken: String, project: String, location: String, modelId: String
     ) throws -> Model {
-        let handle = aimux_vertex_new(accessToken, project, location, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_vertex_new(accessToken, project, location, modelId))
         return Model(handle: handle)
     }
 
@@ -185,19 +169,14 @@ public final class Model: @unchecked Sendable {
     public static func vertex(
         accessToken: String, project: String, location: String, modelId: String, baseUrl: String
     ) throws -> Model {
-        let handle = aimux_vertex_new_with_base(accessToken, project, location, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(
+            aimux_vertex_new_with_base(accessToken, project, location, modelId, baseUrl))
         return Model(handle: handle)
     }
 
     /// Create an Anthropic-on-AWS model instance (API key + region).
     public static func anthropicAws(apiKey: String, region: String, modelId: String) throws -> Model {
-        let handle = aimux_anthropic_aws_new(apiKey, region, modelId)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_anthropic_aws_new(apiKey, region, modelId))
         return Model(handle: handle)
     }
 
@@ -205,10 +184,7 @@ public final class Model: @unchecked Sendable {
     public static func anthropicAws(
         apiKey: String, region: String, modelId: String, baseUrl: String
     ) throws -> Model {
-        let handle = aimux_anthropic_aws_new_with_base(apiKey, region, modelId, baseUrl)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_anthropic_aws_new_with_base(apiKey, region, modelId, baseUrl))
         return Model(handle: handle)
     }
 
@@ -217,10 +193,7 @@ public final class Model: @unchecked Sendable {
     public static func azure(
         apiKey: String, resourceName: String, deployment: String, apiVersion: String? = nil
     ) throws -> Model {
-        let handle = aimux_azure_new(apiKey, resourceName, deployment, apiVersion)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_azure_new(apiKey, resourceName, deployment, apiVersion))
         return Model(handle: handle)
     }
 
@@ -228,10 +201,7 @@ public final class Model: @unchecked Sendable {
     public static func azureWithBase(
         apiKey: String, baseUrl: String, deployment: String, apiVersion: String? = nil
     ) throws -> Model {
-        let handle = aimux_azure_new_with_base(apiKey, baseUrl, deployment, apiVersion)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_azure_new_with_base(apiKey, baseUrl, deployment, apiVersion))
         return Model(handle: handle)
     }
 
@@ -246,10 +216,7 @@ public final class Model: @unchecked Sendable {
     ///     (`{"base_url": "...", "headers": {...}, "max_retries": 0,
     ///     "body_overrides": {...}}`); `nil` for defaults.
     public static func provider(name: String, apiKey: String? = nil, modelId: String, configJson: String? = nil) throws -> Model {
-        let handle = aimux_provider_new(name, apiKey, modelId, configJson)
-        guard handle != 0 else {
-            throw AimuxError.invalidHandle
-        }
+        let handle = try extractHandle(aimux_provider_new(name, apiKey, modelId, configJson))
         return Model(handle: handle)
     }
 

--- a/bindings/swift/Sources/Aimux/Multimodal.swift
+++ b/bindings/swift/Sources/Aimux/Multimodal.swift
@@ -75,43 +75,37 @@ public final class EmbeddingModel: @unchecked Sendable {
 
     /// Create an OpenAI embedding model instance (e.g. text-embedding-3-small).
     public static func openai(apiKey: String, modelId: String) throws -> EmbeddingModel {
-        let handle = aimux_openai_embedding_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_embedding_new(apiKey, modelId))
         return EmbeddingModel(handle: handle)
     }
 
     /// Create an OpenAI embedding model instance with a custom base URL.
     public static func openai(apiKey: String, modelId: String, baseUrl: String) throws -> EmbeddingModel {
-        let handle = aimux_openai_embedding_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_embedding_new_with_base(apiKey, modelId, baseUrl))
         return EmbeddingModel(handle: handle)
     }
 
     /// Create a Cohere embedding model instance (e.g. embed-english-v3.0).
     public static func cohere(apiKey: String, modelId: String) throws -> EmbeddingModel {
-        let handle = aimux_cohere_embedding_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_cohere_embedding_new(apiKey, modelId))
         return EmbeddingModel(handle: handle)
     }
 
     /// Create a Cohere embedding model instance with a custom base URL.
     public static func cohere(apiKey: String, modelId: String, baseUrl: String) throws -> EmbeddingModel {
-        let handle = aimux_cohere_embedding_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_cohere_embedding_new_with_base(apiKey, modelId, baseUrl))
         return EmbeddingModel(handle: handle)
     }
 
     /// Create a Google embedding model instance (e.g. gemini-embedding-001).
     public static func google(apiKey: String, modelId: String) throws -> EmbeddingModel {
-        let handle = aimux_google_embedding_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_google_embedding_new(apiKey, modelId))
         return EmbeddingModel(handle: handle)
     }
 
     /// Create a Google embedding model instance with a custom base URL.
     public static func google(apiKey: String, modelId: String, baseUrl: String) throws -> EmbeddingModel {
-        let handle = aimux_google_embedding_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_google_embedding_new_with_base(apiKey, modelId, baseUrl))
         return EmbeddingModel(handle: handle)
     }
 
@@ -157,15 +151,13 @@ public final class SpeechModel: @unchecked Sendable {
 
     /// Create an OpenAI speech (TTS) model instance.
     public static func openai(apiKey: String, modelId: String) throws -> SpeechModel {
-        let handle = aimux_openai_speech_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_speech_new(apiKey, modelId))
         return SpeechModel(handle: handle)
     }
 
     /// Create an OpenAI speech model instance with a custom base URL.
     public static func openai(apiKey: String, modelId: String, baseUrl: String) throws -> SpeechModel {
-        let handle = aimux_openai_speech_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_speech_new_with_base(apiKey, modelId, baseUrl))
         return SpeechModel(handle: handle)
     }
 
@@ -209,15 +201,13 @@ public final class TranscriptionModel: @unchecked Sendable {
 
     /// Create an OpenAI transcription (STT) model instance.
     public static func openai(apiKey: String, modelId: String) throws -> TranscriptionModel {
-        let handle = aimux_openai_transcription_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_transcription_new(apiKey, modelId))
         return TranscriptionModel(handle: handle)
     }
 
     /// Create an OpenAI transcription model instance with a custom base URL.
     public static func openai(apiKey: String, modelId: String, baseUrl: String) throws -> TranscriptionModel {
-        let handle = aimux_openai_transcription_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_transcription_new_with_base(apiKey, modelId, baseUrl))
         return TranscriptionModel(handle: handle)
     }
 
@@ -264,29 +254,25 @@ public final class ImageModel: @unchecked Sendable {
 
     /// Create an OpenAI image model instance (e.g. dall-e-3).
     public static func openai(apiKey: String, modelId: String) throws -> ImageModel {
-        let handle = aimux_openai_image_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_image_new(apiKey, modelId))
         return ImageModel(handle: handle)
     }
 
     /// Create an OpenAI image model instance with a custom base URL.
     public static func openai(apiKey: String, modelId: String, baseUrl: String) throws -> ImageModel {
-        let handle = aimux_openai_image_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_image_new_with_base(apiKey, modelId, baseUrl))
         return ImageModel(handle: handle)
     }
 
     /// Create a Google image model instance (e.g. gemini-2.5-flash-image).
     public static func google(apiKey: String, modelId: String) throws -> ImageModel {
-        let handle = aimux_google_image_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_google_image_new(apiKey, modelId))
         return ImageModel(handle: handle)
     }
 
     /// Create a Google image model instance with a custom base URL.
     public static func google(apiKey: String, modelId: String, baseUrl: String) throws -> ImageModel {
-        let handle = aimux_google_image_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_google_image_new_with_base(apiKey, modelId, baseUrl))
         return ImageModel(handle: handle)
     }
 
@@ -330,15 +316,13 @@ public final class VideoModel: @unchecked Sendable {
 
     /// Create a Google video model instance (e.g. veo-3.0).
     public static func google(apiKey: String, modelId: String) throws -> VideoModel {
-        let handle = aimux_google_video_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_google_video_new(apiKey, modelId))
         return VideoModel(handle: handle)
     }
 
     /// Create a Google video model instance with a custom base URL.
     public static func google(apiKey: String, modelId: String, baseUrl: String) throws -> VideoModel {
-        let handle = aimux_google_video_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_google_video_new_with_base(apiKey, modelId, baseUrl))
         return VideoModel(handle: handle)
     }
 
@@ -382,15 +366,13 @@ public final class RerankingModel: @unchecked Sendable {
 
     /// Create a Cohere reranking model instance (e.g. rerank-v3.0).
     public static func cohere(apiKey: String, modelId: String) throws -> RerankingModel {
-        let handle = aimux_cohere_reranking_new(apiKey, modelId)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_cohere_reranking_new(apiKey, modelId))
         return RerankingModel(handle: handle)
     }
 
     /// Create a Cohere reranking model instance with a custom base URL.
     public static func cohere(apiKey: String, modelId: String, baseUrl: String) throws -> RerankingModel {
-        let handle = aimux_cohere_reranking_new_with_base(apiKey, modelId, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_cohere_reranking_new_with_base(apiKey, modelId, baseUrl))
         return RerankingModel(handle: handle)
     }
 
@@ -435,16 +417,14 @@ public final class SearchModel: @unchecked Sendable {
     /// Create a Tavily search model instance. Tavily uses a fixed endpoint, so
     /// no model ID is needed (the C ABI's `model_id` argument is ignored).
     public static func tavily(apiKey: String) throws -> SearchModel {
-        let handle = aimux_tavily_search_new(apiKey, "")
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_tavily_search_new(apiKey, ""))
         return SearchModel(handle: handle)
     }
 
     /// Create a Tavily search model instance with a custom base URL (useful for
     /// testing against a mock server).
     public static func tavily(apiKey: String, baseUrl: String) throws -> SearchModel {
-        let handle = aimux_tavily_search_new_with_base(apiKey, "", baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_tavily_search_new_with_base(apiKey, "", baseUrl))
         return SearchModel(handle: handle)
     }
 
@@ -488,15 +468,13 @@ public final class Files: @unchecked Sendable {
 
     /// Create an OpenAI files manager instance. No model ID is required.
     public static func openai(apiKey: String) throws -> Files {
-        let handle = aimux_openai_files_new(apiKey)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_files_new(apiKey))
         return Files(handle: handle)
     }
 
     /// Create an OpenAI files manager instance with a custom base URL.
     public static func openai(apiKey: String, baseUrl: String) throws -> Files {
-        let handle = aimux_openai_files_new_with_base(apiKey, baseUrl)
-        guard handle != 0 else { throw AimuxError.invalidHandle }
+        let handle = try Model.extractHandle(aimux_openai_files_new_with_base(apiKey, baseUrl))
         return Files(handle: handle)
     }
 

--- a/docs/internal/phase4-audit.md
+++ b/docs/internal/phase4-audit.md
@@ -36,7 +36,7 @@
 | Kotlin | ✅ | `Model.provider(name, apiKey=null, modelId, configJson=null)` + `providerFromEnv` [bindings/kotlin/src/main/kotlin/aimux/Model.kt](D:/code/aimux/bindings/kotlin/src/main/kotlin/aimux/Model.kt#L173)(L180);未知名字同 Java,无列表 |
 | Swift | ✅ | `Model.provider(name:apiKey:modelId:configJson:)` [bindings/swift/Sources/Aimux/Aimux.swift](D:/code/aimux/bindings/swift/Sources/Aimux/Aimux.swift#L107);apiKey nil → env;未知名字 → `AimuxError.invalidHandle`,无列表 |
 | Flutter | ✅ | `Model.provider(name, modelId, {apiKey, configJson})` [bindings/flutter/lib/aimux.dart](D:/code/aimux/bindings/flutter/lib/aimux.dart#L209);未知名字 → `StateError`,无列表 |
-| C ABI | ✅ | `aimux_provider_new` [aimux-ffi/src/lib.rs](D:/code/aimux/aimux-ffi/src/lib.rs#L377)(L407);config_json 解析 `ProviderOptions`(L390-397);失败返回 0(文档化,无错误详情) |
+| C ABI | ✅ | `aimux_provider_new` [aimux-ffi/src/lib.rs](D:/code/aimux/aimux-ffi/src/lib.rs#L377)(L407);config_json 解析 `ProviderOptions`(L390-397);失败返回错误 JSON 信封(含 error/error_type/status_code 详情;经 explore/aimux-ffi-json-constructors 修复,原为返回 0 无详情) |
 
 #### b. ProviderName 派生类型
 


### PR DESCRIPTION
## Summary

Follow-up simplification of #19: constructors return the JSON envelope the rest of the ABI already uses, instead of a bare `u64` plus the `aimux_last_error()` side channel:

```
{"handle":<u64>}                                     on success
{"error":"...","error_type":"...","status_code":...} on failure
```

Success and failure arrive in the same return value of the same call, so there is no second call to correlate — the entire last_error mechanism (TLS slot, `begin_constructor`/`record_error`, the `aimux_last_error` symbol and its thread-affinity contract) is removed. No binding needs thread pinning (`LockOSThread` gone in Go; nothing for Kotlin coroutines / virtual threads to get wrong when they adopt it). The convention matches `aimux_generate_text` / `aimux_embed`, so bindings reuse their existing envelope parsers.

**Net −168 lines vs master** (+1426/−1594) while extending coverage from 3 bindings to all 6.

Error envelopes are byte-identical to #19's (`InvalidArgument`/`Json`/`UnknownProvider`, serde detail for `prompt_json`/`config_json`) — the only change is the retrieval mechanism.

Cost: breaking C ABI change — 40+ constructor signatures change from `uint64_t` to `char *` (freed with `aimux_free_string`). 0.2.x is the cheapest moment this will ever be.

## Verification

- `cargo test -p aimux-ffi --release`: 14 passed — #19's error_detail regression cases kept (reading the error from the constructor result); the TLS-semantics cases have no counterpart and are replaced with envelope-semantics tests (per-call error independence, 8-thread concurrent constructors, no pinning)
- Go: `go vet` + `go test ./...` with a real cgo link; C/C++ examples compile; `swift build` passes
- E2E against a live OpenAI-compatible endpoint through the Go **and C** bindings: unknown-provider detail (full provider list), `invalid prompt_json` serde detail, real generate, real streaming — all pass
- Java/Kotlin/Flutter: static-only changes following existing patterns; CI to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)