### PR TITLE
docs: iOS CocoaPods link verified (issue #25/#26)

### DIFF
--- a/docs/internal/audit/release-plan.md
+++ b/docs/internal/audit/release-plan.md
@@ -421,9 +421,9 @@ dart:ffi 是纯 Dart，但 pub.dev 上的纯 Dart 包**不携带 native 二进�
 
 - `pubspec.yaml` 声明 `flutter.plugin.platforms`（iOS + Android，`dartPluginClass: AimuxPlugin`——纯 Dart 插件，无 platform channel）。
 - **Android**：`android/src/main/jniLibs/<abi>/libaimux_ffi.so`（arm64-v8a / armeabi-v7a / x86_64），Dart 侧 `DynamicLibrary.open('libaimux_ffi.so')`。
-- **iOS（CocoaPods 路径）**：`ios/aimux_ffi.xcframework`（真机 arm64 + 模拟器 arm64 双 slice），podspec `vendored_libraries` + 条件 `-force_load`。
-- **iOS（SwiftPM 路径，✅ 2026-08-04 补）**：`ios/aimux/Package.swift` —— `binaryTarget` 引用同一 xcframework，Swift 空 target 用 `-all_load` 全量链接（Dart 侧 `DynamicLibrary.process()` 解析符号）。
-- **隐私清单**：`ios/aimux/Sources/aimux/PrivacyInfo.xcprivacy`（空声明，podspec `resource_bundles` + SPM `resources` 双路打包，App Store 2024-05+ 要求）。
+- **iOS**：`ios/aimux_ffi.xcframework`（真机 arm64 + 模拟器 arm64 双 slice，静态 framework 型）。✅ 2026-08-04 修复（#25/#26）：podspec `user_target_xcconfig` 的 `-force_load` 指向 `script_phase`（`embed-xcframework.sh`）暂存的 slice（`PODS_XCFRAMEWORKS_BUILD_DIR/aimux/`），符号进 app 主二进制（debug 构建为 `Runner.debug.dylib`），Dart `DynamicLibrary.process()` 解析。CI `flutter-example-build`(iOS) 阻塞 + 符号扫描验证。
+- **iOS 已知限制**：① Flutter 3.44 SPM 集成不支持插件 binaryTarget（`Package.swift` 方案不可行，走 CocoaPods fallback，会提示 SPM 警告但不影响构建）；② 仅 arm64 真机 + arm64 模拟器 slice（Intel x86_64 模拟器暂不支持）；③ 真机发布前建议 `flutter build ios --no-codesign` 验证一次。
+- **隐私清单**：`ios/PrivacyInfo.xcprivacy`（空声明，podspec `resource_bundles` 打包，App Store 2024-05+ 要求）。
 - **桌面端**（Linux/macOS/Windows）：开发/测试用，从平台库路径加载（非插件打包）。
 
 ### 10.3 发布前必修项


### PR DESCRIPTION
release-plan 更新：iOS 集成状态（force_load 经 user_target_xcconfig 生效、SPM binaryTarget 限制、arm64-only slice 限制、真机验证建议）。纯文档变更。