### PR TITLE
docs(rfc0017): backlog B2/B3/B8/B9/B10 状态闭合

### DIFF
--- a/docs/plan/backlog.md
+++ b/docs/plan/backlog.md
@@ -7,13 +7,13 @@
 | # | 来源 | 内容 | 状态 |
 |---|---|---|---|
 | B1 | 调研 batch-04 | `reasoning_effort` 档位差异（kimi-k3 low/high/max、perplexity 四档）——档位不翻译（透传+厂商自决），知识进用户手册 | 已闭合（文档化） |
-| B2 | 调研 batch-05 | `reasoning_format`（stepfun general/deepseek-style）硬编码 `provider=="groq"`——用户 bodyOverrides 表达，手册文档化 | 待文档化 |
-| B3 | 调研 batch-06 | venice_parameters/hetzner chat_template_kwargs 等封闭字段——用户 bodyOverrides，手册文档化 | 待文档化 |
+| B2 | 调研 batch-05 | `reasoning_format`（stepfun general/deepseek-style）硬编码 `provider=="groq"`——用户 bodyOverrides 表达，手册文档化 | 已闭合（手册 §3 StepFun/Groq 行） |
+| B3 | 调研 batch-06 | venice_parameters/hetzner chat_template_kwargs 等封闭字段——用户 bodyOverrides，手册文档化 | 已闭合（手册 §3 Venice/Hetzner 行） |
 | B5 | 调研全局 | 7 处 registry base_url 确定性错误——**已修复**（stage2-004，merge 7a84fb4）；~20 处存疑（novita/nous_research/longcat/moonshotai_cn 等）仍待实测 | 🔶 存疑部分待实测 |
-| B6 | 调研 batch-02 | DeepSeek 是否接受 `max_completion_tokens` 待实测——实测后决定 DeepSeek 是否加 `max_tokens_key="max_tokens"`（v3 下它已无特化，纯通用路径，优先级降低） | 待实测 |
-| B8 | 调研 batch-03 | Heroku 的 `allow_ignored_params` 机制——max_tokens_key 之外的特殊参数行为，用户 bodyOverrides + 手册文档化 | 待文档化 |
-| B9 | verify stage2-001 F7 | 厂商级 `max_tokens_key` 数据接线未做（6 家 `"max_tokens"` + groq/heroku `"max_completion_tokens"`）——**须在 stage2-002/003 收尾前接线**，否则 groq/heroku 修复对真实流量不生效 | 待 stage2-002 |
-| B10 | verify stage2-001 F8 | `Some("max_tokens")` + 显式 `maxCompletionTokens` 被静默丢弃——行为方向符合设计，但需在用户手册标注（用户应改用 `max_output_tokens`） | 待文档化 |
+| B6 | 调研 batch-02 | DeepSeek 是否接受 `max_completion_tokens` 待实测——实测后决定 DeepSeek 是否加 `max_tokens_key="max_tokens"`（v3 下它已无特化，纯通用路径，优先级降低） | 🔶 未实测（2026-08-06 复核：仍走默认推断路径，手册 §4 已标注现状；实测需真实 API 调用） |
+| B8 | 调研 batch-03 | Heroku 的 `allow_ignored_params` 机制——max_tokens_key 之外的特殊参数行为，用户 bodyOverrides + 手册文档化 | 已闭合（手册 §3 Heroku 行，含 bodyOverrides 表达） |
+| B9 | verify stage2-001 F7 | 厂商级 `max_tokens_key` 数据接线未做（6 家 `"max_tokens"` + groq/heroku `"max_completion_tokens"`）——**须在 stage2-002/003 收尾前接线**，否则 groq/heroku 修复对真实流量不生效 | 已闭合（stage2-002 实施：registry 8 家接线 + provider.rs 测试锁定 + 手册 §4） |
+| B10 | verify stage2-001 F8 | `Some("max_tokens")` + 显式 `maxCompletionTokens` 被静默丢弃——行为方向符合设计，但需在用户手册标注（用户应改用 `max_output_tokens`） | 已闭合（手册 §4 标注 2026-08-06） |
 
 ## 已闭合（v3 变更消除）
 

--- a/docs/provider-config-manual.md
+++ b/docs/provider-config-manual.md
@@ -62,7 +62,7 @@ await generateText(model, p, {
 | **SiliconFlow** | `thinking_budget`（思维链 token 上限，Qwen3 系强制截断；**无 0=关 语义**，关思考走 qwen 系 `enable_thinking`） | `bodyOverrides: { thinking_budget: 1024 }`（调低预算） | batch-05 |
 | **Perplexity** | `reasoning_effort` 四档 + `stream_mode`；推理 token **不可强制关闭** | `bodyOverrides: { stream_mode: 'concise' }` | batch-05 |
 | **Groq** | `reasoning_format`（如 raw）+ effort **直传**（无归一化） | `bodyOverrides: { reasoning_format: 'raw' }` | batch-03 |
-| **Heroku** | `extended_thinking:{enabled,budget_tokens,include_reasoning}`；未知参数需 `allow_ignored_params` | `bodyOverrides: { extended_thinking: { enabled: true, budget_tokens: 2000 } }` | batch-03 |
+| **Heroku** | `extended_thinking:{enabled,budget_tokens,include_reasoning}`；未知参数需 `allow_ignored_params` | `bodyOverrides: { extended_thinking: { enabled: true, budget_tokens: 2000 } }`；非标准参数一并 `bodyOverrides: { allow_ignored_params: true, ... }` | batch-03 |
 | **Hetzner** | `chat_template_kwargs:{enable_thinking:false}` | `bodyOverrides: { chat_template_kwargs: { enable_thinking: false } }` | 社区实测（batch-03） |
 | **Venice** | `venice_parameters:{disable_thinking:true}` | `bodyOverrides: { venice_parameters: { disable_thinking: true } }` | 封闭字段（batch-06） |
 | **腾讯 hy3**（TokenHub） | `thinking:{type:"enabled"}` + `reasoning_effort`（默认 low） | `bodyOverrides: { thinking: { type: 'enabled' }, reasoning_effort: 'low' }` | batch-06（C 级官方文档） |
@@ -81,6 +81,16 @@ await generateText(model, prompt, { max_output_tokens: 4096 })
 // OpenAI 推理模型 → {"max_completion_tokens":4096}
 // stepfun → {"max_tokens":4096}
 ```
+
+> ⚠️ **不要用 `provider_options.maxCompletionTokens` 显式指定**：对只认 `max_tokens`
+> 的厂商（stepfun / siliconflow / sarvam / reka_ai / publicai / perplexity），该
+> 选项会被**静默丢弃**（不报错、无 warning，backlog B10）。请改用顶层
+> `max_output_tokens`——它会被自动映射到正确字段名。
+>
+> 未内置 `max_tokens_key` 的厂商（含 **DeepSeek**）走默认推断：推理模型发
+> `max_completion_tokens`，非推理发 `max_tokens`。DeepSeek 对
+> `max_completion_tokens` 的接受性**尚未实测**（backlog B6）——当前行为
+> 由默认推断路径决定，实测结论落地前请勿依赖其行为。
 
 ## 5. bodyOverrides 用法速查
 


### PR DESCRIPTION
Closes #41

复核发现 **stage2-002 已实施 B9**(registry 8 家 `max_tokens_key` 接线 + provider.rs 测试锁定 + 手册 §4),B2/B3 手册 §3 已覆盖。本 PR 补齐剩余:

- **B10**:手册 §4 标注——只认 `max_tokens` 的 6 家(stepfun/siliconflow/sarvam/reka_ai/publicai/perplexity)显式 `maxCompletionTokens` 被静默丢弃,应改用 `max_output_tokens`
- **B6**:手册 §4 记录现状——DeepSeek 未实测 `max_completion_tokens` 接受性,走默认推断路径(实测需真实 API 调用)
- **B8**:手册 §3 Heroku 行补 `allow_ignored_params` 的 bodyOverrides 表达
- **backlog.md**:B2/B3/B8/B9/B10 → 已闭合,B6 → 未实测(保留)

纯文档,零代码改动。