### PR TITLE
feat(ffi,go): add cancellable text streams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,13 @@ jobs:
           export CGO_LDFLAGS="-L${{ github.workspace }}/target/release"
           go vet ./...
           go test ./...
+      - name: Race test Go binding
+        if: runner.os == 'Linux'
+        working-directory: bindings/go
+        shell: bash
+        run: |
+          export CGO_LDFLAGS="-L${{ github.workspace }}/target/release"
+          go test -race ./...
 
   # ── Flutter binding: plugin structure + Dart tests (host FFI lib) ─────────
   flutter-binding:

--- a/aimux-ffi/aimux-ffi.h
+++ b/aimux-ffi/aimux-ffi.h
@@ -253,6 +253,50 @@ void aimux_stream_text(uint64_t handle,
                        void (*on_done)(void),
                        void (*on_error)(const char *err_json));
 
+/**
+ * Create a per-call abort signal.
+ *
+ * @return A non-zero abort handle. Release it with aimux_abort_signal_drop.
+ */
+uint64_t aimux_abort_signal_new(void);
+
+/**
+ * Request cancellation. Invalid handles and repeated calls are safe.
+ *
+ * @param abort_handle Handle from aimux_abort_signal_new.
+ */
+void aimux_abort_signal_abort(uint64_t abort_handle);
+
+/**
+ * Release an abort handle. Active calls keep their signal alive.
+ *
+ * @param abort_handle Handle from aimux_abort_signal_new. Zero is safe.
+ */
+void aimux_abort_signal_drop(uint64_t abort_handle);
+
+/**
+ * Streaming text generation with per-call cancellation.
+ *
+ * This function blocks until the stream ends. Another thread can call
+ * aimux_abort_signal_abort while this function runs. Cancellation calls
+ * on_error with an Aborted error and does not call on_done.
+ *
+ * @param handle       Model handle from aimux_*_new.
+ * @param abort_handle Handle from aimux_abort_signal_new.
+ * @param prompt_json  JSON prompt.
+ * @param opts_json    JSON options. NULL or empty uses defaults.
+ * @param on_part      Called for each StreamPart.
+ * @param on_done      Called once after normal completion.
+ * @param on_error     Called once after an error or cancellation.
+ */
+void aimux_stream_text_with_abort(uint64_t handle,
+                                  uint64_t abort_handle,
+                                  const char *prompt_json,
+                                  const char *opts_json,
+                                  void (*on_part)(const char *json),
+                                  void (*on_done)(void),
+                                  void (*on_error)(const char *err_json));
+
 /* ── Resource management ────────────────────────────────────────────────── */
 
 /**

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -40,6 +40,7 @@ use aimux_core::generate::{GenerateTextOptions, generate_text, stream_text};
 use aimux_core::language_model::LanguageModel;
 use aimux_core::message::ModelPrompt;
 use aimux_core::provider::Provider;
+use aimux_core::shared::AbortSignal;
 use aimux_providers::anthropic::{AnthropicConfig, AnthropicProvider};
 use aimux_providers::anthropic_aws::{AnthropicAwsProvider, AnthropicAwsProviderConfig};
 use aimux_providers::azure::{AzureConfig, AzureProvider};
@@ -60,7 +61,7 @@ use tokio::runtime::Runtime;
 // Global state: handle registry + tokio runtime
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// A type-erased model handle. One registry holds all modalities.
+/// A type-erased FFI handle. One registry holds models and abort signals.
 #[derive(Clone)]
 enum ModelHandle {
     Language(Arc<dyn LanguageModel>),
@@ -72,6 +73,7 @@ enum ModelHandle {
     Video(Arc<dyn aimux_core::video_model::VideoModel>),
     Search(Arc<dyn aimux_core::search_model::SearchModel>),
     Files(Arc<dyn aimux_core::files_model::Files>),
+    Abort(AbortSignal),
 }
 
 type ModelRegistry = HashMap<u64, ModelHandle>;
@@ -121,12 +123,28 @@ fn get_handle(handle: u64) -> Option<ModelHandle> {
         .cloned()
 }
 
+fn get_abort_signal(handle: u64) -> Option<AbortSignal> {
+    match get_handle(handle)? {
+        ModelHandle::Abort(signal) => Some(signal),
+        _ => None,
+    }
+}
+
 /// Remove a handle from the registry (the model drops when the last ref goes).
 fn drop_handle(handle: u64) {
     registry()
         .lock()
         .expect("aimux-ffi: registry mutex poisoned")
         .remove(&handle);
+}
+
+fn drop_abort_signal(handle: u64) {
+    let mut registry = registry()
+        .lock()
+        .expect("aimux-ffi: registry mutex poisoned");
+    if matches!(registry.get(&handle), Some(ModelHandle::Abort(_))) {
+        registry.remove(&handle);
+    }
 }
 
 /// The shared tokio runtime driving all async provider calls.
@@ -855,6 +873,89 @@ pub extern "C" fn aimux_stream_text(
     on_done: extern "C" fn(),
     on_error: extern "C" fn(*const c_char),
 ) {
+    stream_text_with_signal(
+        handle,
+        prompt_json,
+        opts_json,
+        on_part,
+        on_done,
+        on_error,
+        None,
+    );
+}
+
+/// Create a per-call abort signal for a cancelable FFI operation.
+///
+/// The caller must release the returned handle with
+/// [`aimux_abort_signal_drop`].
+#[unsafe(no_mangle)]
+pub extern "C" fn aimux_abort_signal_new() -> u64 {
+    intern_handle(ModelHandle::Abort(AbortSignal::new()))
+}
+
+/// Request cancellation for an abort-signal handle.
+///
+/// Invalid handles and repeated calls are no-ops.
+#[unsafe(no_mangle)]
+pub extern "C" fn aimux_abort_signal_abort(handle: u64) {
+    if let Some(signal) = get_abort_signal(handle) {
+        signal.abort();
+    }
+}
+
+/// Release an abort-signal handle.
+///
+/// This function does not remove model handles if the caller passes the wrong
+/// handle type. Active calls keep their cloned signal alive.
+#[unsafe(no_mangle)]
+pub extern "C" fn aimux_abort_signal_drop(handle: u64) {
+    if handle != 0 {
+        drop_abort_signal(handle);
+    }
+}
+
+/// Stream text with a per-call abort signal.
+///
+/// This function blocks like [`aimux_stream_text`]. Another thread can call
+/// [`aimux_abort_signal_abort`] with `abort_handle` to stop this call.
+#[unsafe(no_mangle)]
+pub extern "C" fn aimux_stream_text_with_abort(
+    handle: u64,
+    abort_handle: u64,
+    prompt_json: *const c_char,
+    opts_json: *const c_char,
+    on_part: extern "C" fn(*const c_char),
+    on_done: extern "C" fn(),
+    on_error: extern "C" fn(*const c_char),
+) {
+    let abort_signal = match get_abort_signal(abort_handle) {
+        Some(signal) => signal,
+        None => {
+            fire_error(on_error, "invalid abort handle");
+            return;
+        }
+    };
+    stream_text_with_signal(
+        handle,
+        prompt_json,
+        opts_json,
+        on_part,
+        on_done,
+        on_error,
+        Some(abort_signal),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn stream_text_with_signal(
+    handle: u64,
+    prompt_json: *const c_char,
+    opts_json: *const c_char,
+    on_part: extern "C" fn(*const c_char),
+    on_done: extern "C" fn(),
+    on_error: extern "C" fn(*const c_char),
+    abort_signal: Option<AbortSignal>,
+) {
     let model = match get_model(handle) {
         Some(m) => m,
         None => {
@@ -877,7 +978,7 @@ pub extern "C" fn aimux_stream_text(
         }
     };
 
-    let opts = match cstr_to_string(opts_json) {
+    let mut opts = match cstr_to_string(opts_json) {
         Some(s) => match parse_opts(&s) {
             Ok(o) => o,
             Err(e) => {
@@ -887,13 +988,39 @@ pub extern "C" fn aimux_stream_text(
         },
         None => GenerateTextOptions::default(),
     };
+    opts.abort_signal = abort_signal.clone();
 
     runtime().block_on(async move {
-        let stream_result = stream_text(&*model, prompt, opts).await;
+        let stream_result = match abort_signal.as_ref() {
+            Some(signal) => {
+                tokio::select! {
+                    biased;
+                    _ = signal.cancelled() => Err(AiMuxError::Aborted),
+                    result = stream_text(&*model, prompt, opts) => result,
+                }
+            }
+            None => stream_text(&*model, prompt, opts).await,
+        };
         match stream_result {
             Ok(sr) => {
                 let mut stream = sr.stream;
-                while let Some(item) = stream.next().await {
+                loop {
+                    let next = match abort_signal.as_ref() {
+                        Some(signal) => {
+                            tokio::select! {
+                                biased;
+                                _ = signal.cancelled() => {
+                                    fire_error_struct(on_error, &AiMuxError::Aborted);
+                                    return;
+                                }
+                                item = stream.next() => item,
+                            }
+                        }
+                        None => stream.next().await,
+                    };
+                    let Some(item) = next else {
+                        break;
+                    };
                     match item {
                         Ok(part) => {
                             let json =

--- a/aimux-ffi/tests/error_detail_test.rs
+++ b/aimux-ffi/tests/error_detail_test.rs
@@ -16,12 +16,14 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde_json::Value;
 
 use aimux_ffi::{
-    aimux_azure_new, aimux_drop_handle, aimux_free_string, aimux_generate_text, aimux_openai_new,
-    aimux_provider_new, aimux_stream_text,
+    aimux_abort_signal_abort, aimux_abort_signal_drop, aimux_abort_signal_new, aimux_azure_new,
+    aimux_drop_handle, aimux_free_string, aimux_generate_text, aimux_openai_new,
+    aimux_provider_new, aimux_stream_text, aimux_stream_text_with_abort,
 };
 
 fn c(s: &str) -> CString {
@@ -144,6 +146,53 @@ fn stream_text_invalid_prompt_json_carries_serde_detail() {
     );
 
     aimux_drop_handle(h);
+}
+
+static CANCEL_ERRORS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static CANCEL_DONE: AtomicUsize = AtomicUsize::new(0);
+
+extern "C" fn on_cancel_done() {
+    CANCEL_DONE.fetch_add(1, Ordering::Relaxed);
+}
+
+extern "C" fn on_cancel_error(json: *const c_char) {
+    // SAFETY: the FFI layer keeps the string alive for this callback.
+    let value = unsafe { CStr::from_ptr(json) }
+        .to_str()
+        .unwrap()
+        .to_string();
+    CANCEL_ERRORS.lock().unwrap().push(value);
+}
+
+#[test]
+fn stream_text_with_pre_aborted_signal_reports_aborted() {
+    let model = valid_handle();
+    let abort = aimux_abort_signal_new();
+    assert_ne!(abort, 0);
+    CANCEL_ERRORS.lock().unwrap().clear();
+    CANCEL_DONE.store(0, Ordering::Relaxed);
+
+    aimux_abort_signal_abort(abort);
+    aimux_stream_text_with_abort(
+        model,
+        abort,
+        c("\"hello\"").as_ptr(),
+        ptr::null(),
+        on_part,
+        on_cancel_done,
+        on_cancel_error,
+    );
+
+    let errors = CANCEL_ERRORS.lock().unwrap().clone();
+    assert_eq!(errors.len(), 1, "expected one cancellation error");
+    let env: Value = serde_json::from_str(&errors[0]).expect("error must be JSON");
+    assert_eq!(env["error_type"], "Aborted");
+    assert_eq!(CANCEL_DONE.load(Ordering::Relaxed), 0);
+
+    aimux_abort_signal_abort(abort);
+    aimux_abort_signal_drop(abort);
+    aimux_abort_signal_drop(abort);
+    aimux_drop_handle(model);
 }
 
 // ── Problem B: constructor failures in the returned envelope ────────────────

--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -44,12 +44,14 @@ static void trampoline_error(const char* err) {
     if (current_stream_id) goStreamError(current_stream_id, (char*)err);
 }
 
-// do_stream: set thread-local ID, call the blocking stream function, clear ID.
-// The callbacks fire synchronously during this call.
-static void do_stream(uint64_t handle, const char* prompt, const char* opts, int64_t id) {
+// do_stream: set the thread-local ID, call the blocking cancelable stream
+// function, then clear the ID. The callbacks fire during this call.
+static void do_stream(uint64_t handle, uint64_t abort_handle,
+                      const char* prompt, const char* opts, int64_t id) {
     current_stream_id = id;
-    aimux_stream_text(handle, prompt, opts,
-                      trampoline_part, trampoline_done, trampoline_error);
+    aimux_stream_text_with_abort(handle, abort_handle, prompt, opts,
+                                 trampoline_part, trampoline_done,
+                                 trampoline_error);
     current_stream_id = 0;
 }
 
@@ -109,6 +111,7 @@ char *aimux_search(uint64_t handle, const char *opts_json);
 import "C"
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -586,10 +589,14 @@ func extractError(result string) string {
 
 // streamEntry holds the channel and error for an active stream.
 type streamEntry struct {
-	parts chan string
-	mu    sync.Mutex
-	err   error
-	once  sync.Once
+	parts        chan string
+	mu           sync.Mutex
+	err          error
+	closeOnce    sync.Once
+	terminalOnce sync.Once
+	terminal     chan struct{}
+	cancelled    chan struct{}
+	abortHandle  uint64
 }
 
 // streamRegistry maps stream IDs to active stream entries. This avoids passing
@@ -601,11 +608,16 @@ var (
 	streamNextID int64
 )
 
-func registerStream() (*streamEntry, int64) {
+func registerStream(abortHandle uint64) (*streamEntry, int64) {
 	streamRegMu.Lock()
 	defer streamRegMu.Unlock()
 	streamNextID++
-	e := &streamEntry{parts: make(chan string, 256)}
+	e := &streamEntry{
+		parts:       make(chan string, 256),
+		terminal:    make(chan struct{}),
+		cancelled:   make(chan struct{}),
+		abortHandle: abortHandle,
+	}
 	streamReg[streamNextID] = e
 	return e, streamNextID
 }
@@ -626,19 +638,39 @@ func unregisterStream(id int64) {
 // against the engine firing both on_done and on_error for the same stream
 // (which would otherwise panic on double close).
 func (e *streamEntry) closeParts() {
-	e.once.Do(func() { close(e.parts) })
+	e.closeOnce.Do(func() { close(e.parts) })
+}
+
+// markTerminal records the first terminal result. A cancellation also wakes
+// callbacks that are waiting to send to a full parts channel.
+func (e *streamEntry) markTerminal(err error, cancelled bool) bool {
+	marked := false
+	e.terminalOnce.Do(func() {
+		marked = true
+		e.mu.Lock()
+		e.err = err
+		e.mu.Unlock()
+		if cancelled {
+			close(e.cancelled)
+		}
+		close(e.terminal)
+	})
+	return marked
+}
+
+func (e *streamEntry) cancel(err error) {
+	if err == nil {
+		err = context.Canceled
+	}
+	if e.markTerminal(err, true) && e.abortHandle != 0 {
+		C.aimux_abort_signal_abort(C.uint64_t(e.abortHandle))
+	}
 }
 
 // Stream is a handle to an in-progress or completed stream.
 // Consume parts via the Parts() channel; check Err() after the channel closes.
 //
-// The channel is buffered (256). If the caller stops consuming, the native
-// stream will block on the 257th part and the stream goroutine (plus the
-// underlying model call) will stall until the stream ends or times out —
-// always drain the channel. There is no context-cancel API (the C ABI
-// stream is synchronous and has no abort hook); the only interruption
-// mechanism is a per-call timeout via GenerateTextOptions.Timeout
-// (RFC-0016 H3).
+// The channel is buffered (256). Call Cancel when the caller stops consuming.
 type Stream struct {
 	parts <-chan string
 	entry *streamEntry
@@ -656,6 +688,11 @@ func (s *Stream) Err() error {
 	return s.entry.err
 }
 
+// Cancel stops this stream. It is safe to call more than once.
+func (s *Stream) Cancel() {
+	s.entry.cancel(context.Canceled)
+}
+
 // StreamText performs streaming text generation.
 //
 // It returns immediately with a *Stream. Consume parts via stream.Parts():
@@ -668,29 +705,45 @@ func (s *Stream) Err() error {
 //	    log.Fatal(err)
 //	}
 //
-// You MUST drain the Parts() channel. If you stop reading, the native
-// callback blocks once the 256-part buffer fills, stalling the stream
-// goroutine and the model until the stream ends or the per-call timeout
-// fires (GenerateTextOptions.Timeout, RFC-0016 H3). There is no
-// context-cancel API — the C ABI stream is synchronous and has no abort
-// hook.
+// Drain the Parts channel or call Cancel when you stop reading. Use
+// StreamTextContext to connect cancellation to a context.
 func (m *Model) StreamText(promptJson, optsJson string) *Stream {
-	entry, id := registerStream()
+	return m.StreamTextContext(context.Background(), promptJson, optsJson)
+}
+
+// StreamTextContext performs streaming text generation. Context cancellation
+// stops the native request and makes Err return the context error.
+func (m *Model) StreamTextContext(ctx context.Context, promptJson, optsJson string) *Stream {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	abortHandle := uint64(C.aimux_abort_signal_new())
+	entry, id := registerStream(abortHandle)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			entry.cancel(ctx.Err())
+		case <-entry.terminal:
+		}
+	}()
 
 	go func() {
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 		defer unregisterStream(id)
+		defer C.aimux_abort_signal_drop(C.uint64_t(abortHandle))
 		// Safety net: ensure the channel is always closed even if the
 		// native layer never fires on_done/on_error (defensive against
 		// future bugs or panic edges in the FFI layer).
-		defer entry.closeParts()
+		defer func() {
+			entry.markTerminal(nil, false)
+			entry.closeParts()
+		}()
 
 		handle, release, err := m.acquireHandle()
 		if err != nil {
-			entry.mu.Lock()
-			entry.err = err
-			entry.mu.Unlock()
+			entry.markTerminal(err, false)
 			return
 		}
 		defer release()
@@ -704,7 +757,13 @@ func (m *Model) StreamText(promptJson, optsJson string) *Stream {
 			defer C.free(unsafe.Pointer(cOpts))
 		}
 
-		C.do_stream(C.uint64_t(handle), cPrompt, cOpts, C.int64_t(id))
+		C.do_stream(
+			C.uint64_t(handle),
+			C.uint64_t(abortHandle),
+			cPrompt,
+			cOpts,
+			C.int64_t(id),
+		)
 	}()
 
 	return &Stream{parts: entry.parts, entry: entry}
@@ -721,7 +780,10 @@ func goStreamPart(id C.int64_t, json *C.char) {
 	if json == nil {
 		return
 	}
-	e.parts <- C.GoString(json)
+	select {
+	case e.parts <- C.GoString(json):
+	case <-e.cancelled:
+	}
 }
 
 //export goStreamDone
@@ -730,6 +792,7 @@ func goStreamDone(id C.int64_t) {
 	if e == nil {
 		return
 	}
+	e.markTerminal(nil, false)
 	e.closeParts()
 }
 
@@ -747,9 +810,7 @@ func goStreamError(id C.int64_t, err *C.char) {
 			msg = extracted
 		}
 	}
-	e.mu.Lock()
-	e.err = errors.New(msg)
-	e.mu.Unlock()
+	e.markTerminal(errors.New(msg), false)
 	e.closeParts()
 }
 

--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -720,13 +720,17 @@ func (m *Model) StreamTextContext(ctx context.Context, promptJson, optsJson stri
 	abortHandle := uint64(C.aimux_abort_signal_new())
 	entry, id := registerStream(abortHandle)
 
-	go func() {
-		select {
-		case <-ctx.Done():
-			entry.cancel(ctx.Err())
-		case <-entry.terminal:
-		}
-	}()
+	if err := ctx.Err(); err != nil {
+		entry.cancel(err)
+	} else if done := ctx.Done(); done != nil {
+		go func() {
+			select {
+			case <-done:
+				entry.cancel(ctx.Err())
+			case <-entry.terminal:
+			}
+		}()
+	}
 
 	go func() {
 		runtime.LockOSThread()

--- a/bindings/go/aimux_test.go
+++ b/bindings/go/aimux_test.go
@@ -110,7 +110,9 @@ func TestStreamTextReturnsStream(t *testing.T) {
 
 func TestStreamTextContextAlreadyCanceled(t *testing.T) {
 	m := OpenAI("sk-test-fake-key", "gpt-4o-mini")
-	defer m.Close()
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/bindings/go/aimux_test.go
+++ b/bindings/go/aimux_test.go
@@ -8,8 +8,11 @@
 package aimux
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestOpenAI(t *testing.T) {
@@ -103,6 +106,34 @@ func TestStreamTextReturnsStream(t *testing.T) {
 	}
 	// Err() should be safe to call after drain.
 	_ = s.Err()
+}
+
+func TestStreamTextContextAlreadyCanceled(t *testing.T) {
+	m := OpenAI("sk-test-fake-key", "gpt-4o-mini")
+	defer m.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stream := m.StreamTextContext(ctx, `"hello"`, "")
+
+	done := make(chan struct{})
+	go func() {
+		for range stream.Parts() {
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled stream did not stop")
+	}
+	if !errors.Is(stream.Err(), context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", stream.Err())
+	}
+
+	stream.Cancel()
+	stream.Cancel()
 }
 
 func TestProviderWithConfigFullOptions(t *testing.T) {

--- a/bindings/go/e2e_test.go
+++ b/bindings/go/e2e_test.go
@@ -16,7 +16,9 @@
 package aimux
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // ── Mock provider server ──────────────────────────────────────────────────────
@@ -401,6 +404,58 @@ func TestE2E_StreamTextYieldsTextDeltas(t *testing.T) {
 	}
 	if !gotFinish {
 		t.Error("expected a Finish part")
+	}
+}
+
+func TestStreamTextContextCancelsInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	requestDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(requestDone)
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(started)
+		select {
+		case <-r.Context().Done():
+		case <-time.After(3 * time.Second):
+		}
+	}))
+	defer srv.Close()
+
+	m := OpenAIWithBase("sk-test-fake-key", "gpt-4o", srv.URL)
+	defer m.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := m.StreamTextContext(ctx, `"wait"`, "")
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream request did not start")
+	}
+	cancel()
+
+	drained := make(chan struct{})
+	go func() {
+		for range stream.Parts() {
+		}
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight stream did not stop after cancellation")
+	}
+	if !errors.Is(stream.Err(), context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", stream.Err())
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider request stayed open after cancellation")
 	}
 }
 

--- a/bindings/go/e2e_test.go
+++ b/bindings/go/e2e_test.go
@@ -117,6 +117,44 @@ func (s *mockProviderServer) SetContentType(ct string) {
 	s.contentType = ct
 }
 
+// newBackpressureSSEServer sends enough parts to fill the Go channel. It then
+// keeps the HTTP request open until the client cancels it.
+func newBackpressureSSEServer(chunks int) (*httptest.Server, <-chan struct{}, <-chan struct{}) {
+	allSent := make(chan struct{})
+	requestDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(requestDone)
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for i := 0; i < chunks; i++ {
+			chunk := `{"id":"1","model":"gpt-4o","choices":[{"delta":{"content":"x"}}]}`
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		close(allSent)
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	}))
+	return server, allSent, requestDone
+}
+
+func waitForChannelFull[T any](t *testing.T, channel chan T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for len(channel) < cap(channel) {
+		if time.Now().After(deadline) {
+			t.Fatalf("channel did not fill: got %d of %d", len(channel), cap(channel))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 // ── Canned OpenAI responses ────────────────────────────────────────────────────
 
 // plainOpenAIResponse is a plain OpenAI text response (no tool calls).
@@ -456,6 +494,50 @@ func TestStreamTextContextCancelsInFlightRequest(t *testing.T) {
 	case <-requestDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("provider request stayed open after cancellation")
+	}
+}
+
+func TestStreamCancelUnblocksFullPartsChannel(t *testing.T) {
+	srv, allSent, requestDone := newBackpressureSSEServer(800)
+	defer srv.Close()
+
+	m := OpenAIWithBase("sk-test-fake-key", "gpt-4o", srv.URL)
+	defer m.Close()
+	stream := m.StreamText(`"fill the channel"`, "")
+	defer stream.Cancel()
+
+	select {
+	case <-allSent:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider did not send the SSE burst")
+	}
+	waitForChannelFull(t, stream.entry.parts)
+	select {
+	case <-stream.entry.terminal:
+		t.Fatal("stream ended before cancellation")
+	default:
+	}
+
+	stream.Cancel()
+	stream.Cancel()
+	drained := make(chan struct{})
+	go func() {
+		for range stream.Parts() {
+		}
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("full parts channel stayed blocked after cancellation")
+	}
+	if !errors.Is(stream.Err(), context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", stream.Err())
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider request stayed open after backpressure cancellation")
 	}
 }
 

--- a/bindings/go/typed.go
+++ b/bindings/go/typed.go
@@ -9,6 +9,7 @@
 package aimux
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -66,10 +67,10 @@ func (m *Model) Generate(prompt any, opts *GenerateTextOptions) (*GenerateTextRe
 // TypedStream is a handle to an in-progress typed stream.
 // Consume parts via Parts(); each part is a parsed *StreamPart.
 type TypedStream struct {
-	raw    *Stream
-	parts  chan *StreamPart
-	err    error
-	done   chan struct{}
+	raw   *Stream
+	parts chan *StreamPart
+	err   error
+	done  chan struct{}
 }
 
 // Parts returns a channel of parsed *StreamPart values.
@@ -81,6 +82,9 @@ func (s *TypedStream) Err() error {
 	<-s.done
 	return s.err
 }
+
+// Cancel stops this stream. It is safe to call more than once.
+func (s *TypedStream) Cancel() { s.raw.Cancel() }
 
 // Stream is the typed streaming method. It accepts a plain string prompt or
 // a []ModelMessage conversation, plus optional typed options, and returns a
@@ -97,6 +101,15 @@ func (s *TypedStream) Err() error {
 //	    }
 //	}
 func (m *Model) Stream(prompt any, opts *GenerateTextOptions) (*TypedStream, error) {
+	return m.StreamContext(context.Background(), prompt, opts)
+}
+
+// StreamContext starts a typed stream that stops when ctx is cancelled.
+func (m *Model) StreamContext(
+	ctx context.Context,
+	prompt any,
+	opts *GenerateTextOptions,
+) (*TypedStream, error) {
 	promptJSON, err := marshalPrompt(prompt)
 	if err != nil {
 		return nil, err
@@ -106,7 +119,7 @@ func (m *Model) Stream(prompt any, opts *GenerateTextOptions) (*TypedStream, err
 		return nil, err
 	}
 
-	rawStream := m.StreamText(promptJSON, optsJSON)
+	rawStream := m.StreamTextContext(ctx, promptJSON, optsJSON)
 	ts := &TypedStream{
 		raw:   rawStream,
 		parts: make(chan *StreamPart, 256),
@@ -120,9 +133,15 @@ func (m *Model) Stream(prompt any, opts *GenerateTextOptions) (*TypedStream, err
 			sp, err := ParseStreamPart(raw)
 			if err != nil {
 				ts.err = err
+				rawStream.Cancel()
 				return
 			}
-			ts.parts <- sp
+			select {
+			case ts.parts <- sp:
+			case <-rawStream.entry.cancelled:
+				ts.err = rawStream.Err()
+				return
+			}
 		}
 		if err := rawStream.Err(); err != nil {
 			ts.err = err

--- a/bindings/go/typed_test.go
+++ b/bindings/go/typed_test.go
@@ -6,8 +6,11 @@
 package aimux
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 )
 
 func TestTypedGenerateString(t *testing.T) {
@@ -165,6 +168,82 @@ func TestTypedStreamMessages(t *testing.T) {
 	}
 	if err := stream.Err(); err != nil {
 		t.Fatalf("stream error: %v", err)
+	}
+}
+
+func TestTypedStreamContextAlreadyCanceled(t *testing.T) {
+	m := OpenAI("sk-test-fake-key", "gpt-4o")
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stream, err := m.StreamContext(ctx, "cancel now", nil)
+	if err != nil {
+		t.Fatalf("StreamContext failed: %v", err)
+	}
+	defer stream.Cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		for range stream.Parts() {
+		}
+		done <- stream.Err()
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pre-canceled typed stream did not stop")
+	}
+
+	stream.Cancel()
+	stream.Cancel()
+}
+
+func TestTypedStreamCancelUnblocksFullPartsChannel(t *testing.T) {
+	srv, allSent, requestDone := newBackpressureSSEServer(1200)
+	defer srv.Close()
+	m := OpenAIWithBase("sk-test-fake-key", "gpt-4o", srv.URL)
+	defer m.Close()
+
+	stream, err := m.Stream("fill the typed channel", nil)
+	if err != nil {
+		t.Fatalf("Stream failed: %v", err)
+	}
+	defer stream.Cancel()
+
+	select {
+	case <-allSent:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider did not send the SSE burst")
+	}
+	waitForChannelFull(t, stream.parts)
+	select {
+	case <-stream.raw.entry.terminal:
+		t.Fatal("typed stream ended before cancellation")
+	default:
+	}
+
+	stream.Cancel()
+	stream.Cancel()
+	done := make(chan error, 1)
+	go func() { done <- stream.Err() }()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("full typed parts channel stayed blocked after cancellation")
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider request stayed open after typed cancellation")
 	}
 }
 


### PR DESCRIPTION
Closes #57

## Summary

- Add C ABI functions that create, trigger, and release per-call abort signals.
- Add `aimux_stream_text_with_abort`.
- Keep the existing `aimux_stream_text` ABI unchanged.
- Add Go `StreamTextContext` and `Stream.Cancel()`.
- Add typed Go `StreamContext` and `TypedStream.Cancel()`.
- Wake blocked Go callbacks when cancellation occurs.
- Resolve pre-canceled contexts before the native worker starts.
- Run the Go race detector in Ubuntu CI.

## Design

Each stream receives its own abort handle. Cancelling one stream does not affect other streams that use the same model.

The FFI layer reuses the existing core `AbortSignal`. It selects on cancellation before connection and while reading stream items.

Cancellation reports `AiMuxError::Aborted`. It does not call `on_done`.

A context that is already canceled wins the terminal state before any worker starts. Cancellation that races with normal completion still uses first-terminal-wins semantics.

## Validation

- `cargo test -p aimux-ffi`: 15 tests passed.
- `cargo clippy -p aimux-ffi --lib --no-deps -- -D warnings`: passed.
- `go test ./...`: 114 tests passed.
- `go test -race ./...`: 114 tests passed.
- `go vet ./...`: passed.
- Pre-canceled tests passed 200 repeated runs.
- Pre-canceled race tests passed 50 repeated runs.
- Backpressure cancellation tests passed 40 repeated runs.
- Backpressure race tests passed 20 repeated runs.
- The workflow YAML parses successfully.
- Exported C symbols were verified in the release static library.

## Note

Full all-target Clippy still reports two existing warnings in the Cohere and Google conversion modules. This PR does not change those modules.