### PR TITLE
docs(rfc): RFC-0020~0024 新方向文档

### DIFF
--- a/docs/external-provider-config-research.md
+++ b/docs/external-provider-config-research.md
@@ -1,0 +1,362 @@
+# 调研:允许外部提供 provider 配置的可行性与设计
+
+> **Status**: 调研报告(非 RFC,供决策)
+> **Date**: 2026-08-05
+> **Scope**: 评估"运行时/宿主应用/配置文件提供 provider 配置"对 aimux 的可行性、形态、成本收益,给出明确建议
+> **Related**: [RFC-0017](../rfc/0017-provider-config-dx.md) 配置 DX、[RFC-0019](../rfc/0019-session-affinity.md) 会话亲和
+
+---
+
+## TL;DR(结论先行)
+
+**建议:部分做(推荐)。** 核心结论——
+
+1. **值得做且低成本的部分**:为 **OpenAI 兼容协议** 的 provider 提供外部配置能力(配置文件 + 编程式注册 + 覆盖内置条目)。这高度契合 aimux 现有架构——`provider_registry.json` 本就是"name → 数据"的查找表,`provider()` 工厂已能把条目数据 + `ProviderOptions` 组装成 `Box<dyn LanguageModel>`;外部配置只需在"查条目"这一步注入运行时数据,后端管线零改动。**最小可行形态约 200~400 行 Rust + 各绑定薄透传。**
+
+2. **不建议(或远期)的部分**:动态注册**原生协议**(anthropic / google / bedrock / vertex / azure …)的新 provider。这些是**代码实现**(各自有独立 convert/stream/model 代码,见 [lib.rs:15-24](../aimux-providers/src/lib.rs#L15-L24)),无法用配置数据描述。配置文件驱动只能覆盖 OpenAI 兼容这一层(250 家薄封装的同类),与 RFC-0017 §2.6 的分层定论一致。
+
+3. **关键架构事实**:aimux **从不存储 `dyn Provider`**(`Provider` trait 仅作工厂,`language_model()` 立即产出 `Box<dyn LanguageModel>`);系统唯一流通货币是 `Box<dyn LanguageModel>` / `Arc<dyn LanguageModel>`(已 object-safe、全链路使用)。因此"动态注册"**不需要** `dyn Provider` 注册表,只需一个运行时可变的 name→数据 覆盖层。
+
+---
+
+## 1. aimux 当前配置机制全貌
+
+### 1.1 数据源:编译期嵌入的 registry JSON
+
+- `provider_registry.json`(251 条,见 [provider.rs:292](../aimux-providers/src/provider.rs#L292) `assert_eq!(entries.len(), 251)`)是**唯一数据源**,通过 `include_str!` 在编译期嵌入([provider.rs:66](../aimux-providers/src/provider.rs#L66))。
+- 每条 `RegistryEntry`([provider.rs:34-42](../aimux-providers/src/provider.rs#L34-L42)):`name` / `display` / `base_url` / `env_var` / `profile`。`profile` 是纯数据(`supports_top_k`/`supports_tools`/`supports_response_format`/`stream_usage_key`/`max_tokens_key`,见 [provider.rs:45-55](../aimux-providers/src/provider.rs#L45-L55))。
+- `REGISTRY` 是 `OnceLock<Vec<RegistryEntry>>`([provider.rs:61](../aimux-providers/src/provider.rs#L61))——**初始化后不可变**,无运行时增删入口。
+
+### 1.2 工厂入口:`provider(name, api_key, model_id, options)`
+
+[provider.rs:119-168](../aimux-providers/src/provider.rs#L119-L168) 是唯一名字驱动入口:
+
+1. `registry().iter().find(|e| e.name == name)`——找不到即 `UnknownProvider`([provider.rs:126-131](../aimux-providers/src/provider.rs#L126-L131))。
+2. api_key 为 `None` 时读条目的 `env_var`([provider.rs:133-136](../aimux-providers/src/provider.rs#L133-L136))。
+3. 用条目数据初始化 `OpenAIConfig`(base_url / provider / profile),再叠加 `ProviderOptions` 覆盖([provider.rs:138-165](../aimux-providers/src/provider.rs#L138-L165))。
+4. `OpenAIProvider::new(config).language_model(model_id)` → `Box<dyn LanguageModel>`([provider.rs:167](../aimux-providers/src/provider.rs#L167))。
+
+**注意**:这条路径**永远构造 `OpenAIProvider`**——registry 只服务 OpenAI 兼容协议。
+
+### 1.3 覆盖能力:`ProviderOptions`(已存在)
+
+[provider.rs:96-110](../aimux-providers/src/provider.rs#L96-L110) 已支持 per-call 覆盖:`base_url` / `headers` / `organization` / `project` / `max_retries` / `body_overrides`。**但只能覆盖已知条目的字段,不能注册新名字,也不能覆盖 `profile`**(profile 来自条目,不在 options 里)。
+
+### 1.4 "与内置表无关"的逃生口:`OpenAIProvider` 基础类
+
+RFC-0017 阶段 4 第 4 点([0017-provider-config-dx.md:359](../rfc/0017-provider-config-dx.md#L359))保留了 `OpenAIConfig`/`OpenAIProvider` 基础类作为"createProvider 等价能力"。即用户可直接:
+
+```rust
+let cfg = OpenAIConfig::new(key).with_base_url(url).with_profile(profile);
+let model = OpenAIProvider::new(cfg).language_model("model-id")?; // Box<dyn LanguageModel>
+```
+
+Node `openai(apiKey, modelId, config)`([lib.rs:283-308](../bindings/node/src/lib.rs#L283-L308))也是此路径——但**不暴露 profile 字段**(`ProviderConfig` 只有 base_url/headers/org/project/max_retries/body_overrides,见 [lib.rs:218-236](../bindings/node/src/lib.rs#L218-L236))。
+
+**现状缺口**:
+- (a) 新名字无法被 `provider("my-relay", ...)` 查到——只能用基础类逐次构造,**无"name → 后续复用"机制**。
+- (b) 绑定层不暴露 profile,自定义 provider 拿到的是 `full()` profile,无法表达 `max_tokens_key` 等差异。
+- (c) 无配置文件加载;无运行时增删;无外部覆盖内置条目。
+
+### 1.5 各绑定配置流
+
+| 绑定 | 入口 | 配置形态 |
+|---|---|---|
+| Rust | `aimux_providers::provider(name, key, model, opts)` | `ProviderOptions` 结构 |
+| Node | `provider(name, apiKey?, model, config?)` + `openai(...)` 等([lib.rs:649-664](../bindings/node/src/lib.rs#L649-L664)) | `ProviderConfig` 对象(JSON string 透传) |
+| C ABI | `aimux_provider_new(name, key, model, config_json)`([lib.rs:738-770](../aimux-ffi/src/lib.rs#L738-L770)) | `ProviderOptions` 的 JSON |
+| Python/Go/… | 经 FFI JSON 透传 | 同 C ABI |
+
+所有绑定最终汇聚到同一个 `provider()` Rust 函数——**外部配置只需在 Rust core 一处落地,绑定层做薄透传即可,8 语言同步受益**(RFC-0017 阶段 4 已验证此分发模式)。
+
+---
+
+## 2. "外部提供配置"的几种可能形态
+
+| 形态 | 描述 | aimux 现状 | 本调研判断 |
+|---|---|---|---|
+| **a. 配置文件注册** | YAML/TOML/JSON 声明 provider 列表,运行时加载 | 无 | ✅ **推荐做(最小可行形态的核心)** |
+| **b. 编程式注册** | 宿主应用调 API 注册自定义 provider(name+url+key+headers+profile) | 仅基础类逐次构造,无注册表 | ✅ **推荐做(与 a 共享同一覆盖层)** |
+| **c. 动态发现/增删** | 网关运行时不重启增删 provider | 无 | ⚠️ **部分做**:增删可行(覆盖层可变),但"动态发现"属网关职责,aimux 定位是接入层不做(见 RFC-0019 §1.4 边界) |
+| **d. 外部覆盖/扩展内置 registry** | 外部条目替换或补充内置 251 条 | 无 | ✅ **推荐做(覆盖层 merge 语义天然支持)** |
+
+a/b/d 三者**共用同一个运行时覆盖层**(见 §4),实现上是同一机制的三个入口;区别仅在数据来源(文件 / API 调用 / 两者皆有)。c 的"增删"也复用该层(可变 map),"动态发现"则超出 aimux 定位。
+
+---
+
+## 3. 业界方案对比
+
+### 3.1 LiteLLM(config.yaml 驱动 + 运行时管理)
+
+- **形态**:`config.yaml` 的 `model_list` 声明 `model_name`(用户面名)+ `litellm_params`(model/api_base/api_key/extra_headers/organization/temperature …),`litellm --config` 启动加载([docs.litellm.ai/docs/proxy/configs](https://docs.litellm.ai/docs/proxy/configs))。
+- **动态性**:`store_model_in_db` 开启后,Admin UI / `/config/update` API 写数据库,运行时增删模型**无需重启**;DB 模型与 YAML 模型共存(load balance),不互相替换([docs.litellm.ai/docs/proxy/model_management](https://docs.litellm.ai/docs/proxy/model_management))。
+- **协议覆盖**:`litellm_params.model` 前缀(`azure/`、`bedrock/`、`openai/`、`ollama/`…)决定走哪个协议实现——**因为 litellm 是 Python,协议实现可在运行时按字符串 dispatch**。
+- **优点**:声明式、动态、协议全覆盖(靠 Python 动态分发)。
+- **缺点**:配置 schema 庞大;DB 与 YAML 的 deep-merge 语义复杂(`null`/空列表的特判);安全面大(api_key 入库、master_key)。
+
+### 3.2 cc-switch(配置文件/预设驱动 provider 切换)
+
+- **形态**:TS 预设表(`claudeProviderPresets.ts` 等),每条预设含 `settingsConfig.env`(注入到目标应用的 env var)、`apiFormat`(`anthropic`/`openai_chat`/`openai_responses`/`gemini_native`)、`providerType`(`github_copilot`/`codex_oauth`/`xai_oauth` 特殊认证)([claudeProviderPresets.ts:25-74](../reference/cc-switch/src/config/claudeProviderPresets.ts#L25-L74))。
+- **关键设计**:`apiFormat` 即**协议类型**字段——cc-switch 本身**不实现协议**,只给 Claude Code/Codex/Gemini 客户端喂 env var,由这些客户端各自处理协议转换。Universal Provider 预设(如 NewAPI)跨三应用同步配置([universalProviderPresets.ts:61-76](../reference/cc-switch/src/config/universalProviderPresets.ts#L61-L76))。
+- **优点**:协议类型作为数据字段清晰;预设可被用户覆盖/扩展。
+- **缺点**:依赖宿主客户端实现协议——这正是 aimux 与之的根本差异(aimux 自己用 Rust 实现协议)。
+
+### 3.3 one-api / new-api(数据库存 provider 配置)
+
+- **形态**:provider 配置(channel)存数据库,运行时管理界面增删改查;支持多协议(OpenAI/Anthropic/Gemini…)通过 relay 层转换。
+- **优点**:完全动态、运营友好。
+- **缺点**:是**网关产品**而非库——自带 HTTP 服务、计费、用户体系。aimux 是接入层库,不承担此定位(RFC-0019 §1.4 已明确"不做渠道路由/账号池")。
+
+### 3.4 Vercel AI SDK(纯编程式)
+
+- **形态**:`createOpenAI({ baseURL, apiKey, headers, ... })` / `createOpenAICompatible(...)` 工厂,纯代码传配置,无配置文件。`transformRequestBody` 闭包做请求体变换。
+- **优点**:类型安全、无解析面、无文件 IO 风险。
+- **缺点**:无声明式配置;无"name 复用"注册表(每次构造)。
+- aimux 的 `OpenAIProvider::new(OpenAIConfig::new(...))` + `ProviderConfig` 已对齐此形态(RFC-0017 §1.2 已论证为何不引入闭包桥接,改用 `bodyOverrides` JSON merge)。
+
+### 3.5 对比小结
+
+| 维度 | litellm | cc-switch | one/new-api | Vercel AISDK | **aimux 现状** | **aimux 适合** |
+|---|---|---|---|---|---|---|
+| 配置文件 | ✅ yaml | ✅ 预设 TS/JSON | ❌ DB | ❌ | ❌ | ✅ 做 |
+| 编程式注册 | ✅ | ✅(喂 env) | ✅ | ✅ | 🔶(基础类,无注册表) | ✅ 做 |
+| 动态增删 | ✅ DB | 🔶(切预设) | ✅ | ❌ | ❌ | ⚠️(增删做,发现不做) |
+| 协议类型字段 | 🔶(model 前缀) | ✅ apiFormat | ✅ | ❌ | ❌ | 🔶(仅 openai_compat 可数据化,见 §4.4) |
+| 定位 | 网关 | 配置切换器 | 网关 | SDK | **接入层库** | — |
+
+---
+
+## 4. aimux 做这个的契合度
+
+### 4.1 registry 是编译期嵌入的 JSON,如何支持运行时注入?
+
+**完全可行,且改动集中。** 现状 `REGISTRY: OnceLock<Vec<RegistryEntry>>` 不可变([provider.rs:61](../aimux-providers/src/provider.rs#L61))。注入方案:
+
+- 新增一个**运行时覆盖层** `OVERLAYS: RwLock<HashMap<String, RegistryEntry>>`(或 `OnceLock<...>` 包 `RwLock`)。
+- `provider()` 查找顺序改为:**覆盖层 → 内置 registry**;找到条目后,后端组装管线(`OpenAIConfig` 构造 + `ProviderOptions` 叠加)完全复用,零改动。
+- 内置 registry 仍是 `include_str!` 编译期嵌入(保留 RFC-0017 的"单一数据源 + 类型派生"不变);覆盖层只承载外部新增/覆盖条目。
+- **这是纯增量改动**:不动 `provider_registry.json`、不动 `gen_provider_names.py`、不动 `ProviderName` 派生(外部名字不属于编译期枚举,走字符串路径即可)。
+
+### 4.2 Provider / LanguageModel trait 是否 object-safe(能否动态注册)?
+
+**是,且更优——aimux 根本不需要 `dyn Provider` 注册表。**
+
+- `Provider` trait([provider.rs:9-14](../aimux-core/src/provider.rs#L9-L14))object-safe(全 `&self` 方法,返回 `&str` / `Box<dyn LanguageModel>`,无泛型/Self)。但全仓库**从不存储 `dyn Provider`**(`grep "dyn Provider"` 零命中)——`Provider` 仅作工厂,`language_model()` 立即产出 `Box<dyn LanguageModel>`。
+- `LanguageModel` trait([language_model.rs:25-42](../aimux-core/src/language_model.rs#L25-L42))经 `#[async_trait]` 去糖为返回 `Pin<Box<dyn Future>>`,object-safe;**已是全链路通用货币**(`Box<dyn LanguageModel>` / `Arc<dyn LanguageModel>`,见 [lib.rs:31](../bindings/node/src/lib.rs#L31)、[lib.rs:767](../aimux-ffi/src/lib.rs#L767))。
+- **推论**:动态注册一个外部 provider = 把它的配置数据塞进覆盖层;`provider()` 查到后照常 `OpenAIProvider::new(config).language_model(id)` → `Box<dyn LanguageModel>`。**无需任何 trait object 注册表,无需新抽象。** 这是 aimux 架构对此需求的天然友好点。
+
+### 4.3 配置 schema 要不要包含 protocol type?
+
+**需要,但只能取一个值:`openai_compat`(且为默认)。** 这是关键约束,理由:
+
+- aimux 的薄封装 registry **只服务 OpenAI 兼容协议**——`provider()` 恒构造 `OpenAIProvider`([provider.rs:167](../aimux-providers/src/provider.rs#L167))。
+- 原生协议(anthropic/google/bedrock/vertex/azure/cohere/mistral)是**独立代码实现**(各有 convert/model/stream 模块,[lib.rs:15-24](../aimux-providers/src/lib.rs#L15-L24)),**无法用配置数据描述**——这与 RFC-0017 §2.6 的分层定论一致("协议不兼容的走核心代码实现,协议兼容且差异可数据化的一律走 JSON")。
+- 对比 cc-switch 的 `apiFormat` 四值——cc-switch 不实现协议(靠宿主客户端),所以能把协议类型当数据;aimux 自己实现协议,新协议=新代码,配置无法承载。
+- **因此**:外部配置能注册"内置 registry 没有的新 provider"——**但仅限 OpenAI 兼容的那些**。要注册一个全新的原生协议 provider,只能走代码(实现 trait + 发 PR),无法靠配置。
+
+schema 里仍**建议显式带 `protocol` 字段**(默认 `openai_compat`),为未来留扩展点(若某天加 plugin/code 扩展机制,可新增取值);当前非 `openai_compat` 直接报清晰错误。
+
+### 4.4 与 RFC-0017 bodyOverrides 的关系
+
+- `body_overrides`(provider 级 + per-call,JSON deep merge)解决的是**请求体字段差异**(关思考、字段重命名等),[0017-provider-config-dx.md:63-136](../rfc/0017-provider-config-dx.md#L63-L136)。
+- 本调研的"外部 provider 配置"解决的是**provider 身份/连接/profile 差异**(name/base_url/env_var/profile)——是比 bodyOverrides **更外层**的配置:先确定"连哪个 provider",再决定"请求体怎么覆盖"。
+- 二者正交且互补:外部配置条目可自带 `body_overrides`(provider 级,等价于把 §2.5 示例 2/3 的 relay/Qwen 配置声明式化),per-call `body_overrides` 仍在其后 merge 覆盖。**无冲突**。
+- RFC-0017 阶段 4 已预留"用户覆盖内置条目"语义([0017-provider-config-dx.md:363](../rfc/0017-provider-config-dx.md#L363):"同名条目——用户 JSON 替换/merge 内置条目,仅在'查条目'一步生效")——**本调研即该语义的具体落地**,是对 RFC-0017 的延续而非偏离。
+
+### 4.5 与"零内置厂商映射"原则(RFC-0017 v3)的关系
+
+RFC-0017 v3 退役了所有内置厂商思考映射,改为用户 `bodyOverrides` 定义([0017-provider-config-dx.md:140-149](../rfc/0017-provider-config-dx.md#L140-L149))。外部配置**强化**而非削弱此原则:
+- 外部 provider 条目可自带 `body_overrides`,把"某 relay 的专属字段""某厂商关思考"**声明式写进配置**,而非散落在调用点代码——更符合"知识放配置/文档,机制放代码"。
+- profile 字段(`max_tokens_key` 等)是**机制数据**(aimux 内部推断用),非厂商映射知识,放入配置不违反原则。
+
+---
+
+## 5. 成本/收益与风险
+
+### 5.1 实现难度
+
+| 部分 | 难度 | 工作量估计 | 说明 |
+|---|---|---|---|
+| 运行时覆盖层(Rust core) | 低 | ~150 行 | `RwLock<HashMap>` + `provider()` 查找顺序调整 + 注册/加载 API |
+| 配置文件解析(YAML/TOML/JSON) | 低 | ~100 行 | 复用 `RegistryEntry` schema;JSON 最省依赖(YAML 需加 `serde_yaml`/`serde_yml`) |
+| 编程式注册 API(Rust) | 低 | ~50 行 | `register_provider(entry)` / `load_config_file(path)` |
+| 绑定层透传(8 语言) | 低 | 每语言 ~30 行 | RFC-0017 阶段 4 已验证分发模式;Node `provider()` 加 config-file 参数或新增 `registerProvider` |
+| profile 字段透出 | 低 | ~50 行 | 绑定 `ProviderConfig` 加 `profile` 子对象 |
+| **合计(最小可行)** | **低** | **~200-400 行 Rust + 绑定薄改** | 无新抽象、无 trait 改动、无破坏性变更 |
+
+对比"动态注册原生协议 provider"(需 plugin/trait 注册系统):**高难度、高复杂度、低边际价值**(原生协议稳定且仅个位数,已代码实现),**不建议纳入**。
+
+### 5.2 收益
+
+1. **"新增/修正 provider 从库行为变用户行为"**(RFC-0017 阶段 4 目标 [0017-provider-config-dx.md:345](../rfc/0017-provider-config-dx.md#L345))的**最后一块拼图**——目前改内置 provider 仍需改 JSON + 重新编译发版;外部配置让 relay/私有网关/新厂商接入**零编译、零发版**。
+2. **宿主应用集成友好**:网关/IDE/agent 宿主可编程式注册其私有 provider,不必 fork aimux。
+3. **声明式配置**与 litellm/cc-switch 生态对齐,降低迁移门槛;配置文件可版本管理、团队共享。
+4. 覆盖内置条目 = 修 base_url 错误等不必等发版(配合 RFC-0017 阶段 4 已修的 7 处 base_url)。
+
+### 5.3 风险与对策
+
+| 风险 | 等级 | 对策 |
+|---|---|---|
+| **API key 注入到配置文件**(明文泄露) | 高 | (1) schema 支持 `api_key: "env:VAR_NAME"` 引用(默认从 env 读,与内置 `env_var` 一致);(2) 文档强警示;(3) 不把 key 写日志(RFC-0015 审计已关注) |
+| **SSRF via base_url**(内网探测) | 中 | (1) `base_url` scheme 校验(默认仅 `http`/`https`);(2) 可选 allowlist/blocklist(宿主侧);(3) 文档警示"外部配置 = 信任边界" |
+| **覆盖层与内置条目 merge 语义歧义** | 中 | 明确定义:外部条目**整体替换**内置同名条目(非 deep merge,简单可预期);`ProviderOptions` 仍在条目之上 per-call 覆盖(已有) |
+| **配置文件解析错误延后到运行时** | 低 | 加载时即校验(schema:必填 name/base_url、profile 字段范围);校验失败返回明确错误(非 panic) |
+| **profile 的 `&'static str` 字段**(`stream_usage_key`/`max_tokens_key`) | 低 | `profile_from_registry` 已用 `Box::leak` 处理运行时字符串([provider.rs:180-187](../aimux-providers/src/provider.rs#L180-L187));覆盖层条目复用同路径,无新问题 |
+| **并发注册竞争** | 低 | `RwLock` 保护;注册应在启动期完成,运行期只读查(动态增删可选,文档建议启动期注册) |
+| **对"零内置厂商映射"原则的冲击** | 低 | 无冲击——profile 是机制数据,厂商映射仍由用户 `body_overrides` 定义(§4.5) |
+
+---
+
+## 6. 推荐的最小可行形态
+
+### 6.1 范围(MVP)
+
+- ✅ 配置文件(JSON 起步,YAML 可选)加载 OpenAI 兼容 provider
+- ✅ 编程式注册 API(`register_provider` / `load_providers_from_file`)
+- ✅ 覆盖/扩展内置 registry(同名替换、新名新增)
+- ✅ profile 字段在配置 schema 中可声明
+- ✅ api_key 支持 `env:VAR` 引用(默认)与明文(不推荐)
+- ❌ 原生协议动态注册(远期,需 plugin 机制)
+- ❌ 动态发现/网关路由(超出定位)
+
+### 6.2 推荐配置 schema(JSON;YAML 等价)
+
+```json
+{
+  "$schema": "https://aimux.dev/schema/providers.v1.json",
+  "providers": [
+    {
+      "name": "my-relay",
+      "display": "My Team Relay",
+      "base_url": "https://relay.internal.team/v1",
+      "env_var": "MY_RELAY_API_KEY",
+      "api_key": "env:MY_RELAY_API_KEY",
+      "protocol": "openai_compat",
+      "profile": {
+        "supports_top_k": true,
+        "supports_tools": true,
+        "supports_response_format": true,
+        "stream_usage_key": null,
+        "max_tokens_key": null
+      },
+      "headers": { "X-Team": "platform" },
+      "body_overrides": { "enable_thinking": false },
+      "max_retries": 2
+    },
+    {
+      "name": "groq",
+      "base_url": "https://api.groq.com/openai/v1",
+      "env_var": "GROQ_API_KEY",
+      "protocol": "openai_compat",
+      "comment": "覆盖内置 groq 条目的 base_url"
+    }
+  ]
+}
+```
+
+**schema 设计要点**:
+- 复用 `RegistryEntry` 字段(name/display/base_url/env_var/profile)+ 已有 `ProviderOptions` 字段(headers/body_overrides/max_retries/organization/project)→ **不发明新概念**,与 [provider.rs:34-110](../aimux-providers/src/provider.rs#L34-L110) 同构。
+- `protocol` 字段:默认 `openai_compat`;其他值当前报错(为扩展预留)。
+- `api_key`:`"env:VAR"` 引用优先(安全默认,与内置 `env_var` 语义一致);明文字符串技术支持但文档不推荐。
+- `profile`:全可选,缺省 `full()`(与内置 `profile: {}` 等价)。
+- `comment`:用户备注,库忽略(配置文件可读性)。
+
+### 6.3 推荐的 Rust API(MVP)
+
+```rust
+// aimux-providers/src/provider.rs 增量
+
+/// 外部 provider 配置条目(与 RegistryEntry + ProviderOptions 同构,可 Deserialize)。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExternalProviderEntry {
+    pub name: String,
+    pub display: Option<String>,
+    pub base_url: String,
+    pub env_var: Option<String>,
+    pub api_key: Option<String>,        // "env:VAR" 或明文
+    #[serde(default = "default_openai_compat")]
+    pub protocol: String,               // 当前仅 "openai_compat"
+    #[serde(default)]
+    pub profile: RegistryProfile,
+    pub headers: Option<HashMap<String, String>>,
+    pub organization: Option<String>,
+    pub project: Option<String>,
+    pub max_retries: Option<u32>,
+    pub body_overrides: Option<Value>,
+}
+
+/// 注册一个外部 provider(覆盖同名内置条目,或新增)。
+pub fn register_provider(entry: ExternalProviderEntry) -> Result<(), AiMuxError> { /* 校验 + 写 OVERLAYS */ }
+
+/// 从配置文件加载并注册多个 provider。
+pub fn load_providers_from_file(path: &Path) -> Result<(), AiMuxError> { /* parse + register each */ }
+
+/// 从 JSON 字符串加载(供绑定层透传)。
+pub fn load_providers_from_json(json: &str) -> Result<(), AiMuxError> { /* ... */ }
+```
+
+`provider()` 查找改为:`OVERLAYS.read().get(name)` → 命中则用外部条目组装 `OpenAIConfig`(含 profile/headers/body_overrides);未命中走内置 `registry()`。后端 `OpenAIProvider::new(config).language_model(id)` 不变。
+
+### 6.4 绑定层(Node 示例)
+
+```ts
+// 新增:编程式注册(透传到 Rust load_providers_from_json)
+export function registerProviders(configJson: string): Promise<void>
+
+// 或:provider() 工厂接受额外配置文件路径/对象
+// (保持向后兼容:新参数可选)
+```
+
+C ABI:`aimux_register_providers(json: *const c_char) -> *mut c_char`,各 FFI 语言复用。
+
+### 6.5 校验与安全(MVP 必须)
+
+- 加载即校验:`name`/`base_url` 非空;`base_url` 是合法 `http(s)` URL;scheme 白名单;`protocol` 仅 `openai_compat`。
+- `api_key` 解析:`env:VAR` → 读 env,失败报清晰错误;明文 → 警告日志。
+- 校验失败 → 返回 `AiMuxError`,不 panic(与内置 registry 的 `panic` 不同——外部配置是用户输入,不可 panic)。
+
+---
+
+## 7. 实施建议(分阶段)
+
+| 阶段 | 内容 | 风险 | 依赖 |
+|---|---|---|---|
+| **P1** | Rust core:覆盖层 + `register_provider` + `load_providers_from_json` + `provider()` 查找调整 + 校验 + 测试 | 低 | 无 |
+| **P2** | 绑定层透传(Node/C ABI/Python/Go…)+ profile 字段透出 `ProviderConfig` | 低 | P1 |
+| **P3**(可选) | 配置文件加载(`load_providers_from_file`,YAML 支持)+ 文档 | 低 | P1 |
+| **P4**(远期,单独提案) | 原生协议动态注册(plugin/code 扩展机制) | 高 | 需新 RFC |
+
+**建议先做 P1+P2**:覆盖 90% 真实需求(外部 relay/私有网关/新 OpenAI 兼容厂商),成本最低,与现有架构无缝衔接。P3 视用户反馈;P4 暂不做。
+
+---
+
+## 8. 证据索引(关键 file:line)
+
+| 结论 | 证据 |
+|---|---|
+| registry 编译期嵌入、不可变 | [provider.rs:61](../aimux-providers/src/provider.rs#L61) `OnceLock`、[provider.rs:66](../aimux-providers/src/provider.rs#L66) `include_str!` |
+| 251 条、name→数据 查找 | [provider.rs:126](../aimux-providers/src/provider.rs#L126)、[provider.rs:292](../aimux-providers/src/provider.rs#L292) |
+| `provider()` 恒构造 OpenAIProvider | [provider.rs:167](../aimux-providers/src/provider.rs#L167) |
+| `ProviderOptions` 已支持 per-call 覆盖(不含 profile) | [provider.rs:96-110](../aimux-providers/src/provider.rs#L96-L110)、[provider.rs:143-165](../aimux-providers/src/provider.rs#L143-L165) |
+| `Provider` trait object-safe 但从不存 `dyn Provider` | [provider.rs:9-14](../aimux-core/src/provider.rs#L9-L14);`grep "dyn Provider"` 零命中 |
+| `LanguageModel` object-safe、全链路通用货币 | [language_model.rs:25-42](../aimux-core/src/language_model.rs#L25-L42);[lib.rs:31](../bindings/node/src/lib.rs#L31)、[lib.rs:767](../aimux-ffi/src/lib.rs#L767) |
+| profile 的 `&'static str` 已用 `Box::leak` 处理运行时串 | [provider.rs:180-187](../aimux-providers/src/provider.rs#L180-L187) |
+| 绑定层不暴露 profile | [lib.rs:218-236](../bindings/node/src/lib.rs#L218-L236) |
+| RFC-0017 已预留"用户覆盖内置条目"语义 | [0017-provider-config-dx.md:363](../rfc/0017-provider-config-dx.md#L363) |
+| RFC-0017 §2.6 分层:原生协议=代码,OpenAI 兼容=JSON | [0017-provider-config-dx.md:230-242](../rfc/0017-provider-config-dx.md#L230-L242) |
+| 原生协议是独立代码实现 | [lib.rs:15-24](../aimux-providers/src/lib.rs#L15-L24) |
+| aimux 定位=接入层,不做网关路由 | [0019-session-affinity.md:41-44](../rfc/0019-session-affinity.md#L41-L44) |
+| litellm config.yaml model_list 形态 | [docs.litellm.ai/docs/proxy/configs](https://docs.litellm.ai/docs/proxy/configs) |
+| litellm 运行时 DB 增删、不替换 YAML | [docs.litellm.ai/docs/proxy/model_management](https://docs.litellm.ai/docs/proxy/model_management) |
+| cc-switch apiFormat 协议类型字段 | [claudeProviderPresets.ts:49-58](../reference/cc-switch/src/config/claudeProviderPresets.ts#L49-L58) |
+| cc-switch 不实现协议(喂 env var) | [claudeProviderPresets.ts:98-107](../reference/cc-switch/src/config/claudeProviderPresets.ts#L98-L107) |
+
+---
+
+## 9. 剩余不确定性
+
+1. **配置文件格式选型**:JSON(零依赖,与 registry 同构)vs YAML(用户更友好,但加 `serde_yml` 依赖)。建议 MVP 用 JSON,P3 再加 YAML——需用户反馈确认偏好。
+2. **覆盖语义:替换 vs deep-merge**:本报告推荐"整体替换"(简单可预期),但 litellm 用 deep-merge。若用户期望"只改 base_url、其余继承内置条目",需改为 merge——建议先替换,按反馈调整。
+3. **是否需要"卸载/列出已注册外部 provider"的运维 API**:MVP 可不做(进程生命周期内注册即固定),但宿主应用管理界面可能需要——P2 后视需求加。
+4. **`api_key: "env:VAR"` 的引用语法**是否与现有 `load_api_key(None, env_var, ...)`([provider.rs:135](../aimux-providers/src/provider.rs#L135))完全对齐,还是有独立解析路径——实现时需统一,避免两套 env 读取逻辑。
+5. **原生协议动态注册**的真实需求强度:当前无证据表明用户需要"运行时注册全新原生协议 provider"(原生协议稳定且少);若有强需求,需另立 plugin/extension RFC——本报告不预设。

--- a/rfc/0020-external-provider-config.md
+++ b/rfc/0020-external-provider-config.md
@@ -1,0 +1,314 @@
+# RFC-0020: 外部 Provider 配置
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-05
+> **Scope**: `aimux-providers` 新增运行时覆盖层,允许外部(配置文件 / 编程式 API)注册、覆盖 OpenAI 兼容 provider 条目;各 binding 薄透传
+> **Related**: [RFC-0017](0017-provider-config-dx.md) 配置 DX(本 RFC 落地其 §363 预留的"用户覆盖内置条目"语义)、[RFC-0019](0019-session-affinity.md) 会话亲和、[调研报告](../docs/external-provider-config-research.md)
+
+---
+
+## 1. Motivation
+
+aimux 当前有 251 个 OpenAI 兼容 provider 通过 `provider_registry.json` 编译期嵌入(`include_str!` + `OnceLock`),初始化后不可变。新增或修正一个 provider 需要改 JSON + 重新编译发版。
+
+三个真实痛点:
+
+1. **私有 relay / 内网网关无法接入**:企业自建 OpenAI 兼容网关(base_url 指向内网)无法被 `provider("my-relay", ...)` 查到,只能用 `OpenAIProvider::new(OpenAIConfig::new(...))` 逐次手工构造,无"name → 后续复用"机制。
+2. **内置条目修正需等发版**:RFC-0017 阶段 4 修了 7 处 base_url 错误,但仍有 ~20 处存疑(novita/nous_research/longcat 等)待实测——外部覆盖能让用户不等发版自行修正。
+3. **宿主应用集成不友好**:网关 / IDE / agent 宿主想注册其私有 provider,目前必须 fork aimux 改 JSON。
+
+RFC-0017 阶段 4 已预留语义([0017-provider-config-dx.md:363](0017-provider-config-dx.md#L363):"同名条目——用户 JSON 替换/merge 内置条目,仅在'查条目'一步生效")。本 RFC 是该语义的具体落地。
+
+---
+
+## 2. Design Goals
+
+1. **零破坏性**:不动 `provider_registry.json`、不动 `gen_provider_names.py`、不动 `ProviderName` 派生、不动 `provider()` 签名(新参数全 `Option`)。
+2. **后端管线零改动**:外部配置只影响"查条目"一步;查到后 `OpenAIConfig` 构造 + `ProviderOptions` 叠加 + `OpenAIProvider::new(config).language_model(id)` 完全复用。
+3. **8 语言同步受益**:Rust core 一处落地,各 binding 薄透传(RFC-0017 阶段 4 已验证此分发模式)。
+4. **仅 OpenAI 兼容协议**:原生协议(anthropic/google/bedrock…)是代码实现,无法用配置数据描述(RFC-0017 §2.6 分层定论)。
+5. **安全默认**:api_key 优先 env 引用;base_url scheme 校验;外部配置是用户输入,校验失败返回错误不 panic。
+
+---
+
+## 3. Design
+
+### 3.1 运行时覆盖层
+
+在 `aimux-providers/src/provider.rs` 新增覆盖层,`provider()` 查找顺序改为 **覆盖层 → 内置 registry**:
+
+```rust
+use std::sync::RwLock;
+use once_cell::sync::Lazy;
+
+static OVERLAYS: Lazy<RwLock<HashMap<String, ExternalProviderEntry>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+// provider() 查找改为:
+// 1. OVERLAYS.read().get(name) → 命中则用外部条目组装 OpenAIConfig
+// 2. registry().iter().find(|e| e.name == name) → 走内置路径(不变)
+// 3. 未命中 → UnknownProvider
+```
+
+内置 registry 仍是 `include_str!` 编译期嵌入(`OnceLock<Vec<RegistryEntry>>` 不变);覆盖层只承载外部新增/覆盖条目。外部名字不属于编译期 `ProviderName` 枚举,走字符串路径——`provider()` 本就接受 `&str`,无需改签名。
+
+### 3.2 配置条目 schema
+
+```rust
+/// 外部 provider 配置条目。与 RegistryEntry + ProviderOptions 同构,可 Deserialize。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExternalProviderEntry {
+    /// provider 名(用于 provider("name", ...) 查找)。必填。
+    pub name: String,
+    /// 显示名。可选,缺省用 name。
+    pub display: Option<String>,
+    /// API base URL。必填。必须是合法 http(s) URL。
+    pub base_url: String,
+    /// 环境变量名(用于读 api_key)。可选。
+    pub env_var: Option<String>,
+    /// api_key:"env:VAR_NAME" 引用(安全默认)或明文字符串(不推荐)。可选。
+    pub api_key: Option<String>,
+    /// 协议类型。当前仅 "openai_compat"(默认)。其他值报错。
+    #[serde(default = "default_openai_compat")]
+    pub protocol: String,
+    /// provider 能力差异 profile。全可选,缺省 full()。
+    #[serde(default)]
+    pub profile: RegistryProfile,
+    // --- 以下等价于 ProviderOptions 的字段 ---
+    pub headers: Option<HashMap<String, String>>,
+    pub organization: Option<String>,
+    pub project: Option<String>,
+    pub max_retries: Option<u32>,
+    pub body_overrides: Option<serde_json::Value>,
+    /// 用户备注,库忽略。
+    pub comment: Option<String>,
+}
+
+fn default_openai_compat() -> String { "openai_compat".to_string() }
+```
+
+**schema 设计要点**:
+- 复用 `RegistryEntry` 字段(name/display/base_url/env_var/profile)+ `ProviderOptions` 字段(headers/body_overrides/max_retries/organization/project)→ 不发明新概念。
+- `protocol` 字段默认 `openai_compat`;非此值当前报清晰错误(为未来 plugin 扩展预留)。
+- `api_key`:`"env:VAR"` 引用优先(与内置 `env_var` 语义一致);明文技术支持但文档不推荐。
+- `profile`:`RegistryProfile` 已存在([provider.rs:45-55](../aimux-providers/src/provider.rs#L45)),全可选,缺省 `full()`。
+
+### 3.3 JSON 配置文件格式
+
+```json
+{
+  "providers": [
+    {
+      "name": "my-relay",
+      "display": "My Team Relay",
+      "base_url": "https://relay.internal.team/v1",
+      "env_var": "MY_RELAY_API_KEY",
+      "api_key": "env:MY_RELAY_API_KEY",
+      "protocol": "openai_compat",
+      "profile": {
+        "supports_top_k": true,
+        "supports_tools": true,
+        "supports_response_format": true,
+        "stream_usage_key": null,
+        "max_tokens_key": null
+      },
+      "headers": { "X-Team": "platform" },
+      "body_overrides": { "enable_thinking": false },
+      "max_retries": 2
+    },
+    {
+      "name": "groq",
+      "base_url": "https://api.groq.com/openai/v1",
+      "env_var": "GROQ_API_KEY",
+      "comment": "覆盖内置 groq 条目的 base_url"
+    }
+  ]
+}
+```
+
+### 3.4 Rust API
+
+```rust
+// aimux-providers/src/provider.rs 增量
+
+/// 注册一个外部 provider(覆盖同名内置条目,或新增)。
+/// 校验失败返回 AiMuxError,不 panic(区别于内置 registry 的 panic)。
+pub fn register_provider(entry: ExternalProviderEntry) -> Result<(), AiMuxError> {
+    validate_entry(&entry)?;           // name/base_url 非空、scheme 校验、protocol 校验
+    let mut overlays = OVERLAYS.write().unwrap();
+    overlays.insert(entry.name.clone(), entry);
+    Ok(())
+}
+
+/// 从 JSON 字符串加载并注册多个 provider(供 binding 层透传)。
+pub fn load_providers_from_json(json: &str) -> Result<(), AiMuxError> {
+    let config: ProvidersConfig = serde_json::from_str(json)?;
+    for entry in config.providers {
+        register_provider(entry)?;
+    }
+    Ok(())
+}
+
+/// 从配置文件加载并注册。
+pub fn load_providers_from_file(path: &std::path::Path) -> Result<(), AiMuxError> {
+    let content = std::fs::read_to_string(path)?;
+    load_providers_from_json(&content)
+}
+
+#[derive(Deserialize)]
+struct ProvidersConfig {
+    providers: Vec<ExternalProviderEntry>,
+}
+```
+
+### 3.5 覆盖语义
+
+外部条目**整体替换**内置同名条目(非 deep merge,简单可预期)。理由:
+- 简单可预期:用户写什么就是什么,无隐式继承。
+- litellm 用 deep-merge 但其 schema 庞大且 null/空列表特判复杂,aimux 不需要。
+- 若用户只想"改 base_url 其余继承",可从内置 registry 拷贝条目改后注册(文档示例说明)。
+
+`ProviderOptions`(per-call)仍在条目之上覆盖,已有机制不变。
+
+---
+
+## 4. Integration Approach
+
+### 4.1 provider() 查找路径调整
+
+```rust
+pub fn provider(
+    name: &str,
+    api_key: Option<String>,
+    model_id: &str,
+    options: Option<ProviderOptions>,
+) -> Result<Box<dyn LanguageModel>, AiMuxError> {
+    // 1. 覆盖层优先
+    if let Some(entry) = OVERLAYS.read().unwrap().get(name) {
+        return build_from_external_entry(entry, api_key, model_id, options);
+    }
+    // 2. 内置 registry(原逻辑不变)
+    let entry = registry().iter().find(|e| e.name == name)
+        .ok_or_else(|| AiMuxError::UnknownProvider(...))?;
+    build_from_registry_entry(entry, api_key, model_id, options)
+}
+
+fn build_from_external_entry(
+    entry: &ExternalProviderEntry,
+    api_key: Option<String>,
+    model_id: &str,
+    options: Option<ProviderOptions>,
+) -> Result<Box<dyn LanguageModel>, AiMuxError> {
+    // 解析 api_key:"env:VAR" → 读 env;明文 → 直接用;None → 读 entry.env_var
+    let key = resolve_api_key(&api_key, &entry.api_key, &entry.env_var)?;
+    let mut config = OpenAIConfig::new(key)
+        .with_base_url(&entry.base_url)
+        .with_provider(&entry.name)
+        .with_profile(entry.profile.clone());
+    // 叠加 entry 自带的 provider 级配置
+    if let Some(h) = &entry.headers { config = config.with_headers(h.clone()); }
+    if let Some(o) = &entry.organization { config = config.with_org_id(o.clone()); }
+    if let Some(p) = &entry.project { config = config.with_project(p.clone()); }
+    if let Some(r) = entry.max_retries { config = config.with_retry_config(RetryConfig { max_retries: r, ..Default::default() }); }
+    if let Some(b) = &entry.body_overrides { config = config.with_body_overrides(b.clone()); }
+    // 叠加 per-call ProviderOptions(已有逻辑)
+    if let Some(opts) = options { config = apply_provider_options(config, opts); }
+    Ok(OpenAIProvider::new(config).language_model(model_id)?)
+}
+```
+
+### 4.2 绑定层透传
+
+**Node**:
+```ts
+// 新增:编程式注册(透传到 Rust load_providers_from_json)
+export function registerProviders(configJson: string): Promise<void>
+```
+
+**C ABI**:
+```c
+// 新增:注册外部 provider(JSON 字符串)
+const char* aimux_register_providers(const char* config_json);
+```
+
+各 FFI 语言(Go/Java/Kotlin/Swift/Flutter/Python)复用同一 C ABI 入口。Python(pyo3 native)直接调 Rust 函数。
+
+**profile 透出**:各 binding 的 `ProviderConfig` 加可选 `profile` 子对象(Node `ProviderConfig` 当前缺此字段,[lib.rs:218-236](../bindings/node/src/lib.rs#L218))。
+
+### 4.3 校验与安全
+
+加载即校验(校验失败返回 `AiMuxError`,不 panic):
+- `name` / `base_url` 非空
+- `base_url` 是合法 `http(s)` URL(scheme 白名单,防 SSRF)
+- `protocol` 仅 `openai_compat`
+- `api_key` 解析:`env:VAR` → 读 env,失败报清晰错误;明文 → warn 日志
+
+---
+
+## 5. Relationship with Existing RFCs
+
+| RFC | 关系 |
+|-----|------|
+| [RFC-0017](0017-provider-config-dx.md) | **延续**。本 RFC 落地 §363 预留的"用户覆盖内置条目"语义;与 `body_overrides`(per-call + provider 级)正交互补——外部配置条目可自带 `body_overrides`(声明式化),per-call `body_overrides` 仍在其后 merge 覆盖。强化"零内置厂商映射"原则:厂商专属字段声明式写进配置而非散落调用点。 |
+| [RFC-0019](0019-session-affinity.md) | **正交**。会话亲和靠 `CallOptions.headers` 透传;外部配置条目可自带 `headers`(含会话亲和头),是更外层的"provider 身份"配置。 |
+| [RFC-0009](0009-request-resilience.md) | **正交**。外部配置条目的 `max_retries` 透传到 `RetryConfig`,复用已有 retry 机制。 |
+
+---
+
+## 6. Non-Goals
+
+1. **不动态注册原生协议 provider**(anthropic/google/bedrock/vertex/azure/cohere/mistral)。这些是代码实现(各有独立 convert/model/stream 模块),无法用配置数据描述。若未来有强需求,另立 plugin/extension RFC。
+2. **不做动态发现 / 网关路由**。增删 provider 可行(覆盖层可变),但"动态发现"(运行时探测可用 provider)属网关职责,aimux 定位是接入层不做(RFC-0019 §1.4)。
+3. **不做 deep-merge 覆盖语义**。整体替换,简单可预期。
+4. **不做配置热重载 / 文件监听**。MVP 是启动期加载注册,进程生命周期内固定。
+5. **不改 `ProviderName` 枚举**。外部名字走字符串路径,不属于编译期派生。
+
+---
+
+## 7. Scope of Changes
+
+| 位置 | 改动 | 工作量 |
+|------|------|--------|
+| `aimux-providers/src/provider.rs` | 新增 `OVERLAYS` 覆盖层 + `ExternalProviderEntry` + `register_provider` / `load_providers_from_json` / `load_providers_from_file` + `provider()` 查找调整 + 校验 | ~200 行 |
+| `bindings/node/src/lib.rs` | 新增 `registerProviders` 函数 + `ProviderConfig` 加 `profile` 字段 | ~30 行 |
+| `aimux-ffi/src/lib.rs` | 新增 `aimux_register_providers` C ABI | ~20 行 |
+| `bindings/{python,go,java,kotlin,swift,flutter}` | 各自薄透传 `register_providers` | 每语言 ~20 行 |
+| `docs/provider-config-manual.md` | 外部配置章节 + 示例 | 文档 |
+
+**合计:~200-400 行 Rust + 绑定薄改。无新抽象、无 trait 改动、无破坏性变更。**
+
+---
+
+## 8. Risks
+
+| 风险 | 等级 | 对策 |
+|------|------|------|
+| **API key 明文泄露到配置文件** | 高 | schema 支持 `api_key: "env:VAR"` 引用(默认);文档强警示;不把 key 写日志 |
+| **SSRF via base_url**(内网探测) | 中 | `base_url` scheme 校验(默认仅 `http`/`https`);可选 allowlist;文档警示"外部配置 = 信任边界" |
+| **覆盖层与内置条目 merge 语义歧义** | 中 | 明确整体替换(非 deep merge);`ProviderOptions` 仍在条目之上 per-call 覆盖 |
+| **配置解析错误延后到运行时** | 低 | 加载即校验;失败返回 `AiMuxError` 不 panic |
+| **profile 的 `&'static str` 字段** | 低 | `profile_from_registry` 已用 `Box::leak` 处理运行时字符串([provider.rs:180-187](../aimux-providers/src/provider.rs#L180));覆盖层复用同路径 |
+| **并发注册竞争** | 低 | `RwLock` 保护;建议启动期注册,运行期只读查 |
+| **对"零内置厂商映射"原则的冲击** | 低 | 无冲击——profile 是机制数据,厂商映射仍由用户 `body_overrides` 定义 |
+
+---
+
+## 9. Open Questions
+
+1. ~~配置文件格式 JSON vs YAML?~~ **MVP 用 JSON**(零依赖,与 registry 同构)。YAML 需加 `serde_yml` 依赖,视用户反馈在 P3 加。
+2. ~~覆盖语义替换 vs deep-merge?~~ **整体替换**(简单可预期)。若用户反馈需要"只改 base_url 其余继承",再评估 merge。
+3. **是否需要"卸载/列出已注册外部 provider"的运维 API?** MVP 可不做(进程内固定),宿主管理界面需要时再加 `unregister_provider` / `list_external_providers`。
+4. **`api_key: "env:VAR"` 引用语法**是否与现有 `load_api_key(None, env_var, ...)`([provider.rs:135](../aimux-providers/src/provider.rs#L135))完全对齐?实现时需统一,避免两套 env 读取逻辑。
+
+---
+
+## 10. Implementation Order
+
+| 阶段 | 内容 | 依赖 | 状态 |
+|------|------|------|------|
+| **P1** | Rust core:覆盖层 + `register_provider` + `load_providers_from_json` + `provider()` 查找调整 + 校验 + 测试 | 无 | 待实施 |
+| **P2** | 绑定层透传(Node/C ABI/Python/Go/…)+ profile 字段透出 `ProviderConfig` | P1 | 待实施 |
+| **P3**(可选) | 配置文件加载(`load_providers_from_file`)+ 文档 + YAML 支持 | P1 | 待实施 |
+| **P4**(远期,单独提案) | 原生协议动态注册(plugin/code 扩展机制) | 需新 RFC | 不做 |
+
+**建议先做 P1+P2**:覆盖 90% 真实需求(外部 relay/私有网关/新 OpenAI 兼容厂商/修正内置 base_url),成本最低。

--- a/rfc/0021-composite-model-routing.md
+++ b/rfc/0021-composite-model-routing.md
@@ -1,0 +1,348 @@
+# RFC-0021: Composite Model 与 Model 路由
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-05
+> **Scope**: `aimux-core` 新增 composite model 基础设施(实现 `LanguageModel` trait 的组合模型)+ `RouterModel`(规则路由 / fallback / 可插拔策略)+ 内置策略(RuleRouter / LLM 分类器 / 视觉分流)
+> **Related**: [RFC-0022](0022-moa-single-fanout.md) MoA(共用 composite 骨架)、[RFC-0016](0016-align-with-aisdk.md) AISDK 对齐、[RFC-0005](0005-protocol-conversion.md) 定位边界
+
+---
+
+## 1. Motivation
+
+aimux 当前**无任何模型级路由 / fallback / 负载均衡基础设施**(全仓 grep `route|router|fallback|load_balance|shard` 零命中,retry 仅在 HTTP 层单 provider 内)。三个真实需求:
+
+1. **省钱**:多个模型配在一起,按价格/延迟选;简单的走小模型,难的走大模型。RouteLLM 实测可砍 85% 成本保 95% 质量。
+2. **容灾**:一个 provider 挂了自动切下一个,提升可用性。这是 HTTP retry 的自然延伸(跨模型而非跨重试)。
+3. **降本分流**:纯文本别走多模态模型(更贵),含图才走多模态。
+
+这些需求的共同点:**在单次 `generate_text`/`stream_text` 调用内,从多个模型中选一个(或组合)执行,不引入 agent loop / 多步工具循环**。这正是访问层的合理延伸边界——aimux 已有 HTTP 层 jitter backoff retry(RFC-0009),跨模型 fallback 是其同类。
+
+**边界判定**:只要不引入多步循环/状态机/RAG/agent loop,且决策是"单次选模型",就还在访问层边缘内。学习型路由(ML 推理)的"重"不在决策本身,而在其运行时依赖——故不进核心,走可插拔 trait 注入。
+
+---
+
+## 2. Design Goals
+
+1. **对调用方透明**:RouterModel 实现 `LanguageModel` trait,`generate_text`/`stream_text` 入口零改动(只依赖 `&dyn LanguageModel`)。
+2. **自动跨 8 binding**:RouterModel 作为 `LanguageModel`,经现有 FFI/napi 自动可用,wire 层零改动(仅需新增构造函数)。
+3. **可插拔策略**:路由决策走 `Router` trait,内置规则/LLM 分类器/视觉策略,用户可注入自定义(含学习型——自带 ort/candle)。
+4. **零新硬依赖**:规则路由 + LLM 分类器路由不需要任何 ML 库(LLM 分类器复用自身 `LanguageModel` 调小模型);学习型由用户自带。
+5. **不演化成内置 agent loop**:流式 fallback 不做(已发 StreamStart 后无法回滚);只做单次组合。
+
+---
+
+## 3. Design
+
+### 3.1 Composite Model 基础设施(与 RFC-0022 共用)
+
+已验证(独立 crate 编译通过):`Vec<Arc<dyn LanguageModel>>` 持有 + 自身实现 `LanguageModel` 完全可行。
+
+```rust
+// aimux-core/src/composite.rs (新增,与 moa.rs 共用基础)
+
+use std::sync::Arc;
+use async_trait::async_trait;
+use crate::language_model::LanguageModel;
+
+/// composite model 共用的子模型持有形状。
+/// 用 Arc(非 Box):与 FFI/Node 的 Arc<dyn LanguageModel> 形状一致,
+/// 可 clone、可跨 composite 共享、child handle drop 后仍由 Arc 保活。
+pub type ChildModel = Arc<dyn LanguageModel>;
+```
+
+**为什么 Arc 而非 Box**(验证结论):
+- `Box<dyn LanguageModel>` 不可 `Clone`(trait object 无 DynClone);`Arc` 可 clone。
+- FFI registry([aimux-ffi/src/lib.rs:79](../aimux-ffi/src/lib.rs#L79))、Node `Model`([bindings/node/src/lib.rs:31](../bindings/node/src/lib.rs#L31))都用 `Arc<dyn LanguageModel>`——composite 用同形状,子模型可同时被 registry 与 composite 持有。
+- child handle drop 后,子模型仍由 composite 的 Arc 保活,引用计数自动管理。
+
+### 3.2 Router trait(可插拔策略)
+
+```rust
+// aimux-core/src/router.rs (新增)
+
+use crate::error::AiMuxError;
+use crate::language_model_message::LanguageModelPrompt;
+use crate::composite::ChildModel;
+
+/// 路由策略 trait。决策"选哪个子模型",不含执行。
+///
+/// 内置实现:RuleRouter / ComplexityRouter / LlmClassifierRouter / ModalityRouter。
+/// 用户可实现此 trait 注入学习型分类器(如调外部 RouteLLM 服务、用 ort 加载 ONNX)。
+pub trait Router: Send + Sync {
+    /// 根据提示选择子模型索引。
+    /// 返回 Err 表示无法路由(如全部子模型不满足能力要求)。
+    fn route(&self, prompt: &LanguageModelPrompt, models: &[ChildModel]) -> Result<usize, AiMuxError>;
+}
+```
+
+**设计要点**:route 是纯决策(看 prompt + models 元信息),不含执行——执行由 RouterModel 做。这让策略可独立测试、可组合(如"先按能力过滤,再按成本排序")。
+
+### 3.3 RouterModel
+
+```rust
+/// 路由模型:实现 LanguageModel,内部按策略选一个子模型执行 + 可选 fallback。
+pub struct RouterModel {
+    models: Vec<ChildModel>,
+    router: Box<dyn Router>,
+    fallback: FallbackPolicy,
+    config: RouterConfig,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum FallbackPolicy {
+    /// 执行失败时按序尝试其余模型(默认)。
+    #[default]
+    OnError,
+    /// 不 fallback,选中的模型失败即失败。
+    None,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RouterConfig {
+    pub provider_name: String,   // 默认 "router"
+    pub model_id: String,        // 默认 "router"
+}
+
+#[async_trait]
+impl LanguageModel for RouterModel {
+    fn provider(&self) -> &str { &self.config.provider_name }
+    fn model_id(&self) -> &str { &self.config.model_id }
+
+    async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
+        let idx = self.router.route(&options.prompt, &self.models)?;
+        match self.models[idx].do_generate(options).await {
+            Ok(r) => Ok(r),
+            Err(e) if self.fallback == FallbackPolicy::OnError => {
+                // 按序尝试其余模型
+                self.fallback_generate(idx, options).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
+        let idx = self.router.route(&options.prompt, &self.models)?;
+        // 流式:路由在前,委托在后。流中不 fallback(已发 StreamStart 无法回滚)。
+        self.models[idx].do_stream(options).await
+    }
+}
+
+impl RouterModel {
+    /// fallback:按序尝试 idx 之外的所有模型。
+    async fn fallback_generate(&self, exclude: usize, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
+        let mut last_err = None;
+        for (i, m) in self.models.iter().enumerate() {
+            if i == exclude { continue; }
+            match m.do_generate(options).await {
+                Ok(r) => return Ok(r),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| AiMuxError::Other("router: all models failed".into())))
+    }
+}
+```
+
+**流式 fallback 不做的理由**:流式 `do_stream` 返回后已向用户吐 `StreamStart`,此时若上游断了,重试会重复吐 token。Hermes/LiteLLM 同此策略(路由在前,委托后,流中不 fallback)。
+
+### 3.4 内置策略
+
+#### 3.4.1 RuleRouter(规则路由 + 静态优先级)
+
+```rust
+/// 静态优先级路由:总是选第 0 个模型,fallback 时按序往下。
+/// 最简形态,等价于"主模型 + 备用"。
+pub struct RuleRouter;
+
+impl Router for RuleRouter {
+    fn route(&self, _prompt: &LanguageModelPrompt, _models: &[ChildModel]) -> Result<usize, AiMuxError> {
+        Ok(0)
+    }
+}
+```
+
+更复杂的规则路由(按 cost/latency 排序)由 `WeightedRouter` 表达:
+
+```rust
+/// 按 weight 排序选模型(weight 可编码 cost/latency/优先级)。
+pub struct WeightedRouter { weights: Vec<f64> }
+impl Router for WeightedRouter {
+    fn route(&self, _prompt: &LanguageModelPrompt, models: &[ChildModel]) -> Result<usize, AiMuxError> {
+        // 选 weight 最高(或最低,看语义)的
+        self.weights.iter().enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .map(|(i, _)| i)
+            .ok_or_else(|| AiMuxError::Other("router: no models".into()))
+    }
+}
+```
+
+#### 3.4.2 ComplexityRouter(LLM 分类器路由)
+
+复用 aimux 自身 `LanguageModel` 调小模型判断难度——**零外部依赖**,这是 aimux 统一 290+ provider 后的独有甜区。
+
+```rust
+/// LLM 分类器路由:调一个小模型判断 prompt 复杂度,分到 SIMPLE/COMPLEX tier。
+pub struct LlmClassifierRouter {
+    classifier: ChildModel,      // 小模型(如 gpt-4o-mini / haiku)
+    /// tier → models 索引映射。如 SIMPLE→0(小模型),COMPLEX→1(大模型)。
+    tier_mapping: HashMap<ComplexityTier, usize>,
+    /// 分类 prompt(可定制)。
+    classify_prompt: String,
+}
+
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum ComplexityTier { Simple, Medium, Complex, Reasoning }
+
+impl Router for LlmClassifierRouter {
+    fn route(&self, prompt: &LanguageModelPrompt, _models: &[ChildModel]) -> Result<usize, AiMuxError> {
+        // 1. 用 classifier 调小模型,结构化输出判断 tier
+        let tier = self.classify(prompt)?;
+        // 2. 查映射选模型
+        self.tier_mapping.get(&tier).copied()
+            .ok_or_else(|| AiMuxError::Other(format!("router: no model for tier {tier:?}")))
+    }
+}
+```
+
+**延迟开销**:~100-500ms(一次小模型 inference)。成本远低于"什么都走大模型"。LiteLLM Auto Routing 同此模式(其 `classifier_type: llm`)。
+
+**fallback**:分类器自身失败时,降级到规则路由(选第一个 / 默认大模型)。这在 `LlmClassifierRouter` 内部处理,不依赖 RouterModel 的 fallback。
+
+#### 3.4.3 ModalityRouter(视觉/文本分流)
+
+这是"视觉路由"的正确形态——**不独立做,作为通用 Router 的一个策略谓词**(~50 行)。
+
+```rust
+/// 模态分流:prompt 含图像 → 多模态模型索引;纯文本 → 文本模型索引。
+pub struct ModalityRouter {
+    vision_model_idx: usize,   // 支持图像输入的模型
+    text_model_idx: usize,     // 纯文本模型(更便宜)
+}
+
+impl Router for ModalityRouter {
+    fn route(&self, prompt: &LanguageModelPrompt, _models: &[ChildModel]) -> Result<usize, AiMuxError> {
+        // 扫 content parts 有无 Image
+        let has_image = prompt.iter().flat_map(|m| m.content.iter())
+            .any(|part| matches!(part, ContentPart::Image { .. }));
+        Ok(if has_image { self.vision_model_idx } else { self.text_model_idx })
+    }
+}
+```
+
+**为什么视觉路由不独立做**(调研结论):
+- 视觉输入管道已完备(`ContentPart::Image` 三大协议都支持转换),路由要解决的是"选哪个模型"。
+- "按内容含不含图分流"是通用路由的一个 ~50 行策略谓词,单独立项必然被通用路由吞掉。
+- "智能选最优视觉模型"(场景 B)本质就是智能路由,视觉只是能力维度之一,归 LLM 分类器/能力声明统一处理。
+
+### 3.5 可插拔学习型路由(不进核心)
+
+学习型路由(RouteLLM 风格 ML 分类器)**不内置**,但通过 `Router` trait 注入:
+
+```rust
+// 用户侧示例(不进 aimux)
+struct RoutellmRouter { /* ort::Session 加载 ONNX 模型 */ }
+impl Router for RoutellmRouter {
+    fn route(&self, prompt: &LanguageModelPrompt, _models: &[ChildModel]) -> Result<usize, AiMuxError> {
+        // 1. prompt → embedding
+        // 2. ONNX 推理 → strong/weak 分数
+        // 3. 分数 > threshold → 大模型,否则小模型
+    }
+}
+```
+
+理由:学习型需训练数据 + 模型权重 + 推理运行时(`ort`/`candle`/`burn`),引入 ~数十 MB 依赖,与 release profile(`opt-level="z"` + `strip` + `lto`,[Cargo.toml:25-30](../Cargo.toml#L25))最小二进制定位冲突。RouteLLM 泛化性好,直接复用其 Python 服务更优。aimux 只提供 trait 接口。
+
+---
+
+## 4. Integration Approach
+
+### 4.1 FFI / binding 透明性(已验证)
+
+- **C ABI**:`aimux_generate_text(handle, ...)` 只做 `get_model(handle) → Arc<dyn LanguageModel>` → `generate_text(&*model, ...)`,只依赖 trait。RouterModel 注册 handle 后直接可用,wire 层零改动。
+- **Node**:`Model { inner: Arc<dyn LanguageModel> }`,`generateText`/`streamText` 只依赖 trait,零改动。
+- **新增构造函数**(纯新增符号,不改现有 FFI):
+  - C ABI:`aimux_router_new(handles: *const u64, len: usize, config_json: *const c_char) -> *mut c_char`——内部对每个 child handle 调 `get_model`,组装 `RouterModel`,再 `intern_model`。
+  - Node:`router(models: Array<&Model>, opts) -> Model` napi factory。
+
+### 4.2 generate_text / stream_text 入口零改动
+
+[generate.rs:178](../aimux-core/src/generate.rs#L178) `generate_text(model: &dyn LanguageModel, ...)` 只接受 `&dyn LanguageModel`,RouterModel 传入即可工作。`provider()`/`model_id()` 返回 `"router"` 让现有 tracing span 正常打点。
+
+### 4.3 子模型共享
+
+同一子模型可被多个 RouterModel 持有(用 `Arc` clone),也可同时被 registry 与 composite 持有。child handle drop 后,子模型仍由 composite 的 Arc 保活。
+
+---
+
+## 5. Relationship with Existing RFCs
+
+| RFC | 关系 |
+|-----|------|
+| [RFC-0022](0022-moa-single-fanout.md) | **共用 composite 骨架**。RouterModel 选 1 个,MoaModel 全调+聚合。两者都是 composite model 实现 trait,可共用 `ChildModel = Arc<dyn LanguageModel>`。 |
+| [RFC-0016](0016-align-with-aisdk.md) | **正交**。路由是访问层组合,AISDK 对齐是单 provider 能力补齐。H4 多步工具循环明确不做,与路由的单次组合定位一致。 |
+| [RFC-0005](0005-protocol-conversion.md) | **边界确认**。RFC-0005 结论"不做跨协议转换(网关的活)"。路由是"跨模型选一个(SDK 的活)",不碰协议转换。 |
+| [RFC-0009](0009-request-resilience.md) | **同类延伸**。HTTP retry 是单 provider 内重试,RouterModel fallback 是跨模型容灾,同一职责层。 |
+
+---
+
+## 6. Non-Goals
+
+1. **不内置学习型路由**(RouteLLM 风格 ML 分类器)。需训练 + 推理运行时,与最小二进制定位冲突。走 `Router` trait 注入,用户自带 `ort`/`candle`。
+2. **不做流中 fallback**。流式 `do_stream` 返回后已吐 `StreamStart`,重试会重复 token。路由在前,委托后,流中不 fallback(Hermes/LiteLLM 同策略)。
+3. **不做多步工具循环 / agent loop**(H4,RFC-0016 §7.5 明确不做)。RouterModel/MoaModel 都是单次 `generate_text`/`stream_text` 内完成。
+4. **不做能力声明系统**(provider 声明 supports_vision/tools/reasoning)。薄版路由靠用户配置"哪个模型支持什么";能力数据工程(从 litellm `supports_vision` 补全 inventory)是后续独立工作,不在本 RFC。
+5. **不做负载均衡 / 多 key 池 / 限流**。那是网关职责(RFC-0005 边界)。RouterModel 的 fallback 是容灾,不是负载均衡。
+
+---
+
+## 7. Scope of Changes
+
+| 位置 | 改动 | 工作量 |
+|------|------|--------|
+| `aimux-core/src/composite.rs` | 新增:`ChildModel` 类型别名 + 共用辅助(usage 累加等) | ~50 行 |
+| `aimux-core/src/router.rs` | 新增:`Router` trait + `RouterModel` + `FallbackPolicy` + `RouterConfig` | ~200 行 |
+| `aimux-core/src/router_strategies.rs` | 新增:`RuleRouter` / `WeightedRouter` / `LlmClassifierRouter` / `ModalityRouter` | ~300 行 |
+| `aimux-core/src/lib.rs` | `pub mod composite; pub mod router; pub mod router_strategies;` + prelude | ~10 行 |
+| `aimux-core/Cargo.toml` | `async-stream`(workspace 已有,与 RFC-0022 共用) | 1 行 |
+| `aimux-ffi/src/lib.rs` | 新增 `aimux_router_new` C ABI | ~30 行 |
+| `bindings/node/src/lib.rs` | 新增 `router(models, opts)` napi factory | ~30 行 |
+| `bindings/{python,go,...}` | 薄透传 | 每语言 ~25 行 |
+| 测试 | 每个策略单测 + RouterModel fallback 测 + object-safety 测 | ~250 行 |
+
+**合计:~600-800 行。无 trait 改动、无破坏性变更、入口零改动。**
+
+---
+
+## 8. Risks
+
+| 风险 | 等级 | 对策 |
+|------|------|------|
+| **LLM 分类器路由增加延迟**(100-500ms) | 中 | 默认关闭,用户显式选 `LlmClassifierRouter`;分类器失败降级规则路由;文档标注延迟开销 |
+| **流式无 fallback 用户体验** | 低 | 文档明确"流式仅路由不 fallback";非流式有完整 fallback |
+| **学习型路由用户误以为内置** | 低 | 文档明确"不内置,走 trait 注入";给 `RoutellmRouter` 示例代码 |
+| **provider()/model_id() 返回 "router" 丢失下游信息** | 低 | 在 `provider_metadata` 补 `selected_provider`/`selected_model`;tracing span 可读 |
+| **fallback 顺序与用户预期不符** | 低 | `RouterConfig` 可配 fallback 顺序;默认按 models 数组序 |
+
+---
+
+## 9. Open Questions
+
+1. **`provider()`/`model_id()` 返回值**:返回固定 `"router"` 还是透传被选模型?返回固定值让 tracing span 统一,但丢失下游信息。建议返回 `"router"`,`provider_metadata` 补被选模型信息。
+2. **LLM 分类器的成本归属**:分类调用消耗 token,需在 `Usage` 明确归属。建议归到 RouterModel 的总 usage(已含分类器调用)。
+3. **能力声明系统是否前置**:薄版路由靠用户配置;若要做"自动按能力过滤",需补能力数据工程(从 litellm `supports_vision` 补全)。本 RFC 不做,留后续。
+4. **fallback 与 retry 的交互**:RouterModel fallback 时,每个子模型的 `max_retries` 仍生效(单 provider 内 retry 先跑完,再 fallback 下一个)。需文档明确语义。
+
+---
+
+## 10. Implementation Order
+
+| 阶段 | 内容 | 依赖 | 状态 |
+|------|------|------|------|
+| **P1** | composite 骨架(`composite.rs`)+ `Router` trait + `RouterModel` + `RuleRouter`/`WeightedRouter` + 单测 | 无 | 待实施 |
+| **P2** | `ModalityRouter`(视觉分流策略)+ `LlmClassifierRouter` + 单测 | P1 | 待实施 |
+| **P3** | FFI(`aimux_router_new`)+ Node(`router` factory)+ 其他 binding 透传 | P1 | 待实施 |
+| **P4**(可选) | 能力声明数据工程(从 litellm 补全)+ 基于能力的自动路由 | 独立 | 待评估 |
+| **P5**(不进核心) | `RoutellmRouter` 示例(文档/示例仓库,用 ort 加载 ONNX) | P1 | 文档示例 |
+
+**建议先做 P1**:骨架 + 规则路由 + fallback 立即可用(容灾 + 成本优化)。P2 加策略。P3 同步 binding。

--- a/rfc/0022-moa-single-fanout.md
+++ b/rfc/0022-moa-single-fanout.md
@@ -1,0 +1,332 @@
+# RFC-0022: MoA 单次扇出聚合
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-05
+> **Scope**: `aimux-core` 新增 `MoaModel`——实现 `LanguageModel` trait 的 Mixture-of-Agents 单次扇出聚合模型(reference models 并行跑 → 输出拼进 aggregator prompt → aggregator 跑 → 返回),不含 agent loop
+> **Related**: [RFC-0021](0021-composite-model-routing.md) Composite Model 骨架(共用)、[RFC-0016](0016-align-with-aisdk.md) H4 边界(不做多步循环)
+
+---
+
+## 1. Motivation
+
+**MoA(Mixture-of-Agents)是提质手段,与路由(省钱)正交。** Hermes MoA 实测:Opus aggregator + GPT-5.5 reference 比单独跑 Opus 高 6 分(HermesBench 0.8202 vs 0.7607)。机制是多个模型并行给分析,aggregator 聚合出最终答案——适合难题(架构、安全审查、难 bug),用模型协作弥补单模型盲区。
+
+**为什么 aimux 做薄版(单次扇出)而非完整版**:
+- Hermes MoA 之所以强,正因为它嵌在 agent loop 里每轮重跑(reference 在每次工具迭代后重新分析)。这个"嵌在 loop 里"是 agent 框架的活,aimux 明确不做(RFC-0005 + H4 多步工具循环已排除)。
+- aimux 能做的原子能力:**单次 `generate_text`/`stream_text` 内,reference 并行扇出 + aggregator 聚合,不含 loop**。上层 agent 框架拿这个原子能力去 loop(把 MoaModel 当一个模型塞进它的循环)。
+- 这与 RouterModel(RFC-0021)是兄弟——都是 composite model 实现 `LanguageModel` trait,只是一个"选 1 个"、一个"全调+聚合",可共用 `ChildModel = Arc<dyn LanguageModel>` 骨架。
+
+**与路由的区别**:路由是"选一个模型"(降本);MoA 是"全调一遍+聚合"(提质,但更贵更慢)。两者独立,可组合(如用 RouterModel 选 reference 池,再 MoaModel 聚合)。
+
+---
+
+## 2. Design Goals
+
+1. **单次调用内完成**:`do_generate`/`do_stream` 内扇出+聚合,不含 agent loop / 多步工具循环。
+2. **对调用方透明**:MoaModel 实现 `LanguageModel`,`generate_text`/`stream_text` 入口零改动。
+3. **自动跨 8 binding**:作为 `LanguageModel`,经现有 FFI/napi 自动可用(wire 层零改动,仅需新增构造函数)。
+4. **复用 aimux 自身能力**:reference 并行调 `do_generate` 用 `futures::join_all`(aimux-core 已依赖 `futures`),**不引入 tokio/ML 库**。
+5. **错误容忍**:默认 BestEffort(单 reference 失败丢弃+告警,其余继续),可配 FailFast。
+6. **usage 正确累加**:reference + aggregator 的 token usage 全部累加,不丢计费信息。
+
+---
+
+## 3. Design
+
+### 3.1 MoaModel 结构
+
+```rust
+// aimux-core/src/moa.rs (新增)
+
+use std::sync::Arc;
+use async_trait::async_trait;
+use futures::future::join_all;
+use crate::composite::ChildModel;  // = Arc<dyn LanguageModel>,与 RFC-0021 共用
+
+/// Mixture-of-Agents 单次扇出聚合模型。
+///
+/// reference models 并行跑(非流式)→ 输出拼进 aggregator prompt → aggregator 跑 → 返回。
+/// 单次 generate_text/stream_text 内完成,不含 agent loop。
+pub struct MoaModel {
+    references: Vec<ChildModel>,
+    aggregator: ChildModel,
+    config: MoaConfig,
+}
+
+/// reference 失败策略。
+#[derive(Debug, Clone, Copy, Default)]
+pub enum MoaFailMode {
+    /// 尽力而为:某个 reference 失败则丢弃 + 发 Warning,其余继续。(默认)
+    #[default]
+    BestEffort,
+    /// 任一 reference 失败立即整体失败。
+    FailFast,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MoaConfig {
+    pub provider_name: String,            // 默认 "moa"
+    pub model_id: String,                 // 默认 "moa"
+    /// aggregator 独立 system 指令(拼在原 prompt 前)。None 用默认聚合指令。
+    pub aggregator_instructions: Option<String>,
+    /// reference 是否去掉 tools/tool_choice(Hermes:reference 不带 tool schema 保便宜)。默认 true。
+    pub strip_reference_tools: bool,
+    pub fail_mode: MoaFailMode,
+}
+```
+
+**为什么用 `ChildModel = Arc<dyn LanguageModel>`**(与 RFC-0021 一致,验证结论):
+- `Arc` 可 clone,与 FFI/Node 形状一致;child handle drop 后子模型仍由 Arc 保活。
+- `Box<dyn LanguageModel>` 不可 Clone,不适合 composite 共享。
+
+### 3.2 Prompt 拼接格式(方案 A)
+
+reference 输出拼成一条新 `Role::User` 消息,append 到 aggregator 的 prompt 末尾(等价 Hermes 的 "private context injection")。
+
+```
+[原始 prompt messages ...(原样)]
++ Role::User 消息:
+    {aggregation_instruction}
+
+    # Reference model responses
+
+    ## {model_id_1}
+    {a₁}
+
+    ## {model_id_2}
+    {a₂}
+    ...
+```
+
+**为什么不用 `provider_options`**(方案 B 否决):`provider_options` 是给单个 provider 的 opaque 桶(`HashMap<String, Value>`,key 是 provider 名),无法表达"多模型输出"这种结构化语义,aggregator provider 也不会去读它。
+
+**reference 输出只取文本**:`extract_text` 从 `GenerateContent::Text` 提取,丢弃 `Reasoning`/`ToolCall`/`Source`(薄版)。若未来要保留 reference 的 reasoning,可另开配置,但 aggregator 会把它当历史 reasoning,语义有歧义,薄版不建议。
+
+### 3.3 do_generate 流程
+
+```rust
+#[async_trait]
+impl LanguageModel for MoaModel {
+    fn provider(&self) -> &str { &self.config.provider_name }
+    fn model_id(&self) -> &str { &self.config.model_id }
+
+    async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
+        // 1. 扇出 reference(并行,非流式)。join_all 等待全部完成(不短路)。
+        let results = if self.references.is_empty() {
+            Vec::new()
+        } else {
+            let ref_opts = self.reference_options(options);  // clone + 去掉 tools
+            join_all(self.references.iter().map(|m| m.do_generate(&ref_opts))).await
+        };
+
+        // 2. 收集成功输出 + 累加 reference usage + 收集失败 warning。
+        let mut ref_usage = Usage::default();
+        let mut warnings = Vec::new();
+        let mut texts: Vec<(String, String)> = Vec::new();  // (model_id, text)
+        for (i, r) in results.into_iter().enumerate() {
+            match r {
+                Ok(res) => {
+                    ref_usage = add_usage(ref_usage, &res.usage);
+                    let mid = res.response.model_id.clone().unwrap_or_else(|| format!("ref-{i}"));
+                    texts.push((mid, extract_text(&res.content)));
+                }
+                Err(e) => {
+                    if matches!(self.config.fail_mode, MoaFailMode::FailFast) { return Err(e); }
+                    warnings.push(Warning::Other { message: format!("moa reference {i} failed: {e}") });
+                }
+            }
+        }
+        // 全部失败(且配置了 reference)→ 无法聚合。
+        if !self.references.is_empty() && texts.is_empty() {
+            return Err(AiMuxError::Other("moa: all reference models failed".into()));
+        }
+
+        // 3. 拼 aggregator prompt + aggregator CallOptions。
+        let agg_prompt = build_aggregator_prompt(&options.prompt, self.config.aggregator_instructions.as_deref(), &texts);
+        let mut agg_opts = options.clone();
+        agg_opts.prompt = agg_prompt;
+
+        // 4. 调 aggregator。
+        let mut agg = self.aggregator.do_generate(&agg_opts).await?;
+
+        // 5. 合并:usage 加上 reference 部分;warnings 追加 reference 失败告警。
+        agg.usage = add_usage(agg.usage, &ref_usage);
+        agg.warnings.extend(warnings);
+        Ok(agg)
+    }
+    // do_stream 见 §3.4
+}
+```
+
+**并行执行要点**(已验证):
+- `join_all`(非 `try_join_all`)——后者遇首个 Err 短路,而 BestEffort 需"等全部完成再分区成败"。
+- 所有 reference 共享同一个 `&ref_opts`(`do_generate` 只读借用)。
+- `AbortSignal` 是 `Clone` 且共享同一 `CancellationToken`——`options.clone()` clone 出共享信号,abort 一次取消所有 reference + aggregator。
+
+### 3.4 do_stream 策略
+
+**reference 全部非流式跑完(`do_generate`),再流式调 aggregator,aggregator 流透传给用户。**
+
+理由:
+- reference 是辅助上下文,没必要把它们的 token 流给用户(用户只关心最终聚合结果)。
+- 若 reference 也流式,首 token 延迟 = max(reference 流式) + aggregator,且要先把所有 reference 流收齐才能开始 aggregator,实现复杂、收益为零。
+
+```rust
+async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
+    // 1. reference 非流式扇出(同 do_generate 前半段)。
+    let (texts, ref_usage, drop_warnings) = self.run_references_nonstream(options).await?;
+    //    (全失败则 return Err,同 do_generate)
+
+    // 2. aggregator prompt + options。
+    let agg_prompt = build_aggregator_prompt(&options.prompt, self.config.aggregator_instructions.as_deref(), &texts);
+    let mut agg_opts = options.clone();
+    agg_opts.prompt = agg_prompt;
+
+    // 3. aggregator 流式(先 await 拿到 StreamResult)。
+    let agg = self.aggregator.do_stream(&agg_opts).await?;
+    let mut agg_stream = agg.stream;
+
+    // 4. 包装:发自己的 StreamStart(带 reference 失败告警),转发其余,
+    //    吞 aggregator 的 StreamStart(已发过),Finish 时把 reference usage 累加。
+    let stream = async_stream::stream! {
+        yield Ok(StreamPart::StreamStart { warnings: drop_warnings });
+        while let Some(part) = agg_stream.next().await {
+            match part {
+                Ok(StreamPart::StreamStart { .. }) => { /* 吞掉 */ }
+                Ok(StreamPart::Finish { finish_reason, usage, provider_metadata }) => {
+                    yield Ok(StreamPart::Finish {
+                        finish_reason,
+                        usage: add_usage(usage, &ref_usage),
+                        provider_metadata,
+                    });
+                }
+                Ok(other) => yield Ok(other),
+                Err(e) => yield Err(e),
+            }
+        }
+    };
+
+    Ok(StreamResult { stream: Box::pin(stream), request_body: None, response_headers: None })
+}
+```
+
+**do_stream 阻塞语义**:`do_stream` 内先 await reference 扇出再返回 stream,意味着 `stream_text(model, ..).await?` 在拿 stream 句柄前要等 reference 全跑完。这是 MoA 固有延迟,可接受。若想"调用立即返回、首 poll 时才扇出",可把扇出挪进 `async_stream` 体内(发 StreamStart 后),代价是 reference 全失败的错误只能以 `StreamPart::Error` 出现在流里而非 `do_stream` 返回 `Err`。**建议保持当前草案**(返回 `Err` 更清晰)。
+
+### 3.5 与 CallOptions 的关系
+
+| 字段 | reference | aggregator | 依据 |
+|---|---|---|---|
+| `prompt` | 原样 | 原 prompt + reference 上下文 | §3.2 |
+| `tools` / `tool_choice` | **去掉**(`tools=None`, `tool_choice=Auto`) | 原样继承 | Hermes:reference 不带 tool schema 保便宜;aggregator 才产出最终 tool call |
+| `temperature`/`max_output_tokens`/`top_p`/… | 原样继承 | 原样继承 | 薄版不做 per-reference 调参 |
+| `abort_signal` | 继承(共享同一 token) | 继承 | abort 一次全取消 |
+| `headers`/`provider_options`/`body_overrides`/`max_retries`/`timeout` | 原样继承 | 原样继承 | 透传底层 provider |
+
+`strip_reference_tools` 默认 true(可关)。某些 MoA 变体想让 reference 也规划 tool call 再由 aggregator 汇总,但已超出薄版范围。
+
+### 3.6 错误处理
+
+| 场景 | 策略 |
+|---|---|
+| 单个 reference 失败 | BestEffort(默认):丢弃 + `Warning::Other`;FailFast:直接 `return Err` |
+| 部分 reference 失败 | 同上,继续用成功的输出聚合 |
+| 全部 reference 失败 | `AiMuxError::Other("moa: all reference models failed")` |
+| aggregator 失败 | 透传其 `Err` |
+| reference 配置为空(0 个) | 跳过扇出,aggregator 用原 prompt 跑(退化为单模型,不报错) |
+
+默认 BestEffort——MoA 的价值在于"多路冗余",单点失败不应击穿。
+
+### 3.7 usage 累加
+
+`Usage`/`TokenUsage`([types.rs:31-62](../aimux-core/src/types.rs#L31))各含 `total/no_cache/cache_read/cache_write/text/reasoning`,逐项 `Option` 相加。`Usage.raw`(provider 专属 opaque)跨 provider 累加无意义,丢弃。若要保留各 reference 的原始 usage,可塞进 `provider_metadata` 的 `moa` key(待 Open Question 定)。
+
+---
+
+## 4. Integration Approach
+
+### 4.1 FFI / binding 透明性(与 RFC-0021 同,已验证)
+
+- **C ABI**:`aimux_generate_text(handle, ...)` 只依赖 trait,MoaModel 注册 handle 后直接可用,wire 层零改动。
+- **Node**:`Model { inner: Arc<dyn LanguageModel> }`,`generateText`/`streamText` 零改动。
+- **新增构造函数**(纯新增):
+  - C ABI:`aimux_moa_new(reference_handles: *const u64, ref_len: usize, aggregator_handle: u64, config_json: *const c_char) -> *mut c_char`。
+  - Node:`moa(references: Array<&Model>, aggregator: &Model, opts?) -> Model` napi factory。
+
+### 4.2 落点
+
+- **模块**:`aimux-core/src/moa.rs`。纯 `LanguageModel` trait 组合,无 HTTP/provider 专属代码,与 trait 同属 core 最自然。
+- **依赖**:`aimux-core/Cargo.toml` 加 `async-stream = { workspace = true }`(workspace 已有,与 RFC-0021 共用)。**不需要 tokio**——`join_all` 来自 `futures`,async future 由调用方运行时驱动。
+- **prelude**:`lib.rs` 加 `pub mod moa;` + re-export `MoaModel`/`MoaConfig`/`MoaFailMode`。
+
+---
+
+## 5. Relationship with Existing RFCs
+
+| RFC | 关系 |
+|-----|------|
+| [RFC-0021](0021-composite-model-routing.md) | **共用 composite 骨架**(`ChildModel = Arc<dyn LanguageModel>`)。RouterModel 选 1 个,MoaModel 全调+聚合。两者可组合:RouterModel 选 reference 池 → MoaModel 聚合。 |
+| [RFC-0016](0016-align-with-aisdk.md) | **边界确认**。H4 多步工具循环明确不做;MoaModel 是单次组合,不含 loop。Hermes MoA 的"嵌在 loop 里每轮重跑"是上层 agent 框架的活,aimux 只提供原子能力。 |
+| [RFC-0005](0005-protocol-conversion.md) | **正交**。MoA 不碰协议转换,各 reference/aggregator 走各自 provider 协议。 |
+
+---
+
+## 6. Non-Goals
+
+1. **不含 agent loop / 多步工具循环**(H4,RFC-0016 §7.5)。MoaModel 是单次 `generate_text`/`stream_text` 内完成。上层 agent 框架把 MoaModel 当一个模型塞进它的循环去实现"每轮重跑"。
+2. **不做多轮聚合(多 layer)**。本方案是单层(reference→aggregator)。Hermes 原版支持多轮(layer N 输出喂 layer N+1)。薄版不做;若要,可把 MoaModel 自身作为 reference 嵌套进外层 MoaModel(天然支持,因 `MoaModel: LanguageModel`),但 usage/warning 累加会嵌套,需测。
+3. **不做 fanout per_iteration**(Hermes 的"每次工具迭代重跑 advisor")。那是 agent loop 内的语义,aimux 不做 loop。
+4. **不内置 reference 的 reasoning 透传**。薄版只取 reference 的文本输出。保留 reasoning 另开配置。
+5. **不做 reference 自适应选择**(按 query 难度选 reference 池)。那是路由(RFC-0021)的活,与 MoA 正交,可组合。
+
+---
+
+## 7. Scope of Changes
+
+| 位置 | 改动 | 工作量 |
+|------|------|--------|
+| `aimux-core/src/moa.rs` | 新增:`MoaModel` + `MoaConfig` + `MoaFailMode` + `build_aggregator_prompt` + `extract_text` + `add_usage` + impl `LanguageModel` | ~300 行 |
+| `aimux-core/src/composite.rs` | 新增:`ChildModel` + `add_usage`(与 RFC-0021 共用) | ~50 行(RFC-0021 已计) |
+| `aimux-core/src/lib.rs` | `pub mod moa;` + prelude | ~5 行 |
+| `aimux-core/Cargo.toml` | `async-stream`(与 RFC-0021 共用) | 1 行 |
+| `aimux-ffi/src/lib.rs` | 新增 `aimux_moa_new` C ABI | ~30 行 |
+| `bindings/node/src/lib.rs` | 新增 `moa(references, aggregator, opts?)` napi factory | ~30 行 |
+| `bindings/{python,go,...}` | 薄透传 | 每语言 ~25 行 |
+| 测试 | 扇出正确性 + BestEffort/FailFast + usage 累加 + stream 包装 + object-safety | ~200 行 |
+
+**合计:~350-450 行(含与 RFC-0021 共用的 composite.rs)。无 trait 改动、无破坏性变更、入口零改动。**
+
+---
+
+## 8. Risks
+
+| 风险 | 等级 | 对策 |
+|------|------|------|
+| **延迟倍增**(reference 串行等待) | 中 | reference 并行(`join_all`),延迟 = max(reference) + aggregator,非累加;文档标注 MoA 固有延迟 |
+| **成本倍增**(N 个 reference 各消耗 token) | 中 | 默认关闭,用户显式构造 MoaModel;文档建议仅难题用;`strip_reference_tools` 保 reference 便宜 |
+| **`provider()`/`model_id()` 返回 "moa" 丢失下游** | 低 | `provider_metadata` 补 `aggregator_provider`/`aggregator_model` + 各 `reference_*` |
+| **do_stream 阻塞至 reference 完成** | 低 | MoA 固有延迟,文档明确;可接受(难题场景不在意首 token 延迟) |
+| **usage 累加口径** | 低 | reference + aggregator 逐项相加;`raw` 丢弃(跨 provider 无意义);可选塞 `provider_metadata` |
+| **aggregator prompt 膨胀**(N 个 reference 输出) | 低 | 文档建议 reference 用 `max_output_tokens` 限制(Hermes `reference_max_tokens`);薄版不做内置 cap |
+
+---
+
+## 9. Open Questions
+
+1. **`provider()`/`model_id()` 返回值**:返回固定 `"moa"` 还是透传 aggregator?建议返回 `"moa"`,`provider_metadata` 补 aggregator + reference 信息(tracing span 可读)。
+2. **reference 输出是否带 reasoning**:薄版只取 `Text`,丢弃 `Reasoning`。若 aggregator 想看 reference 思考链,需另开配置。默认丢弃。
+3. **多轮聚合(多 layer)**:薄版单层。若要,可嵌套 MoaModel(天然支持),但 usage/warning 累加嵌套需测。不做。
+4. **reference 数量上限**:无硬上限,但 prompt 膨胀 + 成本倍增。文档建议 2-4 个 reference(Hermes 默认 2 个)。
+5. **`reference_max_tokens`**(Hermes 的 advisor token cap):薄版不做内置 cap,用户可 per-reference 设 `max_output_tokens`。是否内置待反馈。
+
+---
+
+## 10. Implementation Order
+
+| 阶段 | 内容 | 依赖 | 状态 |
+|------|------|------|------|
+| **P1** | `composite.rs` 共用骨架(与 RFC-0021 协同)+ `moa.rs`:`MoaModel` + `do_generate` + 单测 | RFC-0021 P1 | 待实施 |
+| **P2** | `do_stream`(reference 非流式 + aggregator 流透传 + StreamStart/Finish 包装)+ 单测 | P1 | 待实施 |
+| **P3** | FFI(`aimux_moa_new`)+ Node(`moa` factory)+ 其他 binding 透传 | P1 | 待实施 |
+| **P4**(可选) | 多 layer 嵌套测试 + `reference_max_tokens` 内置 cap | P1 | 待评估 |
+
+**建议与 RFC-0021 协同实施**:先做 composite 骨架(共用),再分别做 RouterModel(0021)和 MoaModel(0022)。两者可并行开发,共用 `composite.rs` + `ChildModel` + `add_usage`。

--- a/rfc/0023-runtime-request-recording.md
+++ b/rfc/0023-runtime-request-recording.md
@@ -1,0 +1,444 @@
+# RFC-0023: 调用上下文录制与回放
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-05(重写:从"仅 HTTP 录制"扩展为"三层完整上下文录制 + 两种回放模式")
+> **Scope**: `aimux-core` + `aimux-provider-utils` 新增可选的完整调用上下文录制(输入侧 + 配置侧 + HTTP 侧)与两种回放模式(请求回放 / mock 响应回放),opt-in,默认关闭
+> **Related**: [RFC-0003](0003-test-cassette.md) 测试 cassette(格式与匹配基础)、[RFC-0014](0014-logging.md) 统一日志(零成本门控范本)、[RFC-0015](0015-cache-trace-audit.md) 缓存审计(sink 抽象兄弟)、[RFC-0020](0020-external-provider-config.md) 外部 provider 配置(配置侧录制关联)
+
+---
+
+## 1. Motivation
+
+aimux 当前**完全没有运行时录制与回放能力**。一次调用失败或返回异常,用户只拿到最终 `AiMuxError` JSON,看不到:实际发出的请求、上游返回的原始响应、当时的调用参数与 provider 配置。无法离线重现问题,也无法用录制的响应做 mock 测试。
+
+现有可观测性都不够:
+- RFC-0014(tracing 日志)只记 span 元数据(provider/model/attempt/状态码),不存完整 payload。
+- RFC-0003(测试 cassette)是**测试期**录制回放(wiremock `#[cfg(test)]`),aimux 自身零运行时录制能力。
+- RFC-0015(缓存审计)只存哈希指纹,**刻意不存明文**,无法用于"看原始请求/响应"或回放。
+
+### 1.1 录制要覆盖三层完整上下文
+
+一次 `generate_text`/`stream_text` 调用的完整上下文分三层,录制必须全部覆盖,缺一层则回放无法重建调用:
+
+| 层 | 内容 | 来源 | 回放用途 |
+|---|---|---|---|
+| **① 输入侧**(调用参数) | `prompt`(消息数组)+ `GenerateTextOptions`(temperature/tools/reasoning/headers/body_overrides/max_retries/timeout/seed/response_format...) | `generate_text` 入口的 `CallOptions` | 请求回放(重建调用)+ mock 匹配键 |
+| **② 配置侧**(provider 身份) | provider name / model_id / base_url / api_key 来源(不存明文 key)/ profile / ProviderOptions(headers/org/project) | `model.provider()`/`model.model_id()` + provider config | 请求回放(重建 provider)+ 审计 |
+| **③ HTTP 侧**(wire) | 实际发出的 request(method/url/headers/body)+ response(status/headers/body/流式每帧)+ timing/attempt | `aimux-provider-utils/src/http.rs` 咽喉点 | mock 响应回放(返回录制响应) |
+
+### 1.2 回放分两种模式
+
+| 模式 | 机制 | 用途 |
+|---|---|---|
+| **请求回放**(request replay) | 拿录制的 ①+②,重新构造 `generate_text` 调用,发**真实 API**。响应是新的(可能不同) | 离线重跑、改 prompt 重发、回归对比、A/B 测试 |
+| **mock 响应回放**(mock replay) | 拿录制的 ① 作匹配键,命中则返回录制的 ③(response),**不发真实 API** | 测试、离线 debug、降本(当缓存用) |
+
+两种模式共享同一份录制(三层都录),只是消费方式不同:
+- 请求回放只用 ①+②(重建调用),③ 仅作审计参考(对比新旧响应)。
+- mock 响应回放用 ①(匹配)+ ③(返回响应),② 仅作日志/过滤。
+
+---
+
+## 2. Design Goals
+
+1. **三层完整录制**:输入侧 + 配置侧 + HTTP 侧全覆盖,缺一则回放无法重建。
+2. **两种回放模式**:请求回放(重发真实 API)+ mock 响应回放(返回录制响应)。
+3. **零成本关闭**:默认关闭,关闭时热路径 ~0(1 原子读 + 1 分支),对标 RFC-0014 门控范本。
+4. **开启低开销**:录制开启 <0.1%(μs 级 vs LLM 调用 50-500ms);热路径不阻塞 I/O(异步落盘)。
+5. **隐私受控**:api_key / Authorization 永不录明文(只录来源:`env:VAR` / 明文标记)。**body 默认录**——aimux 是面向开发者的 SDK,录制的目的就是 debug/回放,不录 body 等于没录;录制的 opt-in 开关本身已是隐私门控(默认整体关闭,开启即开发者明确知情)。
+6. **复用 RFC-0003**:录制格式在 cassette 格式上扩展;mock 匹配复用 `score()` 逻辑。
+
+---
+
+## 3. Design
+
+### 3.1 录制数据模型(三层 + 关联 ID)
+
+```rust
+// aimux-core/src/recording.rs (新增)
+
+use serde::{Serialize, Deserialize};
+use crate::options::CallOptions;
+use crate::language_model_message::LanguageModelPrompt;
+
+/// 一次完整调用的录制记录(三层 + trace_id 关联)。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Recording {
+    /// 全局唯一 ID,关联三层。
+    pub trace_id: String,
+    pub recorded_at: String,           // ISO 8601
+
+    /// ① 输入侧:调用参数(prompt + options)。
+    pub input: InputRecord,
+
+    /// ② 配置侧:provider 身份与配置。
+    pub provider: ProviderRecord,
+
+    /// ③ HTTP 侧:实际 wire 交换(含重试,每次 attempt 一条)。
+    pub exchanges: Vec<HttpExchange>,
+
+    /// 最终结果摘要(成功/失败 + finish_reason + usage)。
+    pub outcome: OutcomeRecord,
+}
+
+/// ① 输入侧:完整调用参数,足以重建 generate_text 调用。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputRecord {
+    /// 完整 prompt(消息数组,含 ContentPart::Image 等多模态)。
+    pub prompt: LanguageModelPrompt,
+    /// 序列化的 CallOptions(除 abort_signal 外全部字段,#[serde(skip)] 的已自动排除)。
+    pub options: serde_json::Value,
+}
+
+/// ② 配置侧:provider 身份,足以重建 provider(请求回放用)。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderRecord {
+    pub provider: String,              // model.provider(),如 "openai"
+    pub model_id: String,              // model.model_id(),如 "gpt-4o"
+    pub base_url: Option<String>,      // provider 的 base_url
+    /// api_key 来源(不存明文):"env:OPENAI_API_KEY" / "explicit"(明文已传) / "none"。
+    pub api_key_source: String,
+    pub profile: Option<serde_json::Value>,  // OpenAICompatProfile(能力差异)
+    pub provider_options: Option<serde_json::Value>,  // ProviderOptions(headers/org/project/...)
+}
+
+/// ③ HTTP 侧:单次 attempt 的 wire 交换。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpExchange {
+    pub attempt: u32,                  // 第几次重试(0=首次)
+    pub request: HttpRecord,
+    pub response: Option<ResponseRecord>,  // None = 请求失败未获响应
+    pub timing: TimingRecord,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpRecord {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<(String, String)>,  // Authorization 等敏感头脱敏
+    pub body: Option<String>,            // 明文(脱敏后);None = 未开 body 录制
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseRecord {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Option<String>,            // 非流式:完整 JSON;流式:原始 SSE 拼接文本
+    pub stream_chunks: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimingRecord {
+    pub latency_ms: u64,
+    pub ttfb_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutcomeRecord {
+    pub success: bool,
+    pub finish_reason: Option<String>,
+    pub usage: Option<serde_json::Value>,  // 序列化的 Usage
+    pub error: Option<String>,
+}
+```
+
+### 3.2 录制点:两层,trace_id 关联
+
+录制分两层,用同一 `trace_id` 关联成一条完整 `Recording`:
+
+**层 A:`generate_text`/`stream_text` 入口(录 ①+②+outcome)**
+
+```rust
+// aimux-core/src/generate.rs 增量
+
+pub async fn generate_text(model: &dyn LanguageModel, prompt: impl Into<ModelPrompt>, options: GenerateTextOptions) -> Result<GenerateTextResult, AiMuxError> {
+    let trace_id = new_trace_id();
+    let call_options = options.into_call_options(lm_prompt);
+
+    // 录制 ①+②(若开):输入侧 + provider 元信息
+    let recorder = recording::recorder();
+    if let Some(rec) = &recorder {
+        rec.record_input(&trace_id, &call_options, model.provider(), model.model_id());
+        // provider config(base_url/api_key_source/profile)从 model 提取——
+        // 见 §3.3 ConfigSnapshot trait
+    }
+
+    let result = do_generate_with_logging(model, &call_options, span, started).await;
+
+    // 录制 outcome
+    if let Some(rec) = &recorder {
+        rec.record_outcome(&trace_id, &result);
+    }
+    // ...
+}
+```
+
+**层 B:`http.rs` 咽喉点(录 ③)**
+
+```rust
+// aimux-provider-utils/src/http.rs 增量
+
+// send() / send_stream() 内,每次 attempt 录一条 HttpExchange
+// trace_id 从哪里来?——见 §3.4(通过 call_options 的扩展字段或 thread-local 传递)
+```
+
+### 3.3 ConfigSnapshot trait(提取配置侧)
+
+`LanguageModel` trait 只暴露 `provider()`/`model_id()`,不暴露 base_url/api_key_source/profile。录制配置侧需新增可选 trait:
+
+```rust
+// aimux-core/src/recording.rs
+
+/// 可选 trait:让 provider 暴露配置侧快照供录制。
+/// 默认实现返回最小信息(只有 provider/model_id,无 base_url/profile)。
+/// 各 provider 实现(OpenAIProvider/AnthropicProvider/...)覆盖以提供完整配置。
+pub trait ConfigSnapshot {
+    fn config_snapshot(&self) -> ProviderRecord;
+}
+```
+
+`OpenAIModel` 实现 `ConfigSnapshot`(从 `self.config: OpenAIConfig` 取 base_url/profile/api_key 来源);`RouterModel`/`MoaModel`(RFC-0021/0022)转发被选子模型的快照。`generate_text` 入口录制时,若 `model` 也实现 `ConfigSnapshot` 则用其完整快照,否则用最小信息(降级)。
+
+**为什么是可选 trait 而非改 LanguageModel**:不破坏现有 trait 契约;录制是 opt-in 功能,provider 按需实现。
+
+### 3.4 trace_id 传递
+
+层 A(generate 入口)生成 `trace_id`,层 B(http.rs)需要拿到它来关联 ③。传递方式:
+
+- **方案 A(推荐)**:`CallOptions` 加 `#[serde(skip)] trace_id: Option<String>` 字段——入口生成后塞进 call_options,http.rs 从 `HttpRequest`(经 provider 透传)读取。serde skip 保证不过 JSON 边界(与 `abort_signal` 同模式,[options.rs:119](../aimux-core/src/options.rs#L119))。
+- **方案 B**:thread-local / task-local(`tokio::task_local!`)——无需改 CallOptions,但隐式传递,调试性差。
+
+**选 A**:显式、可测、与现有 `abort_signal` 同模式。`HttpRequest` 已有 `abort_signal` 字段([http.rs:197](../aimux-provider-utils/src/http.rs#L197)),加 `trace_id` 同理。
+
+### 3.5 Recorder trait 与实现
+
+```rust
+/// 录制器 trait。
+pub trait Recorder: Send + Sync {
+    /// 录制输入侧 + 配置侧(层 A 入口调用)。
+    fn record_input(&self, trace_id: &str, options: &CallOptions, provider: &str, model_id: &str);
+    /// 录制配置侧完整快照(若 provider 实现 ConfigSnapshot)。
+    fn record_provider(&self, trace_id: &str, snapshot: &ProviderRecord);
+    /// 录制单次 HTTP 交换(层 B http.rs 调用)。
+    fn record_exchange(&self, trace_id: &str, exchange: &HttpExchange);
+    /// 录制最终结果(层 A 入口调用)。
+    fn record_outcome(&self, trace_id: &str, outcome: &OutcomeRecord);
+    /// flush(关闭前调用,确保落盘)。
+    fn flush(&self);
+}
+
+/// 全局录制开关。None = 关闭(默认)。
+static RECORDER: OnceLock<Option<Arc<dyn Recorder>>> = OnceLock::new();
+
+pub fn init_recording(recorder: Arc<dyn Recorder>) { let _ = RECORDER.set(Some(recorder)); }
+pub fn init_recording_from_env() { /* AIMUX_RECORD=1 + AIMUX_RECORD_DIR;body 默认录 */ }
+
+/// 热路径检查:关闭时 ~1ns。
+fn recorder() -> Option<&'static Arc<dyn Recorder>> {
+    RECORDER.get().and_then(|opt| opt.as_ref())
+}
+```
+
+**默认实现**:
+- `JsonlRecorder`:每条 `Recording` 序列化为一行 jsonl 写磁盘(层 A/B 的分片通过 `trace_id` 在 flush 时合并,或实时写分片文件)。
+- `RingRecorder`:内存有界 ring buffer(默认 2048 条 ≈ 6-7MB),对标 RFC-0015。
+
+**异步落盘**:录制数据通过 mpsc channel 发到后台 tokio task,**热路径永不阻塞 I/O**。
+
+### 3.6 回放模式
+
+#### 3.6.1 请求回放(request replay)
+
+用录制的 ①+② 重新构造 `generate_text` 调用,发**真实 API**。
+
+```rust
+// aimux-core/src/replay.rs (新增,或独立 CLI crate)
+
+/// 从录制重建并重发调用(真实 API)。
+/// 返回新响应(可能与录制不同),用于回归对比/A/B。
+pub async fn replay_request(
+    recording: &Recording,
+    // 可选:覆盖部分参数(改 prompt / 换 model / 调 temperature)
+    overrides: Option<&ReplayOverrides>,
+) -> Result<GenerateTextResult, AiMuxError> {
+    let model = rebuild_provider(&recording.provider, overrides)?;
+    let prompt = rebuild_prompt(&recording.input.prompt, overrides);
+    let options = rebuild_options(&recording.input.options, overrides)?;
+    generate_text(&*model, prompt, options).await
+}
+
+/// 用录制的配置侧重建 provider。
+fn rebuild_provider(p: &ProviderRecord, overrides: Option<&ReplayOverrides>) -> Result<Box<dyn LanguageModel>, AiMuxError> {
+    // 1. provider(name, api_key=None, model_id, options)——复用 registry / 外部配置(RFC-0020)
+    // 2. api_key 从 p.api_key_source 重新解析("env:VAR" → 读 env)
+    // 3. base_url/profile/provider_options 覆盖
+}
+```
+
+**用途**:
+- 离线重跑线上流量(debug 难以重现的问题)
+- 改 prompt 重发(A/B 测试不同 prompt 对同一调用的效果)
+- 回归对比(新旧 aimux 版本对同一输入的输出差异)
+- CI 集成(录制真实流量,定期重跑检测 provider API 变化)
+
+**形态**:可做成库 API(`aimux::replay::replay_request`)或独立 CLI(`aimux-replay recordings.jsonl`)。CLI 更适合离线场景,不污染库。
+
+#### 3.6.2 mock 响应回放(mock replay)
+
+用录制的 ① 作匹配键,命中则返回录制的 ③(response),不发真实 API。
+
+```rust
+// aimux-core/src/replay.rs
+
+/// Mock 回放器:实现 LanguageModel trait,内部按输入匹配录制响应。
+pub struct MockReplayModel {
+    recordings: Vec<Recording>,        // 加载的录制
+    matcher: Box<dyn ReplayMatcher>,   // 匹配策略
+}
+
+#[async_trait]
+impl LanguageModel for MockReplayModel {
+    fn provider(&self) -> &str { "mock-replay" }
+    fn model_id(&self) -> &str { "mock-replay" }
+
+    async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
+        // 1. 用 matcher 按输入侧匹配录制
+        let rec = self.matcher.match(&options.prompt, &options, &self.recordings)?;
+        // 2. 从录制的 ③(response)重建 GenerateResult
+        rebuild_generate_result(&rec.exchanges[0].response, &rec.provider)
+    }
+
+    async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
+        // 同上,重建 stream(从录制的原始 SSE 文本逐帧回放)
+    }
+}
+```
+
+**匹配策略 `ReplayMatcher` trait**(可插拔):
+
+```rust
+pub trait ReplayMatcher: Send + Sync {
+    fn r#match(&self, prompt: &LanguageModelPrompt, options: &CallOptions, recordings: &[Recording]) -> Result<&Recording, AiMuxError>;
+}
+```
+
+内置实现:
+- **`ExactMatcher`**:请求体完全相同才命中(body hash)。精确但命中率低。
+- **`ScoreMatcher`**:复用 RFC-0003 `score()` 逻辑——按 method+path+model+stream 等稳定标量打分,平局取首个。命中率高,现有代码可复用([replay.rs:148-176](../aimux-providers/tests/common/replay.rs#L148))。
+- **`PrefixMatcher`**:按 prompt 前缀匹配(与 RFC-0015 LCP 同源)。适合"相同前缀的请求"命中。
+
+**与现有 wiremock cassette 的关系**:
+- RFC-0003 的 wiremock 是**测试期**机制(`#[cfg(test)]` + MockServer 重定向 base_url)。
+- `MockReplayModel` 是**运行时**机制(实现 `LanguageModel` trait,直接返回录制响应,无需 MockServer)。
+- 两者共享格式与匹配逻辑(`score()`),但运行机制不同。`MockReplayModel` 可替代 wiremock 用于非测试场景(如本地 dev 用录制响应调试,不发真实 API)。
+
+---
+
+## 4. 隐私与安全
+
+aimux 是面向开发者的 SDK,不是终端产品。录制的目的是 debug / 回放 / 测试,需要完整上下文才有意义。隐私门控在**录制开关**本身(opt-in,默认整体关闭),而非在录制内容上做默认裁剪——开发者开启录制即明确知情。
+
+| 维度 | 设计 |
+|------|------|
+| **默认** | **整体关闭**。不调 `init_recording` / 不设 env,零录制、零开销。开启录制 = 开发者明确知情同意。 |
+| **api_key / Authorization** | **永不录明文**。只录来源:`"env:OPENAI_API_KEY"` / `"explicit"`(明文已传但不存值)/ `"none"`。这是唯一强制脱敏项——key 泄露无 debug 价值且有滥用风险。 |
+| **body(prompt/request/response)** | **默认录**。开发者 SDK 的录制就该录完整 wire 上下文,否则无法 debug/回放。录制的 opt-in 开关已是隐私门控。 |
+| **文档警示** | env 说明标注"录制含明文 prompt,仅建议 debug/开发环境开启";生产环境如需开启,责任在开发者(与开 tracing 日志同性质)。 |
+| **回放安全** | 请求回放重发真实 API 会消耗 token/费用,文档警示;mock 回放无此风险。 |
+
+---
+
+## 5. 性能预算
+
+| 场景 | 热路径操作 | 量级 | 对照 |
+|------|-----------|------|------|
+| 关闭 | 1 原子 load + 1 分支 | ~1ns | — |
+| 层 A 录制开启 | clone CallOptions(结构 clone,μs)+ mpsc send | 单数位 μs | LLM 调用 50-500ms → <0.01% |
+| 层 B 每帧开启 | clone `Bytes` chunk(Arc bump,ns)+ `Vec::push` | ns-μs | chunk 间隔 10-100ms → 可忽略 |
+| 落盘 | 后台 task 从 channel 取出写 jsonl | 不在热路径 | — |
+
+**流式录制**:cassette 存原始拼接 SSE 文本(非解析帧),录制流式 = 累积原始 `Bytes` chunk,无需解析 SSE;回放原样吐回。
+
+---
+
+## 6. Relationship with RFC-0015(协调点)
+
+RFC-0015(缓存审计,DRAFT)存哈希指纹 + usage + verdict,**刻意不存明文**。本 RFC 存完整明文上下文。两者是兄弟:
+
+| | RFC-0015 审计 | 本 RFC 录制 |
+|---|---|---|
+| 层 | `LanguageModel` 装饰器 | `generate` 入口 + `http.rs` 咽喉 |
+| 内容 | 哈希指纹 + usage + verdict(无明文) | 完整三层上下文(明文) |
+| 默认 | 可常开(隐私安全) | 必须 opt-in |
+| 用途 | 缓存命中真伪审计 | debug / 回放 / 测试 |
+
+**协调**:共享 ring-store 模式(`RingTraceStore` / `RingRecorder`),但类型不同(`TraceRecord` vs `Recording`)。不强行统一类型,只统一模式。落地顺序:先实施的一方预留合并口子。
+
+---
+
+## 7. Non-Goals
+
+1. **不做请求回放的生产热路径集成**。请求回放(重发真实 API)是离线/CLI 场景,不进 `generate_text` 运行时路径——它是消费录制数据的工具,不是录制本身。
+2. **不做 mock 回放的自动缓存语义**(如 TTL 过期、容量淘汰)。`MockReplayModel` 是确定性回放,不是缓存;缓存(按请求匹配返回响应 + 过期策略)是另一特性,可后续基于 `MockReplayModel` 扩展。
+3. **不做配置热重载 / 文件监听**。MVP 是启动期初始化录制,进程内固定。
+4. **不录 abort_signal / 内部重试退避细节**。只录 attempt 次数 + timing。
+5. **不内置 prompt 脱敏**(PII 检测)。提供 `redact_body` 开关,但不做语义级 PII 识别——那是上层职责。
+
+---
+
+## 8. Scope of Changes
+
+| 位置 | 改动 | 工作量 |
+|------|------|--------|
+| `aimux-core/src/recording.rs` | `Recording`/`InputRecord`/`ProviderRecord`/`HttpExchange`/`OutcomeRecord` + `Recorder` trait + `ConfigSnapshot` trait + `JsonlRecorder`/`RingRecorder` + `init_recording` | ~350 行 |
+| `aimux-core/src/replay.rs` | `replay_request`(请求回放)+ `MockReplayModel` + `ReplayMatcher` trait + `ExactMatcher`/`ScoreMatcher`/`PrefixMatcher` | ~400 行 |
+| `aimux-core/src/generate.rs` | `generate_text`/`stream_text` 录制接入(层 A)+ `trace_id` 生成 | ~60 行 |
+| `aimux-core/src/options.rs` | `CallOptions` 加 `#[serde(skip)] trace_id: Option<String>` | ~5 行 |
+| `aimux-provider-utils/src/http.rs` | `send()`/`send_stream()`/`ObservedByteStream` 录制接入(层 B)+ `HttpRequest` 加 `trace_id` | ~100 行 |
+| `aimux-providers/src/openai/model.rs` 等 | 各 provider 实现 `ConfigSnapshot` | 每个 ~15 行,主要 provider ~10 个 |
+| `aimux-ffi/src/lib.rs` | `aimux_init_recording` + `aimux_mock_replay_new` C ABI | ~40 行 |
+| `bindings/node/src/lib.rs` | `initRecording` + `mockReplay(recordings)` napi | ~40 行 |
+| 测试 | 录制三层正确性 + 两种回放 + 匹配策略 + 性能基准 + 脱敏 | ~300 行 |
+
+**合计:~1200-1400 行。无 trait 破坏性改动(`ConfigSnapshot` 是新增可选 trait)、入口签名不变、关闭时零影响。**
+
+---
+
+## 9. Risks
+
+| 风险 | 等级 | 对策 |
+|------|------|------|
+| **明文 prompt 落盘**(隐私) | 中 | 录制整体 opt-in(默认关闭),开启即开发者知情;api_key/Authorization 恒脱敏(无 debug 价值且有滥用风险);body 默认录(SDK 面向开发者,不录则录制无意义);文档标注仅建议 debug/开发环境开启 |
+| **请求回放消耗真实 API 费用** | 中 | 文档警示;CLI 加 `--dry-run`(只打印不重发);库 API 由调用方显式调 |
+| **mock 回放匹配歧义**(多录制命中) | 中 | `ScoreMatcher` 平局取首个(确定性);`ExactMatcher` 无歧义;文档说明各 matcher 特性 |
+| **流式超大响应内存膨胀** | 中 | 单流累积上限 + 截断标记;`RingRecorder` 有界兜底 |
+| **trace_id 传递漏接**(层 B 拿不到) | 低 | 方案 A 显式塞 CallOptions(serde skip);provider 透传 HttpRequest;测试覆盖 |
+| **ConfigSnapshot 覆盖不全**(部分 provider 未实现) | 低 | 默认实现返回最小信息(降级录制,仍可用);按 provider 逐步补全 |
+| **与 RFC-0015 sink 抽象重复** | 中 | 共享 ring-store 模式;先实施方预留合并口子 |
+
+---
+
+## 10. Open Questions
+
+1. **录制文件组织**:单文件 jsonl(简单)vs 按 trace_id 分文件(便于回放加载单条)vs 按 provider/日期分目录?MVP 建议单文件 jsonl + 滚动;回放加载时全读进内存索引。
+2. **请求回放的形态**:库 API(`aimux::replay::replay_request`)还是独立 CLI(`aimux-replay`)?建议两者都做——库 API 供程序化使用,CLI 供离线命令行。CLI 可放独立 crate 或 `scripts/`。
+3. **mock 回放的 `MockReplayModel` 是否支持"部分 mock"**(某些请求 mock,某些透传真实 API)?MVP 不做(全 mock);后续可加 `PassthroughOnMiss` 策略。
+4. **`ScoreMatcher` 的匹配键**:复用 RFC-0003 的 `(method, path, model, stream)` 标量打分——但运行时录制有完整 `InputRecord`(含 prompt),是否用 prompt 前缀提升命中率?建议 MVP 用 score(复用现有),PrefixMatcher 作为可选增强。
+5. **`ConfigSnapshot` 是否进 `LanguageModel` trait**:本 RFC 设计为可选 supertrait(不破坏现有)。若后续录制成为核心能力,可考虑并入主 trait——但 MVP 保持可选。
+6. **回放录制格式与 RFC-0003 cassette 的互操作**:能否用 RFC-0003 的 cassette 做 mock 回放?格式相近(cassette 是单 exchange,Recording 是三层),可写转换器。MVP 不做,后续兼容。
+
+---
+
+## 11. Implementation Order
+
+| 阶段 | 内容 | 依赖 | 状态 |
+|------|------|------|------|
+| **P1** | `recording.rs`:`Recorder` trait + `Recording` 数据模型 + `JsonlRecorder` + `init_recording` + 层 A 录制接入(generate.rs)+ `trace_id` 传递 + 单测 | 无 | 待实施 |
+| **P2** | 层 B 录制接入(http.rs:`send`/`send_stream`/`ObservedByteStream`)+ `ConfigSnapshot` trait + OpenAI/Anthropic/Google 等主要 provider 实现 + 性能基准 | P1 | 待实施 |
+| **P3** | `replay.rs`:`MockReplayModel` + `ScoreMatcher`/`ExactMatcher` + 单测(mock 响应回放) | P1 | 待实施 |
+| **P4** | `replay.rs`:`replay_request` + `rebuild_provider`/`rebuild_options`(请求回放)+ CLI 工具 | P1, RFC-0020(外部配置,重建 provider) | 待实施 |
+| **P5** | 绑定层透传(Node/C ABI/Python/…)+ `PrefixMatcher` + 脱敏验证 + 文档 | P1-P3 | 待实施 |
+| **P6**(可选) | `RingRecorder` + 与 RFC-0015 sink 抽象对齐 | P1, RFC-0015 | 待实施 |
+
+**建议顺序**:P1(录制核心)→ P2(HTTP 层 + 配置侧)→ P3(mock 回放,最常用)→ P4(请求回放)。P1+P2 完成即可 debug 取证;P3 完成即可离线测试;P4 完成即可回归/A/B。

--- a/rfc/0024-session-aggregation.md
+++ b/rfc/0024-session-aggregation.md
@@ -1,0 +1,265 @@
+# RFC-0024: 调用会话聚合(session_id 归组)
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-05
+> **Scope**: `aimux-core` 新增 `session_id` 字段(显式为主 + 隐式推断兜底),把连续调用聚合成会话组,为录制(RFC-0023)、缓存探测(RFC-0015)、回放提供链级视图。不做 fork 语义、不做 agent loop。
+> **Related**: [RFC-0023](0023-runtime-request-recording.md) 录制(Recording 加 session_id)、[RFC-0015](0015-cache-trace-audit.md) 缓存探测(链级聚合)、[RFC-0019](0019-session-affinity.md) 会话亲和(路由层 session,与本 RFC 可观测层 session 共享 id 概念但职责不同)、[RFC-0016](0016-align-with-aisdk.md) H4(不做 agent loop 边界)
+
+---
+
+## 1. Motivation
+
+aimux 当前的录制(RFC-0023)、缓存探测(RFC-0015)、回放都是**孤立请求视角**——每条 `Recording`/`TraceRecord` 是一次 `generate_text`,看不到连续调用间的关系。
+
+但真实使用是**连续调用链**:agent loop 是一串 `generate_text`,可能同 session 连续,也可能 fork 式分叉(业务侧不同 session)。开发者真正关心的是**这条链的缓存表现怎么演变**——单请求的"命中率 80%"没意义,有意义的是"这个 session 8 步调用,命中率从 0% 涨到 80% 然后稳定"。脱离链谈单请求缓存,看不到东西。
+
+### 1.1 为什么 aimux 做这个(边界)
+
+- **aimux 不做 agent loop**(RFC-0005 / H4 已定)。loop 的执行(工具调用、多轮编排)是上层框架的活。
+- **但 aimux 要提供会话归组基础设施**:上层 agent 框架调 8 次 `generate_text`,aimux 得能把这 8 次归到一条会话,报告这条会话的缓存表现。这是**可观测性基础设施**,与 tracing/recording 同类,属访问层职责。
+- **类比**:aimux 不做 HTTP 服务,但提供 retry/timeout 基础设施让上层用。会话归组同理——aimux 提供 session_id 聚合与报告,上层 agent loop 消费。
+- **fork 不是 aimux 的建模对象**:fork 是业务侧场景(上层框架决定怎么分叉),aimux 这层只需要 `session_id` 做归组。同一个 session_id 的调用归一组;不同 session_id 各自归组。fork 与否 aimux 不关心。
+
+### 1.2 与 RFC-0019(会话亲和)的区别
+
+两者共享 `session_id` 概念,但职责正交:
+
+| | RFC-0019 会话亲和(路由层) | 本 RFC 会话聚合(可观测层) |
+|---|---|---|
+| 目的 | 传 session 头让**上游**做粘性路由 | 归组调用让**本地**报告链级表现 |
+| 载体 | `CallOptions.headers`(`x-session-id` 等,各厂商头名不同) | `CallOptions.session_id`(新字段,统一) |
+| 代码改动 | 零(文档方案,复用现有 headers) | 加字段 + 聚合逻辑 |
+| 消费者 | 上游网关/provider | 录制/缓存探测/回放 |
+
+**协同**:上层传同一个 `session_id`,aimux 既用它做本地归组(本 RFC),又可选地映射成厂商头喂上游(RFC-0019)。两者可共用一个 id 值,但走不同字段、不同路径。本 RFC 不强制与 0019 绑定——开发者可只用归组不喂上游,或只喂上游不归组。
+
+---
+
+## 2. Design Goals
+
+1. **显式为主**:上层 agent 框架显式传 `session_id`,aimux 不生成、不默认注入、不猜测。
+2. **隐式推断兜底**:未传 `session_id` 时,aimux 按 prompt 前缀延续推断归组(连续调用的 prompt 是前缀扩展 → 同一会话)。
+3. **轻量**:只加一个字段 + 聚合逻辑,不做链结构/fork/状态机。
+4. **三者共用**:录制/缓存探测/回放共享 session_id 归组,不各自零散加字段。
+5. **opt-in 归组**:不传 session_id 且推断关闭时,退化为孤立请求视图(现状),零影响。
+
+---
+
+## 3. Design
+
+### 3.1 session_id 字段
+
+```rust
+// aimux-core/src/options.rs 增量
+
+pub struct CallOptions {
+    // ... 现有字段 ...
+
+    /// 会话标识,用于把连续调用聚合成组(可观测用,见 RFC-0024)。
+    /// 显式传入优先;None 时可由隐式推断填充(若开启)。
+    /// 与 RFC-0019 的会话亲和头正交:本字段供本地归组,headers 里的
+    /// session 头供上游路由,两者可共用同一 id 值但走不同路径。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+```
+
+`GenerateTextOptions`(用户面)同步加 `session_id: Option<String>`。`#[serde(skip_serializing_if)]` 保证未传时不进 JSON,不影响现有 wire 格式。
+
+**为什么不用 `headers` 复用**(RFC-0019 路径):
+- headers 的 session 头是**厂商专属**的(OpenRouter `x-session-id`、Cloudflare `x-session-affinity`、Anthropic `x-claude-code-session-id`...),头名各不同,aimux 无法从中统一提取"会话 id"做归组。
+- 可观测归组需要**统一字段**,与厂商头名解耦。两者可共用同一 id 值(开发者传 `session_id="abc"`,aimux 归组用 `abc`,同时可选映射成厂商头喂上游——但映射属 RFC-0019 的 opt-in,本 RFC 不做)。
+
+### 3.2 隐式推断(兜底)
+
+未传 `session_id` 时,aimux 按 prompt 前缀延续推断:
+
+```rust
+// aimux-core/src/session.rs (新增)
+
+/// 会话推断器:按 prompt 前缀延续把连续调用归组。
+/// opt-in,默认关闭(退化为孤立请求视图)。
+pub struct SessionInferer {
+    /// 最近 N 个调用的 (prompt_hash_prefix, session_id) 缓存。
+    /// 用于检测"新调用的 prompt 是某个近期调用的前缀扩展"。
+    recent: LruCache<String, String>,  // prompt_prefix_hash → session_id
+}
+
+impl SessionInferer {
+    /// 推断或生成 session_id。
+    /// - 显式传入:直接用。
+    /// - 未传 + 推断开:若新 prompt 的前缀匹配某个近期调用,归入同一 session;
+    ///   否则生成新 session_id(新会话)。
+    /// - 未传 + 推断关:None(孤立请求)。
+    pub fn resolve(&self, explicit: Option<&str>, prompt: &LanguageModelPrompt) -> Option<String> {
+        if let Some(id) = explicit { return Some(id.to_string()); }
+        if !self.enabled { return None; }
+        // 计算 prompt 的前缀哈希(复用 RFC-0015 的块哈希链 LCP 算法)
+        let prefix = prompt_prefix_hash(prompt);
+        if let Some(id) = self.recent.get(&prefix) {
+            return Some(id.clone());
+        }
+        let new_id = format!("auto-{}", new_uuid());
+        self.recent.put(prefix, new_id.clone());
+        Some(new_id)
+    }
+}
+```
+
+**推断的歧义与边界**:
+- 歧义:两条独立链碰巧前缀相似会误并。缓解:只对**强前缀延续**(新 prompt 完全包含某个近期调用的完整 prompt 作为前缀)归并,弱相似不并。
+- 推断结果标记来源:`"auto-xxx"`(推断)vs 用户传入的 id(显式),便于审计区分。
+- **默认关闭推断**——显式为主。推断需 `AIMUX_SESSION_INFER=1` 或编程式开启。
+
+### 3.3 归组数据模型
+
+```rust
+// aimux-core/src/session.rs
+
+/// 一个会话的聚合视图(按 session_id 归组的调用序列)。
+/// 不存调用内容本身——内容在 Recording(0023)/TraceRecord(0015)。
+/// 本结构只是索引:session_id → [trace_id 列表]。
+pub struct SessionView {
+    pub session_id: String,
+    pub source: SessionSource,           // Explicit / Inferred
+    pub calls: Vec<SessionCall>,         // 有序调用
+}
+
+pub struct SessionCall {
+    pub trace_id: String,                // 关联 Recording / TraceRecord
+    pub step: u32,                       // 第几步(0 起)
+    pub recorded_at: String,
+}
+
+pub enum SessionSource { Explicit, Inferred }
+```
+
+**存储**:session 索引存在 `SessionStore`(内存 LRU,默认 N 个 session),与 `RingRecorder`/`RingTraceStore` 同级。不持久化——进程重启丢索引,但 Recording/TraceRecord 的 session_id 字段保留,可重建索引。
+
+### 3.4 三者如何消费 session_id
+
+| 子系统 | 消费方式 |
+|---|---|
+| **录制(RFC-0023)** | `Recording` 加 `session_id` + `step` 字段。回放支持"按 session 重放整条链"(按序重发真实 API,或按链前缀做 mock)。查询"这个 session 的所有录制" |
+| **缓存探测(RFC-0015)** | LCP 从单请求扩展到 session scope——"这条链 N 步的命中演变:0%→80%→80%→..."。`TraceRecord` 加 session_id,`SessionStore` 聚合 verdict |
+| **回放(RFC-0023)** | 请求回放支持重放整条 session(按序);mock 回放按 session 内的前缀匹配提升命中率 |
+
+**关键**:session_id 是三者共享的归组键,但**各自消费**——录制存 session_id 到 Recording,缓存探测存到 TraceRecord,回放按 session_id 过滤。不强行统一三者的存储,只统一归组字段。
+
+---
+
+## 4. Integration Approach
+
+### 4.1 generate_text 入口
+
+```rust
+// aimux-core/src/generate.rs 增量
+
+pub async fn generate_text(model: &dyn LanguageModel, prompt: impl Into<ModelPrompt>, options: GenerateTextOptions) -> Result<GenerateTextResult, AiMuxError> {
+    let call_options = options.into_call_options(lm_prompt);
+
+    // 解析 session_id(显式优先,隐式推断兜底)
+    let session_id = SESSION_INFERER.resolve(call_options.session_id.as_deref(), &call_options.prompt);
+    let call_options = call_options.with_session_id(session_id.clone());
+
+    // 录制/缓存探测/会话索引都拿到 session_id
+    if let Some(sid) = &session_id {
+        SESSION_STORE.append(sid, &trace_id);  // 归组
+    }
+    // ... generate_text 主体 ...
+}
+```
+
+### 4.2 绑定层
+
+`session_id` 是 `Option<String>`,经 JSON 边界自动透传(与 `max_retries`/`temperature` 同模式)。Node/Python/FFI 用户在 options 里加 `sessionId` 字段即可,无需新 API。
+
+### 4.3 SessionStore 查询 API
+
+```rust
+/// 查询一个 session 的所有调用(按 step 排序)。
+pub fn session_calls(session_id: &str) -> Vec<SessionCall>;
+
+/// 查询一个 session 的缓存命中演变(聚合 TraceRecord verdict)。
+/// 返回 [(step, hit_rate, verdict), ...]
+pub fn session_cache_trajectory(session_id: &str) -> Vec<(u32, f64, Verdict)>;
+
+/// 列出所有已知 session(分页)。
+pub fn list_sessions() -> Vec<SessionView>;
+```
+
+这些 API 供调试工具/绑定层查询,不在 `generate_text` 热路径。
+
+---
+
+## 5. Relationship with Existing RFCs
+
+| RFC | 关系 |
+|-----|------|
+| [RFC-0023](0023-runtime-request-recording.md) | **Recording 加 session_id + step**。回放支持按 session 重放整条链。本 RFC 是录制的链级视图基础。 |
+| [RFC-0015](0015-cache-trace-audit.md) | **TraceRecord 加 session_id**。LCP 从单请求扩展到 session scope。本 RFC 让缓存探测能报告链级命中演变。 |
+| [RFC-0019](0019-session-affinity.md) | **共享 session_id 概念,职责正交**。0019 是路由层(头喂上游),本 RFC 是可观测层(本地归组)。可共用 id 值,走不同字段。本 RFC 不强制与 0019 绑定。 |
+| [RFC-0016](0016-align-with-aisdk.md) | **边界确认**。H4 不做 agent loop;本 RFC 只做归组,不做 loop 执行。 |
+| [RFC-0005](0005-protocol-conversion.md) | **正交**。会话归组不碰协议转换。 |
+
+---
+
+## 6. Non-Goals
+
+1. **不做 fork 语义**。fork 是业务侧场景(上层框架决定怎么分叉),aimux 只按 session_id 归组。同 session_id 归一组,不同 session_id 各自归组,fork 与否 aimux 不建模。
+2. **不做 agent loop**(H4)。session 归组是可观测基础设施,不是 loop 执行。
+3. **不做 session 头自动注入**(RFC-0019 的活)。本 RFC 的 session_id 是本地归组用,不自动映射成厂商头喂上游。映射属 0019 的 opt-in,由集成方决定。
+4. **不做链结构 / 状态机**。只做 `session_id → [trace_id]` 的扁平归组,不建树、不做父子链。
+5. **不持久化 session 索引**。进程内 LRU,重启丢索引(但 Recording/TraceRecord 的 session_id 字段保留,可重建)。
+6. **不默认开启隐式推断**。显式为主;推断需 opt-in,因有歧义风险。
+
+---
+
+## 7. Scope of Changes
+
+| 位置 | 改动 | 工作量 |
+|------|------|--------|
+| `aimux-core/src/options.rs` | `CallOptions` + `GenerateTextOptions` 加 `session_id: Option<String>` | ~10 行 |
+| `aimux-core/src/session.rs` | `SessionInferer` + `SessionStore` + `SessionView` + 查询 API | ~250 行 |
+| `aimux-core/src/generate.rs` | 入口 resolve session_id + append SessionStore | ~30 行 |
+| `aimux-core/src/lib.rs` | `pub mod session;` + prelude | ~5 行 |
+| `aimux-ffi/src/lib.rs` | `aimux_session_calls` / `aimux_session_cache_trajectory` 查询 C ABI | ~40 行 |
+| `bindings/node/src/lib.rs` | `sessionCalls` / `sessionCacheTrajectory` napi 查询函数 | ~40 行 |
+| 测试 | 归组正确性 + 推断歧义边界 + 查询 API + 与录制/探测的集成 | ~200 行 |
+
+**合计:~500-600 行。无 trait 改动、无破坏性变更(字段 Option + skip_serializing_if)、未传时零影响。**
+
+---
+
+## 8. Risks
+
+| 风险 | 等级 | 对策 |
+|------|------|------|
+| **隐式推断误并**(独立链前缀相似) | 中 | 默认关闭推断;开启时只对强前缀延续归并;推断结果标记 `"auto-"` 前缀可区分 |
+| **SessionStore 内存膨胀**(session 多) | 低 | LRU 有界(默认 N 个 session × M calls/session);可配 |
+| **session_id 与 RFC-0019 头不同步**(开发者传 id 但忘传头) | 低 | 文档说明两者关系;可选提供"自动映射 session_id→厂商头"的 opt-in helper(属 0019 扩展,本 RFC 不做) |
+| **推断的 prompt 前缀哈希与 RFC-0015 LCP 重复实现** | 低 | 共享块哈希链 LCP 算法模块(三者共用) |
+
+---
+
+## 9. Open Questions
+
+1. **隐式推断的"强前缀"阈值**:新 prompt 完全包含某个近期调用的完整 prompt 作为前缀才算归并?还是允许部分匹配?建议 MVP 用强前缀(完整包含),部分匹配留后续。
+2. **SessionStore 的 LRU 容量**:默认多少 session × 多少 calls?建议 256 session × 64 calls(≈16K 条索引,内存可忽略)。
+3. **session_id 是否自动透传给上游**(映射成厂商头):本 RFC 不做(属 RFC-0019),但是否提供 `session_id → headers` 的 helper 函数让集成方方便用?建议作为 0019 的可选增强,不在本 RFC。
+4. **查询 API 的形态**:库 API(Rust 函数)+ 绑定透传?还是独立调试 CLI?建议库 API 为主,CLI 后续。
+5. **与 RFC-0021/0022(composite model)的交互**:RouterModel/MoaModel 的 `do_generate` 收到 session_id,应透传给子模型(保持同一 session)。需在 composite 实现里确认 session_id 透传。
+
+---
+
+## 10. Implementation Order
+
+| 阶段 | 内容 | 依赖 | 状态 |
+|------|------|------|------|
+| **P1** | `CallOptions`/`GenerateTextOptions` 加 `session_id` 字段 + `SessionStore`(显式归组,无推断)+ 查询 API + 单测 | 无 | 待实施 |
+| **P2** | `SessionInferer`(隐式推断,opt-in)+ 单测(强前缀归并、歧义边界) | P1 | 待实施 |
+| **P3** | 录制(RFC-0023)集成:Recording 加 session_id + step + 按 session 查询/回放 | P1, RFC-0023 | 待实施 |
+| **P4** | 缓存探测(RFC-0015)集成:TraceRecord 加 session_id + session 级命中演变聚合 | P1, RFC-0015 | 待实施 |
+| **P5** | 绑定层透传 + 查询 API(Node/C ABI/Python)+ 文档 | P1 | 待实施 |
+
+**建议先做 P1**(显式归组即可用:开发者传 session_id,aimux 归组报告)。P2 推断是增强。P3/P4 是与录制/探测的集成,各自独立。


### PR DESCRIPTION
## 概述

本轮调研后,按"项目边界内 / 边界内边缘 / 边界外不做"分类,落地 5 个 DRAFT RFC + 1 份调研报告。全部为文档,无代码改动。

## RFC 清单

| RFC | 解决需求 | 工作量估计 | 关键设计 |
|-----|---------|-----------|---------|
| [RFC-0020](rfc/0020-external-provider-config.md) | 灵活性 | ~200-400 行 | 运行时覆盖层 `OVERLAYS`,`provider()` 查找改为覆盖层→内置 registry;仅 OpenAI 兼容;落地 RFC-0017 预留语义 |
| [RFC-0021](rfc/0021-composite-model-routing.md) | 省钱+容灾 | ~600-800 行 | `RouterModel` 实现 `LanguageModel` + 可插拔 `Router` trait;内置 Rule/Weighted/LLM 分类器/视觉分流;学习型走 trait 注入不进核心 |
| [RFC-0022](rfc/0022-moa-single-fanout.md) | 提质 | ~350-450 行 | `MoaModel` 实现 trait;reference 并行扇出 → 拼进 aggregator prompt → aggregator 跑;单次内完成不含 loop;与 0021 共用骨架 |
| [RFC-0023](rfc/0023-runtime-request-recording.md) | 可观测 | ~1200-1400 行 | 录制三层(输入侧+配置侧+HTTP wire)+ 两种回放(请求回放重发真实 API / mock 响应回放);body 默认录(开发者 SDK);api_key 永不录 |
| [RFC-0024](rfc/0024-session-aggregation.md) | 连续性 | ~500-600 行 | `session_id` 归组连续调用;显式为主+隐式推断兜底;录制/缓存探测/回放共用归组键;不做 fork 语义 |

另有 [docs/external-provider-config-research.md](docs/external-provider-config-research.md) 作为 RFC-0020 的调研支撑。

## 边界划分

**边界内(访问层本身该做的)**:RFC-0020(外部配置)、RFC-0023(录制)、RFC-0024(session 归组);缓存审计(RFC-0015,已有 DRAFT)

**边界内边缘(composite model,单次组合)**:RFC-0021(路由)、RFC-0022(MoA 薄版)——都是实现 `LanguageModel` trait 的 composite model,单次 `generate_text`/`stream_text` 内完成,不引入 agent loop

**边界外不做**:产品化网关、学习型训练管线、业务语义路由、MoA 完整版(agent loop)、运行时确定性回放当缓存用

## 关键技术验证

composite model 的 object-safety 与 FFI 透明性经独立 crate 编译验证通过:
- `Vec<Arc<dyn LanguageModel>>` 持有 + 自身实现 `LanguageModel` trait 可编译
- `generate_text`/`stream_text` 入口零改动(只依赖 `&dyn LanguageModel`)
- FFI/Node wire 层零改动,只需新增构造函数(`aimux_router_new`/`aimux_moa_new`)

## 跨 RFC 协同

- RFC-0021 + 0022 共用 composite 骨架(`ChildModel = Arc<dyn LanguageModel>` + `add_usage`),建议协同实施
- RFC-0023 + 0015 共享 ring-store/sink 抽象模式,先实施方预留合并口子
- RFC-0024 是 0023(录制)/ 0015(缓存探测)/ 回放的公共连续性基础层
- RFC-0023 请求回放依赖 RFC-0020(外部配置)重建 provider

## 检查清单

- [x] 5 个 RFC 均为 DRAFT (pending review) 状态
- [x] pre-commit 通过(fmt + check)
- [x] pre-push 通过(clippy -D warnings + 全量测试,0 failed)
- [x] 纯文档,无代码改动