### PR TITLE
feat(python,go): expose full ProviderOptions on the registry provider() entry

### DIFF
--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -479,6 +479,27 @@ func Provider(name, apiKey, modelID string) (*Model, error) {
 
 // ProviderWithBase is Provider with a base URL override (config_json).
 func ProviderWithBase(name, apiKey, modelID, baseURL string) (*Model, error) {
+	if baseURL == "" {
+		return ProviderWithConfig(name, apiKey, modelID, nil)
+	}
+	return ProviderWithConfig(name, apiKey, modelID, &ProviderConfig{BaseURL: baseURL})
+}
+
+// ProviderConfig mirrors the Rust ProviderOptions accepted by
+// aimux_provider_new's config_json (RFC-0017 §3.4). Zero-value fields are
+// omitted; MaxRetries is a pointer so 0 (disable retries) is expressible.
+type ProviderConfig struct {
+	BaseURL       string            `json:"base_url,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Organization  string            `json:"organization,omitempty"`
+	Project       string            `json:"project,omitempty"`
+	MaxRetries    *uint32           `json:"max_retries,omitempty"`
+	BodyOverrides map[string]any    `json:"body_overrides,omitempty"`
+}
+
+// ProviderWithConfig is Provider with the full ProviderOptions config.
+// cfg may be nil for defaults.
+func ProviderWithConfig(name, apiKey, modelID string, cfg *ProviderConfig) (*Model, error) {
 	m := &Model{}
 	cName := C.CString(name)
 	cModel := C.CString(modelID)
@@ -492,9 +513,12 @@ func ProviderWithBase(name, apiKey, modelID, baseURL string) (*Model, error) {
 	}
 
 	var cConfig *C.char
-	if baseURL != "" {
-		cfg := `{"base_url":"` + baseURL + `"}`
-		cConfig = C.CString(cfg)
+	if cfg != nil {
+		buf, err := json.Marshal(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("aimux: marshal provider config: %w", err)
+		}
+		cConfig = C.CString(string(buf))
 		defer C.free(unsafe.Pointer(cConfig))
 	}
 

--- a/bindings/go/aimux_test.go
+++ b/bindings/go/aimux_test.go
@@ -8,6 +8,7 @@
 package aimux
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -102,4 +103,41 @@ func TestStreamTextReturnsStream(t *testing.T) {
 	}
 	// Err() should be safe to call after drain.
 	_ = s.Err()
+}
+
+func TestProviderWithConfigFullOptions(t *testing.T) {
+	retries := uint32(0)
+	m, err := ProviderWithConfig("groq", "sk-test-fake-key", "llama-3.3-70b", &ProviderConfig{
+		BaseURL:       "https://example.com/v1",
+		Headers:       map[string]string{"X-Custom": "1"},
+		Organization:  "org-1",
+		Project:       "proj-1",
+		MaxRetries:    &retries,
+		BodyOverrides: map[string]any{"temperature": 0.1},
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	defer m.Close()
+	if m.handle == 0 {
+		t.Fatal("expected non-zero handle")
+	}
+}
+
+func TestProviderWithConfigNil(t *testing.T) {
+	m, err := ProviderWithConfig("groq", "sk-test-fake-key", "llama-3.3-70b", nil)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	defer m.Close()
+}
+
+func TestProviderWithBaseQuotedURLDoesNotInjectJSON(t *testing.T) {
+	// A baseURL containing a quote must not produce malformed config JSON
+	// (the old string concatenation would). The provider layer may reject
+	// the URL itself, but the error must not be a JSON parse failure.
+	_, err := ProviderWithBase("groq", "sk-test-fake-key", "llama-3.3-70b", `https://example.com/"v1`)
+	if err != nil && strings.Contains(err.Error(), "invalid provider config JSON") {
+		t.Fatalf("config JSON injection: %v", err)
+	}
 }

--- a/bindings/python/python/aimux/__init__.py
+++ b/bindings/python/python/aimux/__init__.py
@@ -21,7 +21,7 @@ from .aimux import (
     vertex,
     anthropic_aws,
     azure,
-    provider,
+    provider as _native_provider,
     EmbeddingModel,
     SpeechModel,
     ImageModel,
@@ -79,6 +79,27 @@ __all__ = [
     "generate_text",
     "stream_text",
 ]
+
+
+def provider(
+    name: str,
+    api_key: Optional[str],
+    model_id: str,
+    base_url: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Model:
+    """Create a language model from the built-in registry by provider name.
+
+    Args:
+        name: Registry provider name (e.g. "deepseek", "groq").
+        api_key: API key; None reads the provider's env var.
+        model_id: Model ID.
+        base_url: Base-URL override (wins over config["base_url"]).
+        config: Full ProviderOptions dict — base_url / headers / organization /
+            project / max_retries / body_overrides.
+    """
+    config_json = json.dumps(config) if config is not None else None
+    return _native_provider(name, api_key, model_id, base_url, config_json)
 
 
 def _prompt_to_json(prompt: Union[str, List[Dict[str, Any]]]) -> str:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -387,18 +387,29 @@ fn azure(
 
 /// Create a language model from the built-in registry by provider name
 /// (RFC-0017 phase 4). `api_key=None` reads the provider's env var.
+/// `config_json` is a serialized `ProviderOptions` object (`base_url` /
+/// `headers` / `organization` / `project` / `max_retries` /
+/// `body_overrides`); the `base_url` parameter wins over the JSON field.
 #[pyfunction]
-#[pyo3(signature = (name, api_key, model_id, base_url=None))]
+#[pyo3(signature = (name, api_key, model_id, base_url=None, config_json=None))]
 fn provider(
     name: &str,
     api_key: Option<String>,
     model_id: &str,
     base_url: Option<&str>,
+    config_json: Option<&str>,
 ) -> PyResult<Model> {
-    let options = base_url.map(|url| aimux_providers::ProviderOptions {
-        base_url: Some(url.to_string()),
-        ..Default::default()
-    });
+    let mut options: Option<aimux_providers::ProviderOptions> = match config_json {
+        Some(s) if !s.trim().is_empty() && s.trim() != "null" => {
+            Some(serde_json::from_str(s).map_err(|e| {
+                PyRuntimeError::new_err(format!("[Json] invalid config: {e}"))
+            })?)
+        }
+        _ => None,
+    };
+    if let Some(url) = base_url {
+        options.get_or_insert_with(Default::default).base_url = Some(url.to_string());
+    }
     let model = aimux_providers::provider(name, api_key, model_id, options)
         .map_err(|e| PyRuntimeError::new_err(format!("[{}] {e}", e.error_type())))?;
     Ok(Model {

--- a/bindings/python/tests/test_aimux.py
+++ b/bindings/python/tests/test_aimux.py
@@ -38,6 +38,54 @@ def test_provider_unknown_name_raises():
         provider("no-such-provider", "k", "m")
 
 
+def test_provider_accepts_full_config():
+    """provider() accepts a full ProviderOptions config dict (RFC-0017 §3.4)."""
+    from aimux import provider
+
+    model = provider(
+        "groq",
+        "sk-test-fake-key",
+        "llama-3.3-70b",
+        config={
+            "base_url": "https://example.com/v1",
+            "headers": {"X-Custom": "1"},
+            "organization": "org-1",
+            "project": "proj-1",
+            "max_retries": 0,
+            "body_overrides": {"temperature": 0.1},
+        },
+    )
+    assert model is not None
+    assert hasattr(model, "generate_text")
+
+
+def test_provider_base_url_param_wins_over_config():
+    """Explicit base_url parameter overrides config["base_url"]."""
+    from aimux import provider
+
+    model = provider(
+        "groq",
+        "sk-test-fake-key",
+        "llama-3.3-70b",
+        base_url="https://param.example.com/v1",
+        config={"base_url": "https://config.example.com/v1"},
+    )
+    assert model is not None
+
+
+def test_provider_invalid_config_raises():
+    """provider() rejects a config with wrong field types."""
+    from aimux import provider
+
+    with pytest.raises(Exception, match="invalid config"):
+        provider(
+            "groq",
+            "sk-test-fake-key",
+            "llama-3.3-70b",
+            config={"max_retries": "not-a-number"},
+        )
+
+
 def test_provider_missing_env_key_raises():
     """provider() with api_key=None reads the env var and fails clearly when unset."""
     from aimux import provider

--- a/docs/api/go.md
+++ b/docs/api/go.md
@@ -58,6 +58,13 @@ defer model.Close()
 // 字符串形式同样可用 + base URL 覆盖:
 model2, err := aimux.ProviderWithBase("groq", "sk-...", "llama-3.3-70b", "https://relay.example/v1")
 defer model2.Close()
+
+// 完整 ProviderOptions(base_url / headers / organization / project /
+// max_retries / body_overrides):
+model3, err := aimux.ProviderWithConfig("groq", "sk-...", "llama-3.3-70b", &aimux.ProviderConfig{
+	Headers: map[string]string{"X-Custom": "1"},
+})
+defer model3.Close()
 ```
 
 `NewDeepSeek` / `DeepSeek` remain as shortcuts (registry-backed). Unknown

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -28,14 +28,20 @@ from aimux import provider, generate_text
 model = provider("groq", None, "llama-3.3-70b")
 # Explicit key + base URL override:
 model = provider("groq", "sk-...", "llama-3.3-70b", "https://relay.example/v1")
+# Full ProviderOptions via config dict:
+model = provider("groq", "sk-...", "llama-3.3-70b",
+                 config={"headers": {"X-Custom": "1"}, "max_retries": 0})
 result = generate_text(model, "Hello")
 ```
 
-`provider(name, api_key, model_id, base_url=None)` covers all 250 built-in
-OpenAI-compatible providers. `openai` / `anthropic` / `deepseek` factories
+`provider(name, api_key, model_id, base_url=None, config=None)` covers all
+251 built-in OpenAI-compatible providers. `config` takes the full
+`ProviderOptions` shape (`base_url` / `headers` / `organization` / `project` /
+`max_retries` / `body_overrides`); the `base_url` parameter wins over
+`config["base_url"]`. `openai` / `anthropic` / `deepseek` factories
 remain (deepseek is now registry-backed).
 
-> **Scope:** `provider(name)` covers only the 250 registry OpenAI-compatible
+> **Scope:** `provider(name)` covers only the 251 registry OpenAI-compatible
 > providers; Anthropic/Google/multimodal/local → typed factories
 > (`anthropic(api_key, model)`); custom endpoints → `base_url` param.
 > Full list: [providers.md](providers.md).


### PR DESCRIPTION
The registry entry point (`provider(name, ...)`, RFC-0017 §3.4) accepts a full `ProviderOptions` config in Java/Kotlin/Swift/Flutter via `config_json`, but Python and Go only exposed `base_url` — the other five fields (`headers` / `organization` / `project` / `max_retries` / `body_overrides`) were unreachable from these two bindings. This was recorded in the phase-4 audit as P2-4.

**Python** — `provider()` gains a `config` dict parameter:

```python
model = provider("groq", "sk-...", "llama-3.3-70b",
                 config={"headers": {"X-Custom": "1"}, "max_retries": 0})
```

The native layer takes a `config_json` string (serde → `ProviderOptions`); the Python wrapper serializes the dict, following the existing wrapper-layer pattern (`generate_text` / `stream_text` do the same dict↔JSON conversion). The explicit `base_url` parameter wins over `config["base_url"]`. Invalid config raises with the serde detail. Existing positional calls are unchanged.

**Go** — adds a typed `ProviderConfig` struct and `ProviderWithConfig(name, apiKey, modelID, cfg)`:

```go
model, err := aimux.ProviderWithConfig("groq", "sk-...", "llama-3.3-70b", &aimux.ProviderConfig{
    Headers: map[string]string{"X-Custom": "1"},
})
```

`MaxRetries` is a `*uint32` so `0` (disable retries) is distinguishable from unset. `ProviderWithBase` now routes through `ProviderWithConfig` with `json.Marshal` — which also fixes a latent bug: the old string concatenation (`{"base_url":"` + url + `"}`) produced malformed JSON for a URL containing a quote. An empty `baseURL` still passes NULL config to the C ABI (behavior unchanged).

**Tests:** Python +3 (full config construction, `base_url` precedence, invalid config error), full suite 33/33 passing against a maturin-built wheel. Go +3 (full config, nil config, quote-in-URL no longer injects), full suite passing. Docs (`docs/api/python.md`, `docs/api/go.md`) updated.