### PR TITLE
feat(session): RFC-0024 P5 收尾 — 补齐 4 语言 session_id typed options + 契约测试

### DIFF
--- a/aimux-core/tests/contract_test.rs
+++ b/aimux-core/tests/contract_test.rs
@@ -152,6 +152,26 @@ fn generate_text_options_include_raw_chunks_true_wire_format() {
     assert_eq!(back.include_raw_chunks, Some(true));
 }
 
+/// RFC-0024: an explicit `session_id` crosses the wire as snake_case and
+/// round-trips (companion of the `generate_text_options_with_session_id`
+/// fixture).
+#[test]
+fn generate_text_options_session_id_wire_format() {
+    let opts = GenerateTextOptions {
+        session_id: Some("sess-1".into()),
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&opts).unwrap();
+    let val: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        val.get("session_id"),
+        Some(&Value::String("sess-1".into())),
+        "session_id must serialize as snake_case string, got {json}"
+    );
+    let back: GenerateTextOptions = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.session_id.as_deref(), Some("sess-1"));
+}
+
 #[test]
 fn stream_part_text_delta_wire_format() {
     let part = StreamPart::TextDelta {

--- a/bindings/flutter/lib/types.dart
+++ b/bindings/flutter/lib/types.dart
@@ -663,6 +663,8 @@ class GenerateTextOptions {
   final TimeoutConfiguration? timeout;
   @JsonKey(name: 'include_raw_chunks')
   final bool? includeRawChunks;
+  @JsonKey(name: 'session_id')
+  final String? sessionId;
 
   GenerateTextOptions({
     this.maxOutputTokens,
@@ -684,6 +686,7 @@ class GenerateTextOptions {
     this.maxRetries,
     this.timeout,
     this.includeRawChunks,
+    this.sessionId,
   });
 
   factory GenerateTextOptions.fromJson(Map<String, dynamic> json) {
@@ -715,6 +718,7 @@ class GenerateTextOptions {
           ? TimeoutConfiguration.fromJson(json['timeout'] as Map<String, dynamic>)
           : null,
       includeRawChunks: json['include_raw_chunks'] as bool?,
+      sessionId: json['session_id'] as String?,
     );
   }
   Map<String, dynamic> toJson() => {
@@ -737,6 +741,7 @@ class GenerateTextOptions {
         if (maxRetries != null) 'max_retries': maxRetries,
         if (timeout != null) 'timeout': timeout!.toJson(),
         if (includeRawChunks != null) 'include_raw_chunks': includeRawChunks,
+        if (sessionId != null) 'session_id': sessionId,
       };
 }
 

--- a/bindings/flutter/test/typed_round_trip_test.dart
+++ b/bindings/flutter/test/typed_round_trip_test.dart
@@ -511,4 +511,16 @@ void main() {
     final defaults = GenerateTextOptions().toJson();
     expect(defaults.containsKey('include_raw_chunks'), isFalse);
   });
+
+  test('GenerateTextOptions sessionId round-trips', () {
+    // RFC-0024: explicit session_id crosses the wire as snake_case.
+    final original = GenerateTextOptions(sessionId: 'sess-1');
+    final json = original.toJson();
+    expect(json['session_id'], 'sess-1');
+    final back = GenerateTextOptions.fromJson(json);
+    expect(back.sessionId, 'sess-1');
+
+    final defaults = GenerateTextOptions().toJson();
+    expect(defaults.containsKey('session_id'), isFalse);
+  });
 }

--- a/bindings/java/src/main/java/ai/arcships/aimux/Types.java
+++ b/bindings/java/src/main/java/ai/arcships/aimux/Types.java
@@ -1680,6 +1680,7 @@ public final class Types {
         @JsonProperty("max_retries") private Long maxRetries;
         @JsonProperty("include_raw_chunks") private Boolean includeRawChunks;
         @JsonProperty("timeout") private TimeoutConfiguration timeout;
+        @JsonProperty("session_id") private String sessionId;
 
         @JsonCreator
         GenerateTextOptions() {}
@@ -1690,7 +1691,7 @@ public final class Types {
                                     Map<String, String> headers, Map<String, JsonNode> providerOptions,
                                     ReasoningEffort reasoning, String instructions,
                                     JsonNode bodyOverrides, Long maxRetries, Boolean includeRawChunks,
-                                    TimeoutConfiguration timeout) {
+                                    TimeoutConfiguration timeout, String sessionId) {
             this.maxOutputTokens = maxOutputTokens;
             this.temperature = temperature;
             this.stopSequences = stopSequences;
@@ -1710,6 +1711,7 @@ public final class Types {
             this.maxRetries = maxRetries;
             this.includeRawChunks = includeRawChunks;
             this.timeout = timeout;
+            this.sessionId = sessionId;
         }
 
         public Long getMaxOutputTokens() { return maxOutputTokens; }
@@ -1731,6 +1733,7 @@ public final class Types {
         public Long getMaxRetries() { return maxRetries; }
         public Boolean getIncludeRawChunks() { return includeRawChunks; }
         public TimeoutConfiguration getTimeout() { return timeout; }
+        public String getSessionId() { return sessionId; }
 
         public static Builder builder() { return new Builder(); }
 
@@ -1754,6 +1757,7 @@ public final class Types {
             private Long maxRetries;
             private Boolean includeRawChunks;
             private TimeoutConfiguration timeout;
+            private String sessionId;
 
             public Builder maxOutputTokens(Long v) { this.maxOutputTokens = v; return this; }
             public Builder temperature(Double v) { this.temperature = v; return this; }
@@ -1774,12 +1778,13 @@ public final class Types {
             public Builder maxRetries(Long v) { this.maxRetries = v; return this; }
             public Builder includeRawChunks(Boolean v) { this.includeRawChunks = v; return this; }
             public Builder timeout(TimeoutConfiguration v) { this.timeout = v; return this; }
+            public Builder sessionId(String v) { this.sessionId = v; return this; }
 
             public GenerateTextOptions build() {
                 return new GenerateTextOptions(maxOutputTokens, temperature, stopSequences, topP, topK,
                     presencePenalty, frequencyPenalty, responseFormat, seed, tools, toolChoice, headers,
                     providerOptions, reasoning, instructions, bodyOverrides, maxRetries, includeRawChunks,
-                    timeout);
+                    timeout, sessionId);
             }
         }
 
@@ -1806,14 +1811,15 @@ public final class Types {
                 && Objects.equals(bodyOverrides, that.bodyOverrides)
                 && Objects.equals(maxRetries, that.maxRetries)
                 && Objects.equals(includeRawChunks, that.includeRawChunks)
-                && Objects.equals(timeout, that.timeout);
+                && Objects.equals(timeout, that.timeout)
+                && Objects.equals(sessionId, that.sessionId);
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(maxOutputTokens, temperature, stopSequences, topP, topK, presencePenalty,
                 frequencyPenalty, responseFormat, seed, tools, toolChoice, headers, providerOptions, reasoning,
-                instructions, bodyOverrides, maxRetries, includeRawChunks, timeout);
+                instructions, bodyOverrides, maxRetries, includeRawChunks, timeout, sessionId);
         }
     }
 

--- a/bindings/java/src/test/java/ai/arcships/aimux/ContractTest.java
+++ b/bindings/java/src/test/java/ai/arcships/aimux/ContractTest.java
@@ -183,6 +183,27 @@ class ContractTest {
         assertThat(decoded.getRaw().path("prompt_tokens").asInt()).isEqualTo(20);
     }
 
+    /// RFC-0024: `session_id` crosses the wire as snake_case and round-trips.
+    @Test
+    void generateTextOptionsSessionIdWireAndRoundTrip() throws Exception {
+        // Wire shape: the shared fixture.
+        JsonNode fixtures = loadFixtures();
+        String json = fixtureJson(fixtures, "generate_text_options_with_session_id");
+        Types.GenerateTextOptions opts =
+            Types.AimuxJson.MAPPER.readValue(json, Types.GenerateTextOptions.class);
+        assertThat(opts.getSessionId()).isEqualTo("sess-1");
+
+        // Java-native round-trip with the Builder.
+        Types.GenerateTextOptions nativeOpts = Types.GenerateTextOptions.builder()
+            .sessionId("sess-1")
+            .build();
+        String nativeJson = Types.AimuxJson.MAPPER.writeValueAsString(nativeOpts);
+        assertThat(nativeJson).contains("\"session_id\":\"sess-1\"");
+        Types.GenerateTextOptions decoded =
+            Types.AimuxJson.MAPPER.readValue(nativeJson, Types.GenerateTextOptions.class);
+        assertThat(decoded.getSessionId()).isEqualTo("sess-1");
+    }
+
     @Test
     void streamPartFinishWireShapeAndJavaRoundTrip() throws Exception {
         JsonNode fixtures = loadFixtures();

--- a/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Types.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Types.kt
@@ -603,6 +603,8 @@ data class GenerateTextOptions(
     @SerialName("include_raw_chunks") val includeRawChunks: Boolean? = null,
     /** Per-call timeout configuration (overall / first chunk / inter-chunk idle, in ms). */
     @SerialName("timeout") val timeout: TimeoutConfiguration? = null,
+    /** Session identifier (RFC-0024): groups consecutive calls into a session. */
+    @SerialName("session_id") val sessionId: String? = null,
 )
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/bindings/kotlin/src/test/kotlin/ai/arcships/aimux/ContractTest.kt
+++ b/bindings/kotlin/src/test/kotlin/ai/arcships/aimux/ContractTest.kt
@@ -72,6 +72,17 @@ class ContractTest {
         assertThat(reencoded).contains("\"include_raw_chunks\":true")
     }
 
+    /// RFC-0024: `session_id` decodes from the shared fixture and round-trips.
+    @Test
+    fun `session id wire format and round-trip`() {
+        val json = fixtureJson(loadFixtures(), "generate_text_options_with_session_id")
+        val opts = AimuxJson.decodeFromString<GenerateTextOptions>(json)
+        assertThat(opts.sessionId).isEqualTo("sess-1")
+
+        val reencoded = AimuxJson.encodeToString(GenerateTextOptions.serializer(), opts)
+        assertThat(reencoded).contains("\"session_id\":\"sess-1\"")
+    }
+
     /// RFC-0016 M10: `Usage.raw` with a vendor-specific field survives a
     /// Kotlin round-trip.
     @Test

--- a/bindings/swift/Sources/Aimux/Types.swift
+++ b/bindings/swift/Sources/Aimux/Types.swift
@@ -957,6 +957,7 @@ public struct GenerateTextOptions: Codable, Equatable {
     public var maxRetries: UInt32?
     public var timeout: TimeoutConfiguration?
     public var includeRawChunks: Bool?
+    public var sessionId: String?
 
     enum CodingKeys: String, CodingKey {
         case maxOutputTokens = "max_output_tokens"
@@ -976,6 +977,7 @@ public struct GenerateTextOptions: Codable, Equatable {
         case maxRetries = "max_retries"
         case timeout
         case includeRawChunks = "include_raw_chunks"
+        case sessionId = "session_id"
     }
 
     public init(maxOutputTokens: UInt32? = nil, temperature: Double? = nil,
@@ -987,7 +989,8 @@ public struct GenerateTextOptions: Codable, Equatable {
                 reasoning: ReasoningEffort? = nil, instructions: String? = nil,
                 bodyOverrides: JSONValue? = nil, maxRetries: UInt32? = nil,
                 timeout: TimeoutConfiguration? = nil,
-                includeRawChunks: Bool? = nil) {
+                includeRawChunks: Bool? = nil,
+                sessionId: String? = nil) {
         self.maxOutputTokens = maxOutputTokens; self.temperature = temperature
         self.stopSequences = stopSequences; self.topP = topP; self.topK = topK
         self.presencePenalty = presencePenalty; self.frequencyPenalty = frequencyPenalty
@@ -996,6 +999,7 @@ public struct GenerateTextOptions: Codable, Equatable {
         self.reasoning = reasoning; self.instructions = instructions
         self.bodyOverrides = bodyOverrides; self.maxRetries = maxRetries; self.timeout = timeout
         self.includeRawChunks = includeRawChunks
+        self.sessionId = sessionId
     }
 }
 

--- a/contract-tests/fixtures/wire-format.json
+++ b/contract-tests/fixtures/wire-format.json
@@ -55,7 +55,7 @@
   {
     "name": "generate_text_options_default",
     "type": "GenerateTextOptions",
-    "json": "{\"max_output_tokens\":null,\"temperature\":null,\"stop_sequences\":null,\"top_p\":null,\"top_k\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"response_format\":null,\"seed\":null,\"tools\":null,\"tool_choice\":null,\"headers\":null,\"provider_options\":null,\"reasoning\":null,\"instructions\":null,\"body_overrides\":null,\"max_retries\":null,\"timeout\":null,\"include_raw_chunks\":null}",
+    "json": "{\"max_output_tokens\":null,\"temperature\":null,\"stop_sequences\":null,\"top_p\":null,\"top_k\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"response_format\":null,\"seed\":null,\"tools\":null,\"tool_choice\":null,\"headers\":null,\"provider_options\":null,\"reasoning\":null,\"instructions\":null,\"body_overrides\":null,\"max_retries\":null,\"timeout\":null,\"include_raw_chunks\":null,\"session_id\":null}",
     "description": "Default GenerateTextOptions with all fields null"
   },
   {
@@ -68,7 +68,7 @@
     "name": "generate_text_options_include_raw_chunks_true",
     "type": "GenerateTextOptions",
     "rust_value": "",
-    "json": "{\"max_output_tokens\":null,\"temperature\":null,\"stop_sequences\":null,\"top_p\":null,\"top_k\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"response_format\":null,\"seed\":null,\"tools\":null,\"tool_choice\":null,\"headers\":null,\"provider_options\":null,\"reasoning\":null,\"instructions\":null,\"body_overrides\":null,\"max_retries\":null,\"timeout\":null,\"include_raw_chunks\":true}",
+    "json": "{\"max_output_tokens\":null,\"temperature\":null,\"stop_sequences\":null,\"top_p\":null,\"top_k\":null,\"presence_penalty\":null,\"frequency_penalty\":null,\"response_format\":null,\"seed\":null,\"tools\":null,\"tool_choice\":null,\"headers\":null,\"provider_options\":null,\"reasoning\":null,\"instructions\":null,\"body_overrides\":null,\"max_retries\":null,\"timeout\":null,\"include_raw_chunks\":true,\"session_id\":null}",
     "description": "GenerateTextOptions with include_raw_chunks=true (RFC-0016 M2 true-case)"
   },
   {

--- a/rfc/0024-session-aggregation.md
+++ b/rfc/0024-session-aggregation.md
@@ -1,6 +1,6 @@
 # RFC-0024: 调用会话聚合(session_id 归组)
 
-> **Status**: IMPLEMENTED (P1/P2/P5 — 2026-08-05;P3/P4 待依赖 RFC-0023/0015,见 [§10](#10-implementation-order))
+> **Status**: IMPLEMENTED (P1/P2/P5 — 2026-08-05;P3/P4 待依赖 RFC-0023/0015,见 [§10](#10-implementation-order);P5 含 6 语言 typed options + FFI/Node/Python 查询 API)
 > **Date**: 2026-08-05
 > **Scope**: `aimux-core` 新增 `session_id` 字段(显式为主 + 隐式推断兜底),把连续调用聚合成会话组,为录制(RFC-0023)、缓存探测(RFC-0015)、回放提供链级视图。不做 fork 语义、不做 agent loop。
 > **Related**: [RFC-0023](0023-runtime-request-recording.md) 录制(Recording 加 session_id)、[RFC-0015](0015-cache-trace-audit.md) 缓存探测(链级聚合)、[RFC-0019](0019-session-affinity.md) 会话亲和(路由层 session,与本 RFC 可观测层 session 共享 id 概念但职责不同)、[RFC-0016](0016-align-with-aisdk.md) H4(不做 agent loop 边界)


### PR DESCRIPTION
Closes #49

**P1/P2(core)已在 master 完成**:`session.rs`(SessionStore LRU + SessionInferer 隐式推断 + 查询 API)、双入口接入、FFI(`aimux_session_calls`/`aimux_list_sessions`)、Node/Python 查询 API、Python `test_session.py`、Node `session.test.ts`。

本 PR 补齐 **P5 的剩余语言壳**:
- 4 语言 `GenerateTextOptions` 加 `sessionId`:Flutter(3 处)/Swift(4 处)/Java(6 处含 equals+hashCode)/Kotlin(1 处)
- contract fixture:default 与 include_raw_chunks_true 补 `session_id:null`;with_session_id case 此前已有
- 测试:Rust contract_test + Java/Kotlin ContractTest + Flutter round-trip 的 session_id 往返
- RFC-0024 状态行补充 P5 范围

**P3/P4 未实施**(依赖 RFC-0023 录制 / RFC-0015 探测的 `call_id`/TraceRecord,那两个 RFC 尚未实施)。

验证:local-ci 7/7;Rust contract 12 + session 19;Java 8/8;Kotlin 3/3;Flutter 70。