### PR TITLE
chore(release): bump to 0.2.1 — first Maven/pub.dev release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/arcships/aimux"

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ aimux ships 8 bindings that share the same Rust core:
 | **Node.js** | native | napi-rs v3 | `npm install @arcships/aimux` — [npm](https://www.npmjs.com/package/@arcships/aimux) | bundled in the package, nothing to do |
 | **Python** | native | PyO3 + maturin | `pip install arcships-aimux` — [PyPI](https://pypi.org/project/arcships-aimux/) | bundled in the wheel, nothing to do |
 | **Go** | C ABI | cgo (static link) | `go get github.com/arcships/aimux/bindings/go` then `go generate` | auto-downloaded `.a` from [GitHub Releases](https://github.com/arcships/aimux/releases) |
-| **Swift** | C ABI | SPM | SPM: `https://github.com/arcships/aimux` (`from: "0.2.0"`) | `libaimux_ffi.dylib` — see [guide](docs/api/swift.md#install) |
+| **Swift** | C ABI | SPM | SPM: `https://github.com/arcships/aimux` (`from: "0.2.1"`) | `libaimux_ffi.dylib` — see [guide](docs/api/swift.md#install) |
 | **Kotlin** | C ABI | JNA | `ai.arcships:aimux-kotlin` — Maven Central (publishing) | `libaimux_ffi.so/.dylib` or `aimux_ffi.dll` on the JNA search path — see [guide](docs/api/kotlin.md#install) |
 | **Java** | C ABI | JNA | `ai.arcships:aimux-java` — Maven Central (publishing) | same as Kotlin — see [guide](docs/api/java.md#install) |
 | **Flutter** | C ABI | dart:ffi | `aimux` on pub.dev — Flutter plugin, native core embedded (publisher `arcships.ai`) | iOS/Android 开箱即用，桌面端开发/测试 — see [guide](docs/api/flutter.md#install) |

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,11 +1,13 @@
-## 0.2.0
+## 0.2.1
 
 - First pub.dev release under publisher `arcships.ai`.
 - Flutter plugin conversion: Android `libaimux_ffi.so` per ABI and iOS
   `aimux_ffi.xcframework` embedded in the package; Dart-only plugin
   (`dartPluginClass`), no platform channels.
-- iOS integration: SwiftPM (`ios/aimux/Package.swift`, binary target +
-  `-all_load`) and CocoaPods fallback (`aimux.podspec`, vendored +
-  `-force_load`); privacy manifest (`PrivacyInfo.xcprivacy`) bundled.
+- iOS integration via CocoaPods (`aimux.podspec`): vendored static
+  framework slices staged by `script_phase`, symbols force-loaded into the
+  app binary (`user_target_xcconfig`) — verified by CI symbol scan
+  (issue #25). SwiftPM is not used (Flutter 3.44 cannot link plugin binary
+  targets); privacy manifest (`PrivacyInfo.xcprivacy`) bundled.
 - `example/` app demonstrating the API; CI builds it for iOS and Android
   to validate native integration.

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aimux
 description: Unified LLM service layer for Flutter/Dart (Rust core, 325 providers, C ABI via dart:ffi)
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/arcships/aimux
 repository: https://github.com/arcships/aimux
 issue_tracker: https://github.com/arcships/aimux/issues

--- a/bindings/java/build.gradle.kts
+++ b/bindings/java/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.arcships"
-version = "0.2.0"
+version = "0.2.1"
 
 repositories {
     mavenCentral()

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "ai.arcships"
-version = "0.2.0"
+version = "0.2.1"
 
 repositories {
     mavenCentral()

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcships/aimux",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Unified LLM service layer — one API for 325 AI providers (Rust core, Node.js binding)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "arcships-aimux"
-version = "0.2.0"
+version = "0.2.1"
 description = "Unified LLM service layer for Python (Rust core, 325 providers)"
 readme = "README.md"
 license = "MIT"

--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -3,7 +3,7 @@
 > Unified LLM service access layer — one API to access 325 AI providers
 
 The Java binding goes through the `aimux-ffi` C ABI via JNA — no native
-toolchain is needed at build time. Artifact: `ai.arcships:aimux-java:0.2.0`,
+toolchain is needed at build time. Artifact: `ai.arcships:aimux-java:0.2.1`,
 Java 8+ (compiled with `--release 8`). See [RFC-0013](../../rfc/0013-java-bindings.md)
 for the design.
 
@@ -12,7 +12,7 @@ for the design.
 Maven Central (publishing):
 
 ```groovy
-implementation("ai.arcships:aimux-java:0.2.0")
+implementation("ai.arcships:aimux-java:0.2.1")
 ```
 
 JNA loads `aimux_ffi` by name — provide the native library

--- a/docs/api/kotlin.md
+++ b/docs/api/kotlin.md
@@ -9,7 +9,7 @@ Kotlin wraps the Rust core through the `aimux-ffi` C ABI (via JNA).
 Maven Central (publishing):
 
 ```kotlin
-implementation("ai.arcships:aimux-kotlin:0.2.0")
+implementation("ai.arcships:aimux-kotlin:0.2.1")
 ```
 
 JNA loads `aimux_ffi` by name — provide the native library

--- a/docs/api/swift.md
+++ b/docs/api/swift.md
@@ -10,7 +10,7 @@ with ARC-managed model handles.
 Add the package via SPM (the git tag is the version):
 
 ```swift
-.package(url: "https://github.com/arcships/aimux", from: "0.2.0"),
+.package(url: "https://github.com/arcships/aimux", from: "0.2.1"),
 .target(name: "Aimux", dependencies: ["Aimux"])
 ```
 

--- a/docs/internal/release-keys-guide.md
+++ b/docs/internal/release-keys-guide.md
@@ -3,7 +3,7 @@
 > 发布流水线 `release.yml` 的剩余渠道（PyPI / Maven Central / Go 二进制）需要
 > 账号与密钥。本文是逐步操作手册。已配置完成的渠道（crates.io、npm）标注跳过。
 >
-> 更新时间：2026-08-03（v0.2.0 发布期）
+> 更新时间：2026-08-03（v0.2.1 发布期）
 
 ## 总览
 
@@ -45,7 +45,7 @@
 
 3. **验证**
    - 触发发布：`gh workflow run release.yml --ref master -f python=true`
-   - 成功后 `pip install arcships-aimux==0.2.0` 可安装（import 仍是 `from aimux import ...`）。
+   - 成功后 `pip install arcships-aimux==0.2.1` 可安装（import 仍是 `from aimux import ...`）。
 
 > 不需要 PyPI API token，也不需要改 workflow。
 
@@ -126,13 +126,13 @@
 ```bash
 # JVM：Maven Central
 gh workflow run release.yml --ref master -f jvm=true
-# 成功后 Maven Central 上出现 ai.arcships:aimux-java:0.2.0 与 aimux-kotlin:0.2.0
+# 成功后 Maven Central 上出现 ai.arcships:aimux-java:0.2.1 与 aimux-kotlin:0.2.1
 # （首次发布在 Staging 仓库，需在 central.sonatype.com 手动 Release 一次；
 #   之后的发布自动处理——取决于 build.gradle.kts 的自动发布配置）
 
 # Flutter：pub.dev（需先配置 PUB_DEV_TOKEN，见 §2.5）
 gh workflow run release.yml --ref master -f flutter=true
-# 成功后 pub.dev 出现 aimux@0.2.0（publisher: arcships.ai）
+# 成功后 pub.dev 出现 aimux@0.2.1（publisher: arcships.ai）
 ```
 
 ---


### PR DESCRIPTION
## 变更

版本全链路 0.2.0 → 0.2.1（Cargo workspace / Node / Python / Flutter / Java / Kotlin），docs 与 Flutter CHANGELOG 同步。

## 背景

- 0.2.0 已发布：crates.io（aimux-core 等 7 crate）、npm（@arcships/aimux）
- 0.2.1 将首次发布：Maven Central（ai.arcships:aimux-java/-kotlin）、pub.dev（aimux，publisher arcships.ai）；Rust/Node/Python 重发保持一致（release.yml 幂等跳过已发布版本）
- 自 0.2.0 以来的内容：Java/Kotlin 包名迁移（io.aimux → ai.arcships.aimux）、Flutter 插件化（iOS CocoaPods 集成修复 #25）、InferenceHub provider（#22，已含于 0.2.0 前）

## 验证

- 版本号 6 处 + docs 10 处引用全部更新（python 字节级替换，无编码问题）
- 待 CI 全绿后打 tag v0.2.1 触发发布