### PR TITLE
docs(rfc): 缓存探测三层拆分 — RFC-0015 重写 + RFC-0025 CLI client

### DIFF
--- a/rfc/0015-cache-trace-audit.md
+++ b/rfc/0015-cache-trace-audit.md
@@ -1,9 +1,9 @@
-# RFC-0015: 缓存命中审计与请求 Trace(provider cache-hit audit)
+# RFC-0015: 缓存命中探测(cache-hit probe)
 
-> **Status**: DRAFT (pending review)
-> **Date**: 2026-08-01
-> **Scope**: 在 aimux 统一 LLM 访问层上提供可选的请求 trace + 统计 + 缓存命中审计能力——客户端对连续 agent 调用的原始请求体做前缀对比,审计各 provider 服务端上报的 cache 命中率是否掺水,并提供诊断
-> **Related**: [RFC-0014](0014-logging.md) 统一日志体系(本子系统挂载其 span 树),[RFC-0009](0009-request-resilience.md) retry/超时(重试语义影响判定规则),研究存档 [cache-tracing](../docs/internal/cache-tracing/00-research-plan.md)(10-working-document.md + rounds/ 全部调查与设计中间产物)
+> **Status**: DRAFT (pending review)——2026-08-05 重写:收窄为"探测本身"(core infrastructure),探测业务划给 `tools/aimux-cli` client,告警由外部消费
+> **Date**: 2026-08-01(初稿)/ 2026-08-05(重写)
+> **Scope**: aimux 统一 LLM 访问层上的可选缓存命中探测能力——采集 request_body 指纹 + usage 快照,客户端对连续 agent 调用的原始请求体做前缀对比,判定各 provider 服务端上报的 cache 命中率是否掺水,暴露 verdict 数据与查询接口供消费。**探测本身进 core,探测业务(CLI)独立,告警外部消费。**
+> **Related**: [RFC-0014](0014-logging.md) 统一日志(挂载其 span 树)、[RFC-0023](0023-runtime-request-recording.md) 录制与回放(明文兄弟子系统,trace_id 关联)、[RFC-0024](0024-session-aggregation.md) 会话聚合(session_id 统一来源)、[RFC-0009](0009-request-resilience.md) retry/超时(重试语义影响判定规则)、研究存档 [cache-tracing](../docs/internal/cache-tracing/00-research-plan.md)
 
 ---
 
@@ -19,24 +19,54 @@ LLM 提供商普遍提供 prompt 缓存折扣(OpenAI cached_tokens / Anthropic c
 | 网关改写 | litellm #9812 双重计费;Langfuse #12306 口径叠加 2×;new-api #6144 命中仍按全价收用户(掺水动机模型) |
 | 报低/漏报 | Ollama 官方自认恒报 0;vLLM V1 `prompt_tokens_details` 恒 null(14+ 个月未修);Portkey 流式剥字段;OpenRouter 响应缓存 usage 归零 |
 
-**现状 aimux 无法支撑审计**:`request_body` 已在非流式/流式双路径生成([D6 调查](10-working-document.md#L60-L84)),但 `stream_text` 用户面丢弃它;Anthropic 生产路径只填 `total`;`Usage.raw` 是死字段。业界观测产品(Helicone/Langfuse/Braintrust)均为被动采集,**无人做缓存命中真伪校验**(D3 调查)。
+**现状 aimux 无法支撑探测**:`request_body` 已在非流式/流式双路径生成([D6 调查](10-working-document.md#L60-L84)),但 `stream_text` 用户面丢弃它;Anthropic 生产路径只填 `total`;`Usage.raw` 是死字段。业界观测产品(Helicone/Langfuse/Braintrust)均为被动采集,**无人做缓存命中真伪校验**(D3 调查)。
 
-### 1.2 目标
+### 1.2 三层结构(2026-08-05 对齐)
+
+缓存探测按"探测本身 / 探测业务 / 告警"三层拆分:
+
+```
+① 探测本身(core infrastructure,常开)
+   TraceLayer 装饰器 → 采集指纹+usage → LCP+不变量 → verdict → TraceRecord → RingTraceStore
+   │ 只负责:采数据、算判定、存哈希、暴露查询接口
+   │ 不负责:告警阈值、报表、调优建议
+   ▼
+② 探测业务 client(tools/aimux-cli,独立产物,基于 aimux 构建)
+   一个可运行的 client:审计指定 provider 缓存能力、诊断链级命中、调试 prompt 结构
+   消费 ① 的查询接口(进程内)或 ① 导出的 jsonl(离线)
+   │ 独立二进制,不进 SDK 运行时路径
+   ▼
+③ 告警/校准/跟踪(外部消费)
+   core 只暴露 verdict + TraceRecord + 查询 API
+   告警业务(阈值/通知/报表)由外部应用做,aimux 不直接做
+```
+
+| 层 | 位置 | 状态 |
+|---|---|---|
+| ① 探测本身 | `aimux-core`(本 RFC) | 本 RFC 设计 |
+| ② 探测业务 client | `tools/aimux-cli`(独立 crate,本 repo) | 见 [RFC-0025](0025-aimux-cli-cache-probe.md),不展开在本 RFC |
+| ③ 告警/校准/跟踪 | 外部应用 | 本 RFC 只定义暴露的接口,不做业务 |
+
+### 1.3 目标
 
 1. 客户端可对账的**硬不变量**:命中域 ⊆ 客户端发过的历史前缀;首请求零命中;DeepSeek `hit+miss==prompt`;Anthropic 三字段和;OpenAI 门槛/量化;TTL 时序
 2. 判定输出**期望命中区间**而非单点,掺水判定分置信度
-3. 零隐式全局状态(库)、零明文落盘、性能预算内(0.1ms 热路径、零内存增长承诺不破坏)
-4. 8 语言绑定零改动
+3. 零隐式全局状态(库)、探测层零明文落盘、性能预算内(0.1ms 热路径、零内存增长承诺不破坏)
+4. 暴露**数据与查询接口**,不内置业务逻辑(告警/报表由②③消费)
+5. 8 语言绑定零改动(探测数据经 FFI JSON 透传)
 
-### 1.3 非目标
+### 1.4 非目标
 
 - 不做服务端账单对账(需外部账单输入,仅留接口)
-- 不做跨请求全量明文存储
+- 不做跨请求全量明文存储(明文录制见 [RFC-0023](0023-runtime-request-recording.md),探测层只存哈希)
 - 不改 LanguageModel trait、不动 251 个 compat provider 实现
+- **不做告警业务**(阈值/通知/报表):由外部消费,core 只暴露 verdict 数据
+- **不做调优建议**(如自动改 prompt 提升命中):那是应用层逻辑
+- **不做预判决策**(调用前预测命中并改路由):决策归 [RFC-0021](0021-composite-model-routing.md),探测只提供历史统计数据
 
 ---
 
-## 2. 设计总览
+## 2. 探测本身设计总览
 
 ```
                     ┌──────────────────────────────────────────┐
@@ -54,7 +84,10 @@ LLM 提供商普遍提供 prompt 缓存折扣(OpenAI cached_tokens / Anthropic c
       (有界环形+反向索引)      (JSONL/OTel/自定义)    (规则引擎,strict/shared)
                 │                                        │
                 ▼                                        ▼
-        aggregate()/session_chain()            Verdict 写回 TraceRecord
+        aggregate()/session_chain()/export_jsonl  Verdict 写回 TraceRecord
+                │
+                ▼
+        ② CLI / ③ 外部消费(查询接口或 jsonl)
 ```
 
 **核心不变量(字节级单射性论证)**:byte-level BPE 编码是单射的(enc(a)=enc(b) ⟹ a=b),故**字节相同 ⟺ token 序列相同**——服务端命中必然是客户端某历史请求前缀的字节匹配。因此客户端字节级 LCP 是服务端匹配字节长度的**必要条件**:`claimed_cached > 客户端 LCP` 直接证伪多报(唯一例外:跨进程/跨客户端共享缓存,见 strict/shared 模式)。
@@ -89,7 +122,7 @@ U = min(prompt, quantize_down(token_upper(LCP_i), gran))
 ### 4.2 规则组(8 硬不变量 + 3 诊断组)
 
 - **R-1 硬不变量**:前缀包含域(R-1.1,strict=W/shared=U)、首请求零命中(R-1.2)、DeepSeek 等式(R-1.3)、Anthropic 三字段(R-1.4)、Bedrock quota(R-1.5)、OpenAI 门槛/量化(R-1.6)、5.6+ 写读等式(R-1.7)、TTL 时序(R-1.8)
-- **R-2 分段期望模型**(关键设计):命中只依赖前缀精确匹配,与 session 无关。**system/tools 段可跨 session 命中**;conversation 段仅同 session append-only 链可命中。同 session 连续但 0 命中 → 前缀被破坏(动态 system/历史压缩/tools 变化);报命中但无含该前缀的历史请求 → 掺水信号
+- **R-2 分段期望模型**(关键设计):判定层面命中只依赖前缀精确匹配,与 session 无关(命中是字节级事实);**聚合层面**按 session_id 归组报告链级演变([RFC-0024](0024-session-aggregation.md))。system/tools 段可跨 session 命中;conversation 段仅同 session append-only 链可命中。同 session 连续但 0 命中 → 前缀被破坏(动态 system/历史压缩/tools 变化);报命中但无含该前缀的历史请求 → 掺水信号
 - **R-3 白名单**:预热期(N=10 或 128s)、模型升级、低门槛
 - **R-4 网关**:响应缓存 usage 归零合法(与 provider 缓存区分)、C 级网关降级 U、网关自填标记
 - **R-5 数据完整性**:usage 缺失→U、retry 合并(取最后一次 usage)、多进程视界(shared→U)、无 tokenizer 降级、请求侧 cache_control(best-effort)
@@ -100,31 +133,115 @@ U = min(prompt, quantize_down(token_upper(LCP_i), gran))
 
 ---
 
-## 5. 数据模型与统计 API(完整定义见 [round-3-trace-data-model.md](../docs/internal/cache-tracing/rounds/round-3-trace-data-model.md))
+## 5. 数据模型与统计 API
 
 ### 5.1 TraceRecord(serde + ts_rs,FFI JSON 惯例)
 
-请求身份(provider/model/request_id/session_id/时间戳)+ Fingerprint(块哈希链/body_hash/字节数/token_estimate)+ UsageSnapshot(7 字段平铺 + raw 透传)+ ResponseCacheHeaders + RequestCacheHints(请求侧档位,best-effort)+ Verdict + error。全 owned、Clone、Send+Sync;明文永不进 trace。
+请求身份(provider/model/request_id/**session_id(来自 RFC-0024 CallOptions 字段)**/时间戳)+ Fingerprint(块哈希链/body_hash/字节数/token_estimate)+ UsageSnapshot(7 字段平铺 + raw 透传)+ ResponseCacheHeaders + RequestCacheHints(请求侧档位,best-effort)+ Verdict + error。全 owned、Clone、Send+Sync;明文永不进 trace。
+
+**session_id 来源(2026-08-05 对齐)**:`TraceRecord.session_id` 统一来自 [RFC-0024](0024-session-aggregation.md) 的 `CallOptions.session_id`(显式为主 + 隐式推断兜底)。**不再用 `TraceLayer::with_session` 实例注入**——同一 wrapper 无法跟随 agent loop 中途换 session。`with_session` 降级为"默认 session_id"(CallOptions 未传时 fallback),并保持会话密钥注入(HMAC 脱敏 key)。
 
 ### 5.2 统计口径(防 D3 口径叠加坑)
 
 - `reported_hit_rate` 严格 = cache_read / input_total,**不与 cache_write 相加**(回避 Langfuse 式 2× 口径 bug)
 - `client_upper_bound_hit_rate` = 客户端 LCP token 上界 / input_total
 - **两率并列展示,不合成单一"命中率"**
-- 聚合:会话级 verdict 分布 + 漂移检测(Δ>5%·mean(U) 或 w>10% 警报)+ 漏报侧独立计数 + UNKNOWN 护栏(可判定率<70% 降级)
+- 聚合统计:verdict 分布、reported vs client_upper_bound 双率、TTFT 分位、错误数(见 `TraceStats`)
 
-### 5.3 接口
+> **注(2026-08-05)**:漂移检测警报(Δ>5%·mean(U) 或 w>10%)、漏报侧独立计数、UNKNOWN 护栏降级等**审计业务逻辑**从本 RFC 移出,归 ② CLI / ③ 外部消费。core 只提供原始统计(`TraceStats`)与 verdict 分布,业务判断由消费方做。
+
+### 5.3 接口(探测本身暴露)
 
 ```rust
-pub trait TraceSink: Send + Sync { fn record(&self, rec: TraceRecord); }
-pub trait CacheAuditor: Send + Sync { fn judge(&self, input: &JudgmentInput) -> Verdict; }
-pub struct TraceLayer { /* Arc<dyn LanguageModel> + Arc<dyn TraceSink> + Arc<dyn CacheAuditor> */ }
-// RingTraceStore::aggregate / session_chain / export_jsonl
+/// 采集入口:用户回调 sink。库零全局状态,一切显式注入。
+pub trait TraceSink: Send + Sync {
+    fn record(&self, rec: TraceRecord);          // 每请求一次,线程安全
+    fn flush(&self) {}                            // 可选(持久化 sink 用)
+}
+
+/// 内置 sink:有界环形缓冲 + 会话链索引(Send+Sync,内部可变性)
+pub struct RingTraceStore { /* Mutex<VecDeque<Arc<TraceRecord>>> + per-session 索引 */ }
+
+impl RingTraceStore {
+    pub fn with_capacity(n: usize) -> Self;      // 默认 10_000
+    pub fn aggregate(&self, f: &TraceFilter) -> Vec<TraceStats>;
+    pub fn session_chain(&self, session_id: &str) -> Option<SessionChainView>;
+    pub fn export_jsonl(&self, w: &mut impl std::io::Write) -> std::io::Result<()>;
+    pub fn clear(&self);
+}
+
+/// 装饰器(主推荐钩子,不改 trait、不动 provider 实现):
+/// 用户把 Arc<dyn LanguageModel> 包一层,生成/流式双路径自动采集。
+pub struct TraceLayer { /* inner: Arc<dyn LanguageModel>, sink: Arc<dyn TraceSink> */ }
+
+impl TraceLayer {
+    pub fn new(inner: Arc<dyn LanguageModel>, sink: Arc<dyn TraceSink>) -> Self;
+    /// 默认 session_id(CallOptions.session_id 未传时 fallback)+ 会话密钥(指纹 HMAC 脱敏)
+    pub fn with_default_session(self, session_id: String, key: [u8; 32]) -> Self;
+    /// 挂判定引擎(缺省 no-op,verdict=None,不破坏现有流程)
+    pub fn with_auditor(self, auditor: Arc<dyn CacheAuditor>) -> Self;
+}
+impl LanguageModel for TraceLayer { /* do_generate/do_stream 委托 + 计时 + 指纹 + sink.record */ }
 ```
+
+**判定引擎 trait**(可插拔,内置规则引擎,消费方可替换):
+
+```rust
+pub trait CacheAuditor: Send + Sync {
+    fn judge(&self, input: &JudgmentInput) -> Verdict;
+}
+```
+
+**查询接口**(供 ② CLI / ③ 外部消费):
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct TraceFilter {
+    pub provider: Option<String>, pub model: Option<String>,
+    pub session_id: Option<String>, pub since_unix_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct TraceStats {
+    pub provider: String, pub model: String,
+    pub requests: u64,
+    pub input_tokens_total: u64,
+    pub claimed_cache_read_total: u64,           // Σ 服务端上报
+    pub claimed_cache_write_total: u64,
+    pub reported_hit_rate: Option<f64>,          // cache_read / input_total
+    pub client_upper_bound_hit_rate: Option<f64>,// 客户端 LCP token 上界 / input_total
+    pub verdict_counts: BTreeMap<VerdictKind, u64>,  // 掺水判定分布
+    pub ttft_p50_ms: Option<u64>, pub ttft_p95_ms: Option<u64>,
+    pub errors: u64,
+}
+
+// ── 会话级序列分析(append-only 链 + 前缀稳定性)──
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct SessionChainView {
+    pub session_id: String,
+    pub record_ids: Vec<String>,                 // append-only 顺序
+    pub prefix_stability: f64,                   // 相邻请求字节 LCP / 前请求长度的均值(0..=1)
+    pub breaks: Vec<PrefixBreak>,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct PrefixBreak {
+    pub at_record_id: String,
+    pub prev_record_id: String,
+    pub lcp_bytes: u64,                          // 断点处与上一请求的共享字节
+    pub expected_break: bool,                    // 用户提示(如显式改 system)
+    pub kind: BreakKind,                         // SystemChanged / ToolsChanged / ConversationReset / Unknown
+}
+```
+
+**JSONL 导出格式**:`export_jsonl` 每行一个 `TraceRecord`(serde JSON)。供 ② CLI 离线分析(读文件跑审计/诊断),与 [RFC-0023](0023-runtime-request-recording.md) 的录制 jsonl 并存(不同文件,内容不同:探测=哈希,录制=明文,trace_id 可互查)。
 
 ---
 
-## 6. TraceStore:TTL 窗口、内存与作用域(完整设计见 [round-3-design.md](../docs/internal/cache-tracing/rounds/round-3-design.md))
+## 6. TraceStore:TTL 窗口、内存与作用域
 
 - **TTL_idle 语义修正**:provider 缓存是**空闲淘汰**而非绝对 TTL(前缀持续使用就常驻)。判定:`now − last_touch(P) ≤ TTL_idle` 才可作为上界;**TTL_idle 宁可高估**(低估→误报,高估→少判,安全方向)
 - TTL 表:OpenAI 60min(5.6+ 显式 30m;extended 24h)/ Anthropic 5m-1h / Gemini 24h / DeepSeek 48h / 自托管 ∞
@@ -146,18 +263,21 @@ pub struct TraceLayer { /* Arc<dyn LanguageModel> + Arc<dyn TraceSink> + Arc<dyn
 
 补查结论(2026-07-08 官方文档):Azure gpt-5.6 保持 128-token 粒度且不报 cache_write;Groq 自动缓存 2h 无使用过期(仅 GPT-OSS 3 模型);Qwen 显式+implicit 双模互斥(≥256 token,20-block 回看);Kimi/Moonshot 自动缓存(>256 token,interleaved thinking 丢命中)。
 
+**矩阵的消费方**:矩阵数据(provider 能力档位)是探测本身的**判定参数**(gran/量化/降级规则),进 core;矩阵的"哪些 provider 值得探测、怎么展示结果"是 ② CLI 的展示逻辑,不进 core。
+
 ---
 
-## 8. 上游 P0 改动清单(逐行方案见 [round-4-p0-integration-binding.md](../docs/internal/cache-tracing/rounds/round-4-p0-integration-binding.md))
+## 8. 与录制/回放的协同(2026-08-05 新增)
 
-| # | 改动 | 文件 | 破坏面 |
-|---|---|---|---|
-| P0-1 | `StreamTextResult` 增加 `request_body`/`response_headers`(无 serde,零破坏);FFI 用现有 `Raw{raw_value}` 变体插合成 part 透传(StreamStart 之后发射) | generate.rs、aimux-ffi/src/lib.rs | 编译零破坏;FFI 多 1 个 part(低) |
-| P0-2 | Anthropic 非流式 + message_start 走 `convert_anthropic_usage` 补 cache 字段;vertex/anthropic_model.rs 同修;**⚠ 行为变更:`Usage.input_tokens.total` 语义从"末断点后"改为"三字段和"** | anthropic/stream.rs、anthropic/types.rs、vertex/anthropic_model.rs | 既有 fixture 输出不变 |
-| P0-3 | `Usage.raw` 填充(13 处构造点;4 处零改 + 7 处 1 行/derive + 2 处随 P0-2) | 8 个 provider 文件 | FFI JSON additive 新键,ts_rs 不变 |
-| P0-4 | 时间戳:wrapper 自己记 Instant+SystemTime,结果类型不加字段 | — | 无 |
+| 协同点 | 机制 | 归属 |
+|---|---|---|
+| **离线明文深查** | 探测在线只存哈希(常开安全);深查可疑 verdict 时用 trace_id 拉 [RFC-0023](0023-runtime-request-recording.md) 的明文录制跑完整 LCP 定位"哪段前缀掺水" | 探测暴露 trace_id,RFC-0023 存明文,trace_id 互查 |
+| **缓存可复现性验证** | 对同一录制多次[请求回放](0023-runtime-request-recording.md)(重发真实 API),跑探测算法看 verdict 是否稳定(验证 provider 缓存稳定性/抖动) | ② CLI 组合两者 |
+| **共享 ring-store 模式** | 探测的 `RingTraceStore` 与录制的 `RingRecorder` 共用 FIFO 环形 + TTL 过期 + export 模式,类型不同(`TraceRecord` vs `Recording`);先实施方定义抽象,后实施方复用 | core 内协调 |
+| **共享 LCP/前缀算法** | 探测的块哈希链 LCP 与回放的 `PrefixMatcher`(RFC-0023)共用"前缀最长公共匹配"算法模块 | core 内协调 |
+| **session_id 统一** | 探测/录制/回放共用 [RFC-0024](0024-session-aggregation.md) 的 `CallOptions.session_id` 归组 | RFC-0024 |
 
-**8 语言绑定零改动**(逐语言核验):C/Kotlin/Java/Node 透传或类型断言宽容;Go 任意单 key 宽容解析;Python `_SPRaw` 已存在;Swift `case "Raw"` 已存在;Flutter `StreamPartRaw` + Unknown 兜底。必要条件:用现有 Raw 变体、发射在 StreamStart 后、meta 结构对外 opaque。
+**告警闭环(③外部消费,远期)**:探测 verdict → 外部应用告警"provider 掺水" → 回放策略切换(RFC-0021 RouterModel 对该 provider 优先用客户端 mock 回放)。这是三者的终极闭环,但属外部应用逻辑,本 RFC 只保证数据可消费。
 
 ---
 
@@ -183,7 +303,8 @@ pub struct TraceLayer { /* Arc<dyn LanguageModel> + Arc<dyn TraceSink> + Arc<dyn
 3. **真实 provider 数据回放验证**:Azure 128 量化 vs OpenAI 5.6+ 字节精确双轨分派、字节代理偏差——依赖真实 API 响应回放
 4. **原型同步**:块上界 (j+1)B 与字节代理 W 封顶 B 的规则定案(F2/F3)需同步进原型 verdict 逻辑
 5. **FFI meta 体积**:200KB request_body 序列化翻倍,建议加 `meta_cap_bytes` 配置
-6. **依赖 RFC-0014**:span 树(generate → http_request)挂载审计数据、TTFT 观测点
+6. **依赖 RFC-0014**:span 树(generate → http_request)挂载探测数据、TTFT 观测点
+7. **依赖 RFC-0024**:`CallOptions.session_id` 字段落地后,探测的 session 归组改用该字段(替代 wrapper 实例注入)
 
 ---
 
@@ -194,4 +315,7 @@ pub struct TraceLayer { /* Arc<dyn LanguageModel> + Arc<dyn TraceSink> + Arc<dyn
 - 双级对比:语义级 LCP(规范化 LanguageModelPrompt,诊断 UX)与字节级 LCP(准绳)分离
 - per-process 默认追踪;不变量在进程作用域成立,跨进程命中判 UNKNOWN(strict/shared 双模式)
 - reported 与 client_upper_bound 双指标并列,不合成单值
+- **2026-08-05:三层拆分**——探测本身进 core(常开 infrastructure),探测业务进 `tools/aimux-cli`(独立 client,基于 aimux 构建),告警外部消费。RFC-0015 收窄为"探测本身"。
+- **2026-08-05:session_id 统一**——探测的 session 归组改用 RFC-0024 的 `CallOptions.session_id`,`with_session` 降级为默认值 + 会话密钥注入。
+- **2026-08-05:审计业务逻辑移出**——漂移检测警报、漏报侧独立计数、UNKNOWN 护栏降级归 ② CLI / ③ 外部;core 只暴露 `TraceStats` + verdict 分布。
 - 调查与设计存档:docs/internal/cache-tracing/(working doc + rounds/ + prototype/)

--- a/rfc/0025-aimux-cli-cache-probe.md
+++ b/rfc/0025-aimux-cli-cache-probe.md
@@ -1,0 +1,167 @@
+# RFC-0025: aimux-cli — 缓存探测 client
+
+> **Status**: DRAFT (pending review)
+> **Date**: 2026-08-05
+> **Scope**: 本 repo 内新增 `tools/aimux-cli` crate——基于 aimux 构建的独立可运行二进制(client),第一版只做缓存探测业务(审计/诊断/调试指定 provider 的缓存能力),回放/通用调试子命令后续按需加
+> **Related**: [RFC-0015](0015-cache-trace-audit.md) 缓存命中探测(本 CLI 消费其数据与查询接口)、[RFC-0023](0023-runtime-request-recording.md) 录制与回放(离线数据源)、[RFC-0024](0024-session-aggregation.md) 会话聚合(session 级诊断)
+
+---
+
+## 1. Motivation
+
+缓存探测拆三层(见 [RFC-0015 §1.2](0015-cache-trace-audit.md)):① 探测本身进 core(常开 infrastructure,采集/判定/存储/查询接口),② 探测业务做独立 client,③ 告警外部消费。
+
+**为什么探测业务要做成独立 client 而非 SDK 集成**:
+
+1. **两套逻辑**:SDK 集成是库路径——开发者在自己的应用里调 aimux,`TraceLayer` 包一层,探测数据进 `RingTraceStore`,然后自己消费。探测业务 client 是独立产物路径——直接 run 一个二进制,探测指定 provider 的缓存能力,不需要宿主应用。
+2. **调试工具定位**:开发者想快速回答"这个 provider 的缓存到底靠不靠谱"——不该为此写一个应用,该有一个现成工具。
+3. **不污染库二进制**:探测业务逻辑(审计/诊断/展示)进 core 会膨胀库、绑定业务判断;独立 crate 保持 core 纯净。
+
+**为什么 client 放在本 repo 内**(而非独立 repo):aimux-cli 是 aimux 生态的调试产物,与 core 的探测接口强耦合(接口演进同步),放同一 workspace 便于协同开发与版本一致。它是 **aimux 的"产物"**(基于 aimux 构建的 client),不是 aimux 的一部分——`aimux-core` 不依赖它,它依赖 `aimux-core`。
+
+---
+
+## 2. Design Goals
+
+1. **独立可运行**:`cargo run -p aimux-cli`(或安装后 `aimux`)即可用,不要求宿主应用集成。
+2. **薄 client**:只做探测业务的消费逻辑,探测算法/判定/存储全在 core(RFC-0015)。
+3. **两种数据源**:进程内查询(core 的 `RingTraceStore` 查询接口)+ 离线 jsonl(core `export_jsonl` 导出的 TraceRecord,或 RFC-0023 录制文件)。
+4. **面向调试**:输出人可读报告(审计 summary / 链级命中演变 / prompt 结构诊断),不是机器 API。
+5. **渐进式**:第一版只做缓存探测子命令,回放/通用调试后续按需加。
+
+---
+
+## 3. CLI 形态
+
+### 3.1 位置与命名
+
+```
+tools/aimux-cli/
+├── Cargo.toml        # package name = "aimux-cli",[[bin]] name = "aimux"
+├── src/
+│   ├── main.rs       # 子命令分发(clap)
+│   ├── probe/        # 缓存探测子命令
+│   │   ├── mod.rs
+│   │   ├── online.rs   # 进程内数据源(连 core RingTraceStore 查询)
+│   │   └── offline.rs  # 离线 jsonl 数据源(读 export_jsonl 输出)
+│   └── report.rs     # 人可读报告渲染
+```
+
+加入 workspace members(`Cargo.toml` `members` 数组),`[workspace.dependencies]` 复用。
+
+### 3.2 子命令(第一版:探测)
+
+```text
+aimux cache-probe <SUBCOMMAND>
+
+子命令:
+  online    进程内查询:连上宿主应用导出的探测数据(经 core 查询接口)
+            --provider <name> --model <id> --session <session_id> --since <ms>
+  offline   离线分析:读 core export_jsonl 导出的 TraceRecord jsonl
+            --file <trace.jsonl> --provider <name> [--session <session_id>]
+  session   会话级诊断:读离线 jsonl,输出指定 session 的链级命中演变
+            --file <trace.jsonl> --session <session_id>
+  provider  探测指定 provider 的缓存能力:直接调 aimux provider 发测试请求,
+            跑探测算法,输出该 provider 的缓存能力报告
+            --provider <name> --model <id> --api-key <env:VAR> [--base-url <url>]
+```
+
+**第一版范围**:`offline` + `session` + `provider`(调试指定 provider 缓存的核心诉求)。`online`(连活进程)后续——aimux 是库不是服务,没有常驻进程给 CLI 连,online 形态需再设计(可能经共享内存/Unix socket 或只留 jsonl 路径)。
+
+### 3.3 数据源(两种)
+
+| 数据源 | 内容 | 来源 | 用途 |
+|---|---|---|---|
+| **TraceRecord jsonl(离线)** | 探测哈希数据(指纹/usage/verdict) | core `RingTraceStore::export_jsonl` 或外部 `TraceSink` 落盘 | `offline`/`session` 审计诊断 |
+| **录制 jsonl(RFC-0023)** | 明文完整上下文(输入/配置/HTTP) | core `JsonlRecorder` | 深查可疑 verdict 时拉明文跑完整 LCP;缓存可复现性验证(多次请求回放 + 探测对比) |
+
+两者以 `trace_id` 关联(RFC-0015 §8 协同)。CLI 的 `provider` 子命令是**在线探测**(直接调 provider 发请求),不依赖数据源。
+
+---
+
+## 4. 与 core 探测接口的关系
+
+CLI **只消费** core 暴露的接口(RFC-0015 §5.3),不实现探测算法:
+
+| core 暴露(已设计) | CLI 消费方式 |
+|---|---|
+| `TraceRecord` 结构(serde,jsonl 可读) | `offline` 读文件反序列化 |
+| `TraceStats` / `TraceFilter` 聚合 | `offline --provider X` 输出统计 |
+| `SessionChainView` / `PrefixBreak` | `session --session X` 输出链级诊断 |
+| `CacheAuditor` / 判定规则(内置) | `provider` 子命令:发测试请求 → 挂 `TraceLayer` + 内置 auditor → 读 verdict |
+| `LanguageModel` / `provider()`(aimux-providers) | `provider` 子命令构造指定 provider 发请求 |
+
+**不消费**(core 不暴露的,CLI 也不做):告警阈值决策(③外部)、调优建议生成、预判决策。
+
+---
+
+## 5. 与现有 RFC 的关系
+
+| RFC | 关系 |
+|-----|------|
+| [RFC-0015](0015-cache-trace-audit.md) | **主依赖**。本 CLI 是 ① 探测本身的 ② 业务 client,消费其查询接口与 jsonl。 |
+| [RFC-0023](0023-runtime-request-recording.md) | **协同**。离线深查用录制明文;缓存可复现性验证用请求回放 + 探测组合。 |
+| [RFC-0024](0024-session-aggregation.md) | **协同**。session 级诊断消费 session_id 归组(离线 TraceRecord 自带 session_id)。 |
+| [RFC-0021](0021-composite-model-routing.md) | **远期闭环**。探测 verdict → 外部告警 → RouterModel 切换回放策略。CLI 只出数据,不做决策。 |
+
+---
+
+## 6. Non-Goals(第一版)
+
+1. **不做 `online` 连活进程**(aimux 是库,无常驻进程;形态待定,可能仅留 jsonl 路径)。
+2. **不做回放子命令**(`replay` 属于 RFC-0023 的消费,第一版只做探测;后续按需加)。
+3. **不做通用调试子命令**(单次 generate_text 调用调试)。
+4. **不做告警/报表**(③外部消费;CLI 只输出人可读报告,不做持续监控)。
+5. **不做调优建议**(自动改 prompt 提升命中是应用层逻辑)。
+6. **不实现探测算法**(判定/LCP/存储全在 core,CLI 只消费)。
+
+---
+
+## 7. Scope of Changes
+
+| 位置 | 改动 | 工作量 |
+|------|------|--------|
+| `Cargo.toml` | workspace members 加 `"tools/aimux-cli"` | 1 行 |
+| `tools/aimux-cli/Cargo.toml` | package + bin + deps(clap/tokio/aimux-core/aimux-providers/aimux-provider-utils/serde_json) | ~30 行 |
+| `tools/aimux-cli/src/main.rs` | clap 子命令分发 | ~60 行 |
+| `tools/aimux-cli/src/probe/offline.rs` | 读 TraceRecord jsonl → 审计统计 + 报告 | ~200 行 |
+| `tools/aimux-cli/src/probe/session.rs` | 读 jsonl → session 链级诊断 + 报告 | ~150 行 |
+| `tools/aimux-cli/src/probe/provider.rs` | 构造 provider → 发测试请求 → 挂 TraceLayer + auditor → 报告 | ~200 行 |
+| `tools/aimux-cli/src/report.rs` | 人可读报告渲染(表格式) | ~100 行 |
+| 测试 | 离线解析 + 报告 + provider 探测(用 cassette 或 mock) | ~200 行 |
+
+**合计:~700-900 行(第一版)。依赖 RFC-0015 的探测接口落地(core 先做,P0 改动)。**
+
+---
+
+## 8. Risks
+
+| 风险 | 等级 | 对策 |
+|------|------|------|
+| **依赖 RFC-0015 接口未落地** | 高 | CLI 第一版与 RFC-0015 的 core 实现协同开发;先做离线(jsonl)路径(只依赖 TraceRecord serde,依赖面最小) |
+| **`provider` 子命令消耗真实 API 费用** | 中 | 默认用最短测试 prompt(单轮,~100 token);`--max-requests N` 限制;文档警示 |
+| **`online` 形态不明**(库无常驻进程) | 中 | 第一版不做 online;只做 offline(jsonl)+ provider(直接调)。online 待设计(共享内存/Unix socket/仅 jsonl) |
+| **CLI 与 core 版本漂移** | 低 | 同 workspace,版本一致;TraceRecord serde 是契约,改格式需同步 |
+
+---
+
+## 9. Open Questions
+
+1. **二进制命名**:`aimux` 还是 `aimux-cli`?建议 `aimux`(命令短,与库 crate 名区分),但可能与将来别的 aimux 命令冲突——待定。
+2. **`provider` 子命令的测试 prompt 设计**:测缓存能力需要"两次相同前缀请求"验证命中(第一次写,第二次读)。用固定模板 prompt?还是可配?建议固定模板 + `--prompt` 可覆盖。
+3. **`online` 形态**:aimux 是库不是服务,CLI 怎么连进程内 RingTraceStore?候选:Unix socket / 共享内存 / 只留 jsonl(应用自己 export)。建议第一版只留 jsonl,online 取消或远期。
+4. **报告格式**:文本表格 vs JSON 输出?建议 `--format text|json`(text 给人,json 给脚本)。
+
+---
+
+## 10. Implementation Order
+
+| 阶段 | 内容 | 依赖 | 状态 |
+|------|------|------|------|
+| **P1** | `offline` 子命令:读 TraceRecord jsonl → 审计统计 + 报告 | RFC-0015 P0(core TraceRecord serde + export_jsonl) | 待实施 |
+| **P2** | `session` 子命令:会话级诊断 + 报告 | RFC-0015 P1(session_chain),RFC-0024(session_id) | 待实施 |
+| **P3** | `provider` 子命令:直接调 provider 探测缓存能力 | RFC-0015 P1(TraceLayer + auditor 落地) | 待实施 |
+| **P4**(后续) | `replay` 子命令(RFC-0023 消费)+ 通用调试 | RFC-0023 落地 | 不做(第一版) |
+| **P5**(待定) | `online` 形态(Unix socket / 共享内存 / 仅 jsonl) | 设计先行 | 待定 |
+
+**建议顺序**:P1(离线审计,依赖面最小)→ P3(在线探测 provider)→ P2(会话诊断)。第一版交付 = P1 + P2 + P3,即 `offline`/`session`/`provider` 三个子命令。


### PR DESCRIPTION
## 概述

承接已合并的 #44(RFC-0020~0024),按讨论结论对齐缓存探测的需求与目的。

## 变更内容

### RFC-0015 重写:从"缓存审计"收窄为"探测本身"(core infrastructure)

三层拆分对齐:

```
① 探测本身(core,本 RFC)— 采集+判定+存储+查询接口,常开
② 探测业务 client(tools/aimux-cli)— 独立可运行产物,基于 aimux 构建
③ 告警/校准/跟踪(外部)— core 只暴露数据接口,不直接做业务
```

具体调整:
- **审计业务逻辑移出 core**:漂移检测警报、漏报侧独立计数、UNKNOWN 护栏降级归 CLI/外部;core 只保留 `TraceStats` + verdict 分布
- **session_id 来源统一**:改用 RFC-0024 的 `CallOptions.session_id`;`with_session` 降级为默认 session + HMAC 密钥注入
- **新增协同章节**:与录制(RFC-0023)离线明文深查(trace_id 互查)、缓存可复现性验证(请求回放)、共享 ring-store/LCP 算法
- **判定矩阵定位**:provider 能力档位是判定参数进 core;展示逻辑归 CLI

### RFC-0025 新增:aimux-cli — 缓存探测 client

- `tools/aimux-cli`(workspace 内独立 crate),二进制 `aimux`,**基于 aimux 构建的产物,不是 aimux 的一部分**(core 不依赖它,它依赖 core)
- 第一版子命令:`offline`(读 TraceRecord jsonl 审计)/ `session`(会话级诊断)/ `provider`(直接调 provider 探测缓存能力)
- 渐进式:回放/通用调试子命令后续按需加
- 只消费 core 暴露的接口,不实现探测算法

## 检查清单

- [x] 2 个 RFC 均为 DRAFT
- [x] pre-commit 通过(fmt + check)
- [x] pre-push 通过(clippy + 全量测试 0 failed)
- [x] 纯文档,无代码改动