### PR TITLE
fix(jvm): publish via Central Portal OSSRH Staging API (s01 returns 402)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,6 +412,19 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+      - name: Submit deployments to Central Portal
+        # The OSSRH Staging API compatibility service only stages uploads;
+        # this POST (same IP, same runner) moves them into the Portal for
+        # the ai.arcships namespace.
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        run: |
+          curl -sS -u "$OSSRH_USERNAME:$OSSRH_PASSWORD" \
+            -X POST "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/ai.arcships" \
+            -w '\nHTTP %{http_code}\n'
+          # 201/202 = accepted; the deployment then appears in the Portal
+          # (central.sonatype.com/publishing) for release.
 
   # ── Flutter plugin: embed mobile FFI libs, test, publish to pub.dev ───────
   # Publisher: arcships.ai (pub.dev). The native core (Android .so per ABI +

--- a/bindings/java/build.gradle.kts
+++ b/bindings/java/build.gradle.kts
@@ -110,17 +110,21 @@ publishing {
 
     repositories {
         if (ossrhUsername != null && ossrhPassword != null) {
+            // Central Publisher Portal — OSSRH Staging API compatibility
+            // service (s01.oss.sonatype.org is deprecated; it returns 402).
+            // After uploading, release.yml POSTs /manual/upload/defaultRepository
+            // to move the deployment into the Portal.
             maven {
-                name = "OSSRH"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                name = "CentralPortal"
+                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                 credentials {
                     username = ossrhUsername
                     password = ossrhPassword
                 }
             }
             maven {
-                name = "OSSRHSnapshots"
-                url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                name = "CentralPortalSnapshots"
+                url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                 credentials {
                     username = ossrhUsername
                     password = ossrhPassword

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -96,17 +96,21 @@ publishing {
 
     repositories {
         if (ossrhUsername != null && ossrhPassword != null) {
+            // Central Publisher Portal — OSSRH Staging API compatibility
+            // service (s01.oss.sonatype.org is deprecated; it returns 402).
+            // After uploading, release.yml POSTs /manual/upload/defaultRepository
+            // to move the deployment into the Portal.
             maven {
-                name = "OSSRH"
-                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                name = "CentralPortal"
+                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                 credentials {
                     username = ossrhUsername
                     password = ossrhPassword
                 }
             }
             maven {
-                name = "OSSRHSnapshots"
-                url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                name = "CentralPortalSnapshots"
+                url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                 credentials {
                     username = ossrhUsername
                     password = ossrhPassword


### PR DESCRIPTION
Sonatype 已废弃旧 OSSRH 端点（s01.oss.sonatype.org 返回 402 Payment Required）。迁移到 Central Portal 的 OSSRH Staging API 兼容服务：

- staging: https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
- snapshots: https://central.sonatype.com/repository/maven-snapshots/
- 上传后 POST /manual/upload/defaultRepository/ai.arcships（同 runner IP）将部署移入 Portal

另：SIGNING_KEY secret 已重新设置（原值经 PowerShell 管道传递损坏，'Could not read PGP secret key'）。