### PR TITLE
fix(jvm): route SNAPSHOT vs release to correct portal repo

### DIFF
--- a/bindings/java/build.gradle.kts
+++ b/bindings/java/build.gradle.kts
@@ -114,20 +114,26 @@ publishing {
             // service (s01.oss.sonatype.org is deprecated; it returns 402).
             // After uploading, release.yml POSTs /manual/upload/defaultRepository
             // to move the deployment into the Portal.
-            maven {
-                name = "CentralPortal"
-                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+            // Snapshot versions go to the snapshots repository; release
+            // versions to the staging service (the snapshots repo rejects
+            // non-SNAPSHOT versions with 403).
+            if (version.toString().endsWith("SNAPSHOT")) {
+                maven {
+                    name = "CentralPortal"
+                    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+                    credentials {
+                        username = ossrhUsername
+                        password = ossrhPassword
+                    }
                 }
-            }
-            maven {
-                name = "CentralPortalSnapshots"
-                url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+            } else {
+                maven {
+                    name = "CentralPortal"
+                    url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+                    credentials {
+                        username = ossrhUsername
+                        password = ossrhPassword
+                    }
                 }
             }
         }

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -100,20 +100,26 @@ publishing {
             // service (s01.oss.sonatype.org is deprecated; it returns 402).
             // After uploading, release.yml POSTs /manual/upload/defaultRepository
             // to move the deployment into the Portal.
-            maven {
-                name = "CentralPortal"
-                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+            // Snapshot versions go to the snapshots repository; release
+            // versions to the staging service (the snapshots repo rejects
+            // non-SNAPSHOT versions with 403).
+            if (version.toString().endsWith("SNAPSHOT")) {
+                maven {
+                    name = "CentralPortal"
+                    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+                    credentials {
+                        username = ossrhUsername
+                        password = ossrhPassword
+                    }
                 }
-            }
-            maven {
-                name = "CentralPortalSnapshots"
-                url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-                credentials {
-                    username = ossrhUsername
-                    password = ossrhPassword
+            } else {
+                maven {
+                    name = "CentralPortal"
+                    url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+                    credentials {
+                        username = ossrhUsername
+                        password = ossrhPassword
+                    }
                 }
             }
         }


### PR DESCRIPTION
gradle publish 同时发布到 staging 与 snapshots 仓库，snapshots 仓库对非 SNAPSHOT 版本（0.2.1）返回 403。现在按版本后缀路由：SNAPSHOT → snapshots 仓库，release → OSSRH Staging API。