### PR TITLE
fix: resolve quality-audit issues #65-#76 (H2/H3, M1-M7, M9-M11)

### DIFF
--- a/aimux-core/src/error.rs
+++ b/aimux-core/src/error.rs
@@ -29,10 +29,14 @@ pub enum AiMuxError {
     #[error("invalid prompt: {0}")]
     InvalidPrompt(String),
 
-    #[error("rate limited: retry after {retry_after_ms}ms")]
+    /// Rate-limited (HTTP 429). Carries both the retry hint and the provider's
+    /// response message (e.g. "quota exceeded" vs "too many requests") so
+    /// callers can tell the two apart.
+    #[error("rate limited: {message} (retry after {retry_after_ms}ms)")]
     RateLimited {
         #[ts(type = "number")]
         retry_after_ms: u64,
+        message: String,
     },
 
     #[error("authentication failed: {0}")]
@@ -81,7 +85,10 @@ impl AiMuxError {
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
-            AiMuxError::RateLimited { .. } | AiMuxError::Http(_) | AiMuxError::ApiCall(_)
+            AiMuxError::RateLimited { .. }
+                | AiMuxError::Http(_)
+                | AiMuxError::ApiCall(_)
+                | AiMuxError::Timeout(_)
         )
     }
 
@@ -95,7 +102,7 @@ impl AiMuxError {
     /// `retryWithExponentialBackoffRespectingRetryHeaders` in the TS SDK.
     pub fn retry_after_hint(&self) -> Option<i64> {
         match self {
-            AiMuxError::RateLimited { retry_after_ms } => Some(*retry_after_ms as i64),
+            AiMuxError::RateLimited { retry_after_ms, .. } => Some(*retry_after_ms as i64),
             _ => None,
         }
     }
@@ -128,22 +135,27 @@ impl AiMuxError {
 
     /// Returns the HTTP status code carried by this error, if any.
     ///
-    /// HTTP-layer errors created by `parse_provider_error` and
-    /// `send_with_retry_raw` embed the status code in the message as
-    /// `"HTTP {status}: ..."`. This method extracts it. Errors that don't
-    /// originate from an HTTP response return `None`.
+    /// Status codes are now derived structurally per variant where the variant
+    /// implies a single status (`Auth`/`TokenExpired` → 401,
+    /// `RateLimited` → 429, `ModelNotFound` → 404). Status-bearing variants
+    /// created by the HTTP layer (`Http`/`Provider`/`ApiCall`) embed the code
+    /// in the message as `"HTTP {status}: ..."` (that prefix is stamped by
+    /// `parse_provider_error` and `send_with_retry_raw`); this method extracts
+    /// it as a fallback. Errors that don't originate from an HTTP response
+    /// return `None`.
     pub fn status_code(&self) -> Option<u16> {
-        let message = match self {
-            AiMuxError::Provider(m)
-            | AiMuxError::Http(m)
-            | AiMuxError::Auth(m)
-            | AiMuxError::ApiCall(m)
-            | AiMuxError::ModelNotFound(m) => m,
-            _ => return None,
-        };
-        // Parse "HTTP 403: ..." → 403
-        let rest = message.strip_prefix("HTTP ")?;
-        let code_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        code_str.parse().ok()
+        match self {
+            AiMuxError::Auth(_) | AiMuxError::TokenExpired(_) => Some(401),
+            AiMuxError::RateLimited { .. } => Some(429),
+            AiMuxError::ModelNotFound(_) => Some(404),
+            AiMuxError::Http(m) | AiMuxError::Provider(m) | AiMuxError::ApiCall(m) => {
+                // Parse "HTTP 403: ..." → 403 (only the HTTP layer stamps this
+                // prefix, so the match is unambiguous).
+                let rest = m.strip_prefix("HTTP ")?;
+                let code_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+                code_str.parse().ok()
+            }
+            _ => None,
+        }
     }
 }

--- a/aimux-core/src/error.rs
+++ b/aimux-core/src/error.rs
@@ -32,10 +32,14 @@ pub enum AiMuxError {
     /// Rate-limited (HTTP 429). Carries both the retry hint and the provider's
     /// response message (e.g. "quota exceeded" vs "too many requests") so
     /// callers can tell the two apart.
+    ///
+    /// `#[serde(default)]` on `message` keeps deserializing error values that
+    /// were (de)serialized before the field was added (issue M6).
     #[error("rate limited: {message} (retry after {retry_after_ms}ms)")]
     RateLimited {
         #[ts(type = "number")]
         retry_after_ms: u64,
+        #[serde(default)]
         message: String,
     },
 
@@ -157,5 +161,87 @@ impl AiMuxError {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_code_derives_fixed_codes() {
+        assert_eq!(AiMuxError::Auth("bad key".into()).status_code(), Some(401));
+        assert_eq!(
+            AiMuxError::TokenExpired("expired".into()).status_code(),
+            Some(401)
+        );
+        assert_eq!(
+            AiMuxError::RateLimited {
+                retry_after_ms: 5000,
+                message: String::new()
+            }
+            .status_code(),
+            Some(429)
+        );
+        assert_eq!(
+            AiMuxError::ModelNotFound("nope".into()).status_code(),
+            Some(404)
+        );
+    }
+
+    #[test]
+    fn status_code_parses_http_prefix_only_for_http_layer_variants() {
+        assert_eq!(
+            AiMuxError::Provider("HTTP 403: forbidden".into()).status_code(),
+            Some(403)
+        );
+        assert_eq!(
+            AiMuxError::ApiCall("HTTP 500: boom".into()).status_code(),
+            Some(500)
+        );
+        // Timeout messages must never parse as a status code, even when the
+        // text happens to start with "HTTP ".
+        assert_eq!(
+            AiMuxError::Timeout("HTTP 408: total timeout after 1000ms".into()).status_code(),
+            None
+        );
+        assert_eq!(AiMuxError::Json("HTTP 400".into()).status_code(), None);
+        assert_eq!(AiMuxError::Other("HTTP 400".into()).status_code(), None);
+    }
+
+    #[test]
+    fn timeout_is_retryable() {
+        assert!(AiMuxError::Timeout("total timeout".into()).is_retryable());
+        assert!(!AiMuxError::Json("parse".into()).is_retryable());
+        assert!(
+            AiMuxError::RateLimited {
+                retry_after_ms: 1,
+                message: String::new()
+            }
+            .is_retryable()
+        );
+    }
+
+    /// M6: deserializing an error JSON that was produced before the
+    /// `RateLimited.message` field existed must still succeed (serde default).
+    #[test]
+    fn rate_limited_serde_back_compat() {
+        let old = r#"{"RateLimited":{"retry_after_ms":5000}}"#;
+        let err: AiMuxError = serde_json::from_str(old).unwrap();
+        assert!(matches!(
+            err,
+            AiMuxError::RateLimited { retry_after_ms: 5000, message, .. } if message.is_empty()
+        ));
+        // Round-trip with the new shape keeps the message.
+        let err = AiMuxError::RateLimited {
+            retry_after_ms: 7,
+            message: "quota exceeded".into(),
+        };
+        let json = serde_json::to_string(&err).unwrap();
+        let back: AiMuxError = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            back,
+            AiMuxError::RateLimited { retry_after_ms: 7, message, .. } if message == "quota exceeded"
+        ));
     }
 }

--- a/aimux-core/src/error.rs
+++ b/aimux-core/src/error.rs
@@ -33,8 +33,11 @@ pub enum AiMuxError {
     /// response message (e.g. "quota exceeded" vs "too many requests") so
     /// callers can tell the two apart.
     ///
-    /// `#[serde(default)]` on `message` keeps deserializing error values that
-    /// were (de)serialized before the field was added (issue M6).
+    /// `#[serde(default)]` keeps *deserializing* error values that were
+    /// (de)serialized before the field was added (issue M6). Serialization
+    /// always emits `message`, and the generated TS binding keeps it required —
+    /// that asymmetry is intentional: `serde(default)` is input leniency for
+    /// legacy payloads, while TS describes the current output contract.
     #[error("rate limited: {message} (retry after {retry_after_ms}ms)")]
     RateLimited {
         #[ts(type = "number")]

--- a/aimux-core/src/provider.rs
+++ b/aimux-core/src/provider.rs
@@ -11,5 +11,15 @@ pub trait Provider: Send + Sync {
     fn name(&self) -> &str;
 
     /// Create a model instance by its name string (e.g. `"gpt-4o"`).
-    fn language_model(&self, model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError>;
+    ///
+    /// Non-language-model providers (image/video/speech/search/… — e.g. Tavily,
+    /// Stability, Recraft) do not implement this and get the default
+    /// `Unsupported` error. Only providers that actually expose a language
+    /// model override it (issue M9).
+    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
+        Err(AiMuxError::Unsupported(format!(
+            "provider '{}' does not provide language models",
+            self.name()
+        )))
+    }
 }

--- a/aimux-core/src/types.rs
+++ b/aimux-core/src/types.rs
@@ -87,6 +87,17 @@ pub enum ReasoningEffort {
     Xhigh,
 }
 
+impl ReasoningEffort {
+    /// Whether this is an explicit (custom) effort level rather than the
+    /// "provider default" sentinel.
+    ///
+    /// Replaces the per-provider `is_custom_reasoning` helpers that were
+    /// copy-pasted across openai/anthropic/xai convert modules (issue M10).
+    pub fn is_custom(self) -> bool {
+        !matches!(self, ReasoningEffort::ProviderDefault)
+    }
+}
+
 impl std::fmt::Display for ReasoningEffort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/aimux-ffi/Cargo.toml
+++ b/aimux-ffi/Cargo.toml
@@ -19,6 +19,7 @@ aimux-providers = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 # Needed to drive `Stream::next` while consuming `stream_text` output.
 futures = { workspace = true }
 

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -22,11 +22,12 @@
 //! operation completes. Callbacks execute on the same thread/call-stack that
 //! invoked the FFI function, so they must **not** re-enter the FFI layer:
 //! a nested `block_on` on the same thread makes tokio **panic** ("Cannot start
-//! a runtime from within a runtime"). An unwinding panic crossing the
-//! `extern "C"` boundary is undefined behavior; under this workspace's release
-//! profile (`panic = "abort"`) such a panic terminates the process instead.
-//! Either way the re-entrant call must be rejected before it reaches the
-//! runtime — [`ffi_block_on`] does that with a thread-local guard (issue M7).
+//! a runtime from within a runtime"). Rust's non-unwind `extern "C"` ABI does
+//! not allow a panic to propagate — the process terminates (and under this
+//! workspace's release profile, `panic = "abort"`, it terminates at the panic
+//! site). Either way the re-entrant call must be rejected before it reaches
+//! the runtime; the thread-local guard in [`ffi_block_on`] does that
+//! (issue M7).
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 // `extern "C"` entry points dereference raw pointers (`*const c_char`) by
 // design: the C ABI contract requires callers to pass valid pointers (see
@@ -178,20 +179,21 @@ thread_local! {
     /// Stream callbacks (`on_part`/`on_done`/`on_error`) run synchronously on
     /// the same thread/call-stack that entered the FFI function, so a callback
     /// that calls back into the FFI layer would enter a second `block_on` on
-    /// this thread. tokio rejects nested `block_on` with a **panic** (which,
-    /// depending on the build profile, aborts the process or — if unwinding —
-    /// is UB once it crosses the `extern "C"` boundary). [`ffi_block_on`]
-    /// checks this guard and turns that re-entrant call into an error envelope
-    /// instead (issue M7).
+    /// this thread. tokio rejects nested `block_on` with a **panic**; Rust's
+    /// non-unwind `extern "C"` ABI terminates the process rather than letting
+    /// the panic propagate (and `panic = "abort"` terminates at the panic site).
+    /// [`ffi_block_on`] checks this guard and turns that re-entrant call into
+    /// an error envelope instead (issue M7).
     static IN_FFI_BLOCK_ON: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Run a future on the shared runtime from an FFI entry point (issue M7).
 ///
 /// Rejects re-entrant calls made from inside a stream callback, returning
-/// [`AiMuxError::Other`] instead of letting tokio's `block_on` panic (abort
-/// under `panic = "abort"`, UB if an unwind crosses the C boundary). The
-/// guard is released when the future completes, including when it panics.
+/// [`AiMuxError::Other`] instead of letting tokio's nested `block_on` panic —
+/// a non-unwind `extern "C"` boundary never lets the panic propagate, so the
+/// process would terminate. The guard is released when the future completes,
+/// including when it panics.
 fn ffi_block_on<F, T>(f: F) -> Result<T, AiMuxError>
 where
     F: std::future::Future<Output = T>,

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -266,12 +266,15 @@ fn parse_opts(json: &str) -> Result<GenerateTextOptions, serde_json::Error> {
 /// Never returns null (issue M1): interior NUL bytes — which would make
 /// `CString::new` fail — are replaced with U+FFFD so the C-side contract
 /// ("a non-null NUL-terminated buffer to free, or null") always holds. The
-/// replacement is logged so accidental NULs stay visible.
+/// replacement is reported through `tracing` (RFC-0014 logging, which C hosts
+/// route via `aimux_init_logging`) so accidental NULs stay visible without
+/// the library writing to the host's stderr directly.
 fn into_cstring_raw(s: String) -> *mut c_char {
     if s.contains('\0') {
-        eprintln!(
-            "aimux-ffi: warning: string contains {} NUL byte(s); replaced with U+FFFD before FFI return",
-            s.bytes().filter(|&b| b == 0).count()
+        tracing::warn!(
+            target: "aimux_ffi",
+            nul_bytes = s.bytes().filter(|&b| b == 0).count(),
+            "string contains NUL byte(s); replaced with U+FFFD before FFI return"
         );
     }
     let sanitized = s.replace('\0', "\u{FFFD}");

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -20,8 +20,12 @@
 //! All async provider work runs on a shared multi-threaded tokio runtime. The
 //! C ABI functions are synchronous: they `block_on` the runtime until the
 //! operation completes. Callbacks execute on the same thread/call-stack that
-//! invoked the FFI function, so they must not re-enter the FFI layer (doing so
-//! would deadlock the runtime).
+//! invoked the FFI function, so they must **not** re-enter the FFI layer:
+//! a nested `block_on` on the same thread makes tokio **panic** ("Cannot start
+//! a runtime from within a runtime"), and a panic crossing the `extern "C"`
+//! boundary is **undefined behavior**. Re-entrant calls are detected at runtime
+//! by a thread-local guard and rejected with an error envelope instead of
+//! panicking (see [`ffi_block_on`]).
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 // `extern "C"` entry points dereference raw pointers (`*const c_char`) by
 // design: the C ABI contract requires callers to pass valid pointers (see
@@ -166,6 +170,47 @@ fn runtime() -> &'static Runtime {
     })
 }
 
+thread_local! {
+    /// Re-entrancy guard: set while an FFI entry point is `block_on`-ing the
+    /// shared runtime on the current thread.
+    ///
+    /// Stream callbacks (`on_part`/`on_done`/`on_error`) run synchronously on
+    /// the same thread/call-stack that entered the FFI function, so a callback
+    /// that calls back into the FFI layer would enter a second `block_on` on
+    /// this thread. tokio rejects nested `block_on` with a **panic**, and a
+    /// panic crossing the `extern "C"` boundary is UB. [`ffi_block_on`] checks
+    /// this guard and turns that re-entrant call into an error envelope
+    /// instead (issue M7).
+    static IN_FFI_BLOCK_ON: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Run a future on the shared runtime from an FFI entry point (issue M7).
+///
+/// Rejects re-entrant calls made from inside a stream callback, returning
+/// [`AiMuxError::Other`] instead of letting tokio's `block_on` panic across
+/// the `extern "C"` boundary. The guard is released when the future completes,
+/// including when it panics.
+fn ffi_block_on<F, T>(f: F) -> Result<T, AiMuxError>
+where
+    F: std::future::Future<Output = T>,
+{
+    IN_FFI_BLOCK_ON.with(|flag| {
+        if flag.replace(true) {
+            return Err(AiMuxError::Other(
+                "re-entrant FFI call from within a callback is not allowed".to_string(),
+            ));
+        }
+        struct Reset;
+        impl Drop for Reset {
+            fn drop(&mut self) {
+                IN_FFI_BLOCK_ON.with(|flag| flag.set(false));
+            }
+        }
+        let _reset = Reset;
+        Ok(runtime().block_on(f))
+    })
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -213,10 +258,23 @@ fn parse_opts(json: &str) -> Result<GenerateTextOptions, serde_json::Error> {
 
 /// Build an owned C string (`*mut c_char`) from a `String`, transferring
 /// ownership to the caller (who must free it with [`aimux_free_string`]).
+///
+/// Never returns null (issue M1): interior NUL bytes — which would make
+/// `CString::new` fail — are replaced with U+FFFD so the C-side contract
+/// ("a non-null NUL-terminated buffer to free, or null") always holds. The
+/// replacement is logged so accidental NULs stay visible.
 fn into_cstring_raw(s: String) -> *mut c_char {
-    CString::new(s)
-        .map(|c| c.into_raw())
-        .unwrap_or(std::ptr::null_mut())
+    if s.contains('\0') {
+        eprintln!(
+            "aimux-ffi: warning: string contains {} NUL byte(s); replaced with U+FFFD before FFI return",
+            s.bytes().filter(|&b| b == 0).count()
+        );
+    }
+    let sanitized = s.replace('\0', "\u{FFFD}");
+    // No interior NUL remains: this cannot fail.
+    CString::new(sanitized)
+        .expect("aimux-ffi: impossible: NUL-free string rejected by CString::new")
+        .into_raw()
 }
 
 /// Build the error envelope every FFI error path returns:
@@ -309,7 +367,7 @@ where
     F: std::future::Future<Output = Result<T, AiMuxError>>,
     T: serde::Serialize,
 {
-    let result = runtime().block_on(f);
+    let result = ffi_block_on(f).and_then(|inner| inner);
     match result {
         Ok(r) => serde_json::to_string(&r)
             .map(into_cstring_raw)
@@ -1127,7 +1185,7 @@ fn stream_text_as_openai_with_signal(
 
     opts.abort_signal = abort_signal.clone();
 
-    runtime().block_on(async move {
+    let outcome = ffi_block_on(async move {
         let stream_result = match abort_signal.as_ref() {
             Some(signal) => {
                 tokio::select! {
@@ -1177,6 +1235,11 @@ fn stream_text_as_openai_with_signal(
             Err(e) => fire_error_struct(on_error, &e),
         }
     });
+    // A re-entrant call (FFI invoked from inside a callback) fails here with
+    // an error envelope instead of panicking across the C boundary (M7).
+    if let Err(err) = outcome {
+        fire_error_struct(on_error, &err);
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1223,7 +1286,7 @@ fn stream_text_with_signal(
     };
     opts.abort_signal = abort_signal.clone();
 
-    runtime().block_on(async move {
+    let outcome = ffi_block_on(async move {
         let stream_result = match abort_signal.as_ref() {
             Some(signal) => {
                 tokio::select! {
@@ -1275,6 +1338,11 @@ fn stream_text_with_signal(
             Err(e) => fire_error_struct(on_error, &e),
         }
     });
+    // A re-entrant call (FFI invoked from inside a callback) fails here with
+    // an error envelope instead of panicking across the C boundary (M7).
+    if let Err(err) = outcome {
+        fire_error_struct(on_error, &err);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -22,10 +22,11 @@
 //! operation completes. Callbacks execute on the same thread/call-stack that
 //! invoked the FFI function, so they must **not** re-enter the FFI layer:
 //! a nested `block_on` on the same thread makes tokio **panic** ("Cannot start
-//! a runtime from within a runtime"), and a panic crossing the `extern "C"`
-//! boundary is **undefined behavior**. Re-entrant calls are detected at runtime
-//! by a thread-local guard and rejected with an error envelope instead of
-//! panicking (see [`ffi_block_on`]).
+//! a runtime from within a runtime"). An unwinding panic crossing the
+//! `extern "C"` boundary is undefined behavior; under this workspace's release
+//! profile (`panic = "abort"`) such a panic terminates the process instead.
+//! Either way the re-entrant call must be rejected before it reaches the
+//! runtime — [`ffi_block_on`] does that with a thread-local guard (issue M7).
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 // `extern "C"` entry points dereference raw pointers (`*const c_char`) by
 // design: the C ABI contract requires callers to pass valid pointers (see
@@ -177,9 +178,10 @@ thread_local! {
     /// Stream callbacks (`on_part`/`on_done`/`on_error`) run synchronously on
     /// the same thread/call-stack that entered the FFI function, so a callback
     /// that calls back into the FFI layer would enter a second `block_on` on
-    /// this thread. tokio rejects nested `block_on` with a **panic**, and a
-    /// panic crossing the `extern "C"` boundary is UB. [`ffi_block_on`] checks
-    /// this guard and turns that re-entrant call into an error envelope
+    /// this thread. tokio rejects nested `block_on` with a **panic** (which,
+    /// depending on the build profile, aborts the process or — if unwinding —
+    /// is UB once it crosses the `extern "C"` boundary). [`ffi_block_on`]
+    /// checks this guard and turns that re-entrant call into an error envelope
     /// instead (issue M7).
     static IN_FFI_BLOCK_ON: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
@@ -187,9 +189,9 @@ thread_local! {
 /// Run a future on the shared runtime from an FFI entry point (issue M7).
 ///
 /// Rejects re-entrant calls made from inside a stream callback, returning
-/// [`AiMuxError::Other`] instead of letting tokio's `block_on` panic across
-/// the `extern "C"` boundary. The guard is released when the future completes,
-/// including when it panics.
+/// [`AiMuxError::Other`] instead of letting tokio's `block_on` panic (abort
+/// under `panic = "abort"`, UB if an unwind crosses the C boundary). The
+/// guard is released when the future completes, including when it panics.
 fn ffi_block_on<F, T>(f: F) -> Result<T, AiMuxError>
 where
     F: std::future::Future<Output = T>,

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -678,20 +678,48 @@ impl Stream for TimeoutBodyStream {
 /// Body reads for 429/5xx/other failures are awaited before the next retry
 /// decision; without this, an abort during the read would be ignored until
 /// the next attempt.
+///
+/// The body is capped at [`MAX_ERROR_BODY_BYTES`] so a misbehaving provider
+/// cannot force unbounded memory growth or flood logs/FFI envelopes with a
+/// huge error payload (audit finding on issue M6).
+const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
+
 async fn read_error_body(
     resp: reqwest::Response,
     request: &HttpRequest,
 ) -> Result<String, AiMuxError> {
+    let read = async {
+        resp.bytes()
+            .await
+            .map(|bytes| {
+                let mut s = String::from_utf8_lossy(&bytes).into_owned();
+                if s.len() > MAX_ERROR_BODY_BYTES {
+                    // Truncate on a UTF-8 char boundary so the marker never
+                    // splits a multi-byte character.
+                    let mut cut = MAX_ERROR_BODY_BYTES;
+                    while !s.is_char_boundary(cut) {
+                        cut -= 1;
+                    }
+                    s.truncate(cut);
+                    s.push_str(&format!(
+                        "…(truncated, full error body {} bytes)",
+                        bytes.len()
+                    ));
+                }
+                s
+            })
+            .unwrap_or_default()
+    };
     match &request.abort_signal {
         Some(signal) => {
-            let text = resp.text();
+            let text = read;
             tokio::select! {
                 biased;
                 _ = signal.cancelled() => Err(AiMuxError::Aborted),
-                t = text => Ok(t.unwrap_or_default()),
+                t = text => Ok(t),
             }
         }
-        None => Ok(resp.text().await.unwrap_or_default()),
+        None => Ok(read.await),
     }
 }
 

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -679,9 +679,11 @@ impl Stream for TimeoutBodyStream {
 /// decision; without this, an abort during the read would be ignored until
 /// the next attempt.
 ///
-/// The body is capped at [`MAX_ERROR_BODY_BYTES`] so a misbehaving provider
-/// cannot force unbounded memory growth or flood logs/FFI envelopes with a
-/// huge error payload (audit finding on issue M6).
+/// The body is **streamed** (chunk-by-chunk) and only the first
+/// [`MAX_ERROR_BODY_BYTES`] are retained — the total byte count is still
+/// counted for the truncation marker — so a misbehaving provider cannot force
+/// unbounded memory growth or flood logs/FFI envelopes with a huge error
+/// payload (audit finding, rounds 1–2).
 const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
 
 async fn read_error_body(
@@ -689,26 +691,34 @@ async fn read_error_body(
     request: &HttpRequest,
 ) -> Result<String, AiMuxError> {
     let read = async {
-        resp.bytes()
-            .await
-            .map(|bytes| {
-                let mut s = String::from_utf8_lossy(&bytes).into_owned();
-                if s.len() > MAX_ERROR_BODY_BYTES {
-                    // Truncate on a UTF-8 char boundary so the marker never
-                    // splits a multi-byte character.
-                    let mut cut = MAX_ERROR_BODY_BYTES;
-                    while !s.is_char_boundary(cut) {
-                        cut -= 1;
-                    }
-                    s.truncate(cut);
-                    s.push_str(&format!(
-                        "…(truncated, full error body {} bytes)",
-                        bytes.len()
-                    ));
-                }
-                s
-            })
-            .unwrap_or_default()
+        let mut stream = resp.bytes_stream();
+        let mut collected: Vec<u8> = Vec::new();
+        let mut total: usize = 0;
+        while let Some(chunk) = stream.next().await {
+            let chunk = match chunk {
+                Ok(c) => c,
+                // The connection died mid-read: surface what we have.
+                Err(_) => break,
+            };
+            total += chunk.len();
+            if collected.len() < MAX_ERROR_BODY_BYTES {
+                let take = (MAX_ERROR_BODY_BYTES - collected.len()).min(chunk.len());
+                collected.extend_from_slice(&chunk[..take]);
+            }
+        }
+        let mut s = String::from_utf8_lossy(&collected).into_owned();
+        if total > MAX_ERROR_BODY_BYTES {
+            // Truncate on a UTF-8 char boundary so the marker never splits a
+            // multi-byte character. `0` is always a char boundary, so the
+            // loop terminates.
+            let mut cut = s.len().min(MAX_ERROR_BODY_BYTES);
+            while !s.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            s.truncate(cut);
+            s.push_str(&format!("…(truncated, full error body {total} bytes)"));
+        }
+        s
     };
     match &request.abort_signal {
         Some(signal) => {

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -700,16 +700,17 @@ async fn read_error_body(
                 // The connection died mid-read: surface what we have.
                 Err(_) => break,
             };
-            total += chunk.len();
+            total = total.saturating_add(chunk.len());
             if collected.len() < MAX_ERROR_BODY_BYTES {
                 let take = (MAX_ERROR_BODY_BYTES - collected.len()).min(chunk.len());
                 collected.extend_from_slice(&chunk[..take]);
             }
         }
         let mut s = String::from_utf8_lossy(&collected).into_owned();
-        // Lossy decoding can expand invalid bytes (each became U+FFFD, 3
-        // bytes), so gate the cap on the *decoded* length, not just `total`.
-        if s.len() > MAX_ERROR_BODY_BYTES {
+        // Truncate when either the raw body exceeded the budget (marker must
+        // warn that content was dropped) or lossy decoding expanded the string
+        // (invalid bytes become 3-byte U+FFFD) beyond the budget.
+        if total > MAX_ERROR_BODY_BYTES || s.len() > MAX_ERROR_BODY_BYTES {
             // Truncate on a UTF-8 char boundary so the marker never splits a
             // multi-byte character. `0` is always a char boundary, so the
             // loop terminates.

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -747,9 +747,13 @@ async fn send_with_retry_raw(
                             .and_then(|v| v.to_str().ok()),
                         SystemTime::now(),
                     );
-                    let _ = read_error_body(resp, request).await?; // 消费 body
+                    // Keep the provider's rate-limit body (e.g. "quota
+                    // exceeded" vs "too many requests") so consumers can tell
+                    // the two apart (issue M6).
+                    let body = read_error_body(resp, request).await?;
                     last_error = AiMuxError::RateLimited {
                         retry_after_ms: hint.unwrap_or(1000).max(0) as u64,
+                        message: format!("HTTP {status_code}: {}", body),
                     };
                 } else if resp.status().is_server_error() {
                     // 5xx: 可重试。

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -707,7 +707,9 @@ async fn read_error_body(
             }
         }
         let mut s = String::from_utf8_lossy(&collected).into_owned();
-        if total > MAX_ERROR_BODY_BYTES {
+        // Lossy decoding can expand invalid bytes (each became U+FFFD, 3
+        // bytes), so gate the cap on the *decoded* length, not just `total`.
+        if s.len() > MAX_ERROR_BODY_BYTES {
             // Truncate on a UTF-8 char boundary so the marker never splits a
             // multi-byte character. `0` is always a char boundary, so the
             // loop terminates.

--- a/aimux-provider-utils/src/response.rs
+++ b/aimux-provider-utils/src/response.rs
@@ -76,6 +76,7 @@ pub fn parse_provider_error(status: u16, body: &str, structure: &ErrorStructure)
         401 => AiMuxError::Auth(message),
         429 => AiMuxError::RateLimited {
             retry_after_ms: 1000,
+            message: format!("HTTP 429: {}", message),
         },
         404 => AiMuxError::ModelNotFound(message),
         _ => AiMuxError::Provider(format!("HTTP {}: {}", status, message)),

--- a/aimux-provider-utils/tests/http_send_test.rs
+++ b/aimux-provider-utils/tests/http_send_test.rs
@@ -532,3 +532,43 @@ async fn abort_wins_over_total_timeout() {
         .expect("task must not panic");
     assert!(matches!(result, Err(AiMuxError::Aborted)), "got {result:?}");
 }
+
+/// Regression (audit round 3, B1): a large *valid-UTF-8* error body must be
+/// truncated with a marker — a silent truncation would make callers believe
+/// the response body was complete.
+#[tokio::test]
+async fn truncates_large_error_body_with_marker() {
+    let server = MockServer::start().await;
+    let big_body = "x".repeat(100 * 1024);
+    Mock::given(method("POST"))
+        .and(path("/v1/chat"))
+        .respond_with(ResponseTemplate::new(429).set_body_string(big_body))
+        .up_to_n_times(3)
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/v1/chat", server.uri());
+    let no_retry = RetryConfig {
+        max_retries: 0,
+        ..RetryConfig::default()
+    };
+    let err = send(json_post(&url), no_retry, &DEFAULT_ERROR_STRUCTURE)
+        .await
+        .unwrap_err();
+
+    match err {
+        AiMuxError::RateLimited { message, .. } => {
+            assert!(
+                message.contains("(truncated"),
+                "large error body must be marked as truncated, got len={}",
+                message.len()
+            );
+            assert!(
+                message.len() < 70 * 1024,
+                "truncated message must stay bounded, got {} bytes",
+                message.len()
+            );
+        }
+        other => panic!("expected RateLimited, got {other:?}"),
+    }
+}

--- a/aimux-provider-utils/tests/retry_with_exponential_backoff.rs
+++ b/aimux-provider-utils/tests/retry_with_exponential_backoff.rs
@@ -181,6 +181,7 @@ async fn uses_rate_limit_header_delay_when_reasonable() {
         if n == 1 {
             Some(AiMuxError::RateLimited {
                 retry_after_ms: 3000,
+                message: String::new(),
             })
         } else {
             None
@@ -211,6 +212,7 @@ async fn uses_exponential_backoff_when_delay_too_long() {
         if n == 1 {
             Some(AiMuxError::RateLimited {
                 retry_after_ms: 70_000,
+                message: String::new(),
             })
         } else {
             None
@@ -271,6 +273,7 @@ async fn handles_anthropic_429_with_retry_after_ms() {
         if n == 1 {
             Some(AiMuxError::RateLimited {
                 retry_after_ms: 5000,
+                message: String::new(),
             })
         } else {
             None
@@ -302,9 +305,11 @@ async fn multiple_retries_with_exponential_progression() {
     let closure = failing_then_success(counter.clone(), |n| match n {
         1 => Some(AiMuxError::RateLimited {
             retry_after_ms: 5000,
+            message: String::new(),
         }),
         2 => Some(AiMuxError::RateLimited {
             retry_after_ms: 2000,
+            message: String::new(),
         }),
         _ => None,
     });
@@ -368,6 +373,7 @@ async fn retries_on_gateway_rate_limit_error() {
         if n == 1 {
             Some(AiMuxError::RateLimited {
                 retry_after_ms: 2000,
+                message: String::new(),
             })
         } else {
             None
@@ -421,6 +427,7 @@ async fn uses_retry_after_hint_from_wrapped_error() {
         if n == 1 {
             Some(AiMuxError::RateLimited {
                 retry_after_ms: 3000,
+                message: String::new(),
             })
         } else {
             None

--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -1288,6 +1288,7 @@ fn insert_anthropic_thinking(
 /// adjusted `max_tokens` (unchanged when thinking is not enabled).
 #[allow(clippy::too_many_arguments)]
 fn apply_anthropic_thinking_post_processing(
+    body: &mut Value,
     thinking_type: &Option<String>,
     thinking_budget: &mut Option<u32>,
     max_tokens: u32,
@@ -1310,6 +1311,12 @@ fn apply_anthropic_thinking_post_processing(
             ),
         });
         *thinking_budget = Some(1024);
+        // Mirrors the original implementation: the default budget must also be
+        // written into the `thinking` body field, not just added to max_tokens
+        // (audit finding — default budget was dropped during the M11 split).
+        if let Some(thinking_obj) = body.get_mut("thinking") {
+            thinking_obj["budget_tokens"] = json!(1024);
+        }
     }
 
     if temperature.is_some() {
@@ -1629,6 +1636,7 @@ pub fn build_request_body_with_warnings(
     // Thinking-enabled post-processing (TS L651-696): default budget,
     // sampling-parameter stripping, `max_tokens` adjustment.
     let adjusted_max_tokens = apply_anthropic_thinking_post_processing(
+        &mut body,
         &thinking_type,
         &mut thinking_budget,
         max_tokens,
@@ -1680,5 +1688,46 @@ pub fn parse_stop_reason(s: &str) -> FinishReason {
     FinishReason {
         unified,
         raw: Some(s.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_with_anthropic_thinking(thinking: serde_json::Value) -> CallOptions {
+        let mut provider = std::collections::HashMap::new();
+        provider.insert("anthropic".to_string(), thinking);
+        CallOptions {
+            provider_options: Some(provider),
+            ..CallOptions::new(LanguageModelPrompt::default())
+        }
+    }
+
+    /// Regression (audit finding on the M11 split): when `thinking.enabled` is
+    /// set without an explicit `budgetTokens`, the body must carry both the
+    /// default `budget_tokens: 1024` **and** the adjusted `max_tokens`
+    /// (base + 1024), exactly like the pre-split implementation.
+    #[test]
+    fn thinking_enabled_without_budget_writes_default_budget() {
+        let opts = opts_with_anthropic_thinking(json!({
+            "thinking": { "type": "enabled" }
+        }));
+        let req = build_request_body_with_warnings("claude-sonnet-4-5", &opts, false).unwrap();
+        assert_eq!(req.body["thinking"]["type"], json!("enabled"));
+        assert_eq!(req.body["thinking"]["budget_tokens"], json!(1024));
+        // claude-sonnet-4-5 caps: 64000 tokens, +1024 thinking budget.
+        assert_eq!(req.body["max_tokens"], json!(65024));
+    }
+
+    /// Explicit `budgetTokens` must be preserved (no default override).
+    #[test]
+    fn thinking_enabled_with_explicit_budget_keeps_it() {
+        let opts = opts_with_anthropic_thinking(json!({
+            "thinking": { "type": "enabled", "budgetTokens": 4096 }
+        }));
+        let req = build_request_body_with_warnings("claude-sonnet-4-5", &opts, false).unwrap();
+        assert_eq!(req.body["thinking"]["budget_tokens"], json!(4096));
+        assert_eq!(req.body["max_tokens"], json!(64000 + 4096));
     }
 }

--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -1,4 +1,4 @@
-﻿//! Conversion between `LanguageModelPrompt` and Anthropic API format.
+//! Conversion between `LanguageModelPrompt` and Anthropic API format.
 //!
 //! This is the single (merged) Anthropic convert module. It provides the full
 //! `convertToAnthropicPrompt` implementation with betas, warnings, and
@@ -910,15 +910,6 @@ fn get_model_capabilities(model_id: &str) -> ModelCapabilities {
     }
 }
 
-/// Returns `true` when the reasoning effort is a user-chosen level (i.e. not
-/// `ProviderDefault` and not absent), mirroring the TS `isCustomReasoning`.
-fn is_custom_reasoning(reasoning: Option<ReasoningEffort>) -> bool {
-    match reasoning {
-        Some(ReasoningEffort::ProviderDefault) | None => false,
-        Some(_) => true,
-    }
-}
-
 /// The Anthropic thinking config + optional effort resolved from a top-level
 /// reasoning level, mirroring the TS `resolveAnthropicReasoningConfig` return.
 struct ReasoningConfig {
@@ -1105,42 +1096,20 @@ pub fn build_request_body(
     stream: bool,
 ) -> Result<Value, AiMuxError> {
     Ok(build_request_body_with_warnings(model_id, options, stream)?.body)
-}
+} // ── Request-body construction (split into helpers, issue M11) ───────────────
 
-/// Build the Anthropic request body, returning warnings alongside the body.
-///
-/// Implements the thinking/reasoning pipeline from the TS
-/// `anthropic-language-model.ts` `getArgs`: model-capability detection,
-/// `rejectsSamplingParameters` stripping, top-level `reasoning` → thinking/
-/// effort mapping (provider options take precedence), and thinking-enabled
-/// default budget, sampling-parameter stripping, and `max_tokens` adjustment.
-pub fn build_request_body_with_warnings(
-    model_id: &str,
+/// Strip temperature / topK / topP when the model rejects sampling parameters
+/// (with a compatibility warning per stripped value).
+fn strip_anthropic_sampling_params(
     options: &CallOptions,
-    stream: bool,
-) -> Result<RequestBodyResult, AiMuxError> {
-    let mut warnings: Vec<Warning> = Vec::new();
-    let mut betas: BTreeSet<String> = BTreeSet::new();
-    let caps = get_model_capabilities(model_id);
-
-    // Unknown-model max output tokens warning (TS L305-314): when the model is
-    // not recognised and the caller did not set maxOutputTokens, emit a
-    // compatibility warning noting the default limit applied.
-    if !caps.is_known_model && options.max_output_tokens.is_none() {
-        warnings.push(Warning::Compatibility {
-            feature: "maxOutputTokens".to_string(),
-            details: Some(format!(
-                "The model \"{}\" is unknown. The max output tokens have been limited to {}. Set maxOutputTokens explicitly to override this limit.",
-                model_id, caps.max_output_tokens
-            )),
-        });
-    }
-
+    model_id: &str,
+    caps: &ModelCapabilities,
+    warnings: &mut Vec<Warning>,
+) -> (Option<f64>, Option<f64>, Option<f64>) {
     let mut temperature = options.temperature;
     let mut top_p = options.top_p;
     let mut top_k = options.top_k;
 
-    // rejectsSamplingParameters: strip temperature/topK/topP with warnings.
     if caps.rejects_sampling_parameters {
         if temperature.is_some() {
             warnings.push(Warning::Unsupported {
@@ -1174,41 +1143,56 @@ pub fn build_request_body_with_warnings(
         }
     }
 
-    // providerOptions.anthropic.thinking / .effort take precedence over the
-    // top-level `reasoning`. The top-level mapping only runs when `effort` is
-    // not already set by provider options (TS L426-445).
+    (temperature, top_p, top_k)
+}
+
+/// Resolve thinking config + optional effort from provider options and the
+/// top-level `reasoning` level.
+///
+/// `providerOptions.anthropic.thinking` / `.effort` take precedence over the
+/// top-level `reasoning`; the top-level mapping only runs when `effort` is not
+/// already set by provider options (TS L426-445). Also lowers xhigh/max to
+/// high when the model rejects disabling thinking above high effort
+/// (TS L451-464).
+fn resolve_anthropic_thinking(
+    model_id: &str,
+    options: &CallOptions,
+    caps: &ModelCapabilities,
+    warnings: &mut Vec<Warning>,
+) -> (Option<Value>, Option<String>) {
     let mut thinking_config: Option<Value> =
         anthropic_option(&options.provider_options, "thinking");
     let mut effort: Option<String> = anthropic_option(&options.provider_options, "effort")
         .and_then(|v| v.as_str().map(|s| s.to_string()));
 
-    if is_custom_reasoning(options.reasoning) && effort.is_none() {
-        let reasoning = options.reasoning.unwrap();
-        if let Some(rc) = resolve_anthropic_reasoning_config(
+    if let Some(reasoning) = options.reasoning
+        && reasoning.is_custom()
+        && effort.is_none()
+        && let Some(rc) = resolve_anthropic_reasoning_config(
             reasoning,
             caps.supports_adaptive_thinking,
             caps.supports_xhigh_effort,
             caps.max_output_tokens,
-            &mut warnings,
-        ) {
-            if thinking_config.is_none() {
-                thinking_config = Some(rc.thinking);
-            }
-            if let Some(eff) = rc.effort {
-                let is_disabled = thinking_config
-                    .as_ref()
-                    .and_then(|t| t.get("type"))
-                    .and_then(|t| t.as_str())
-                    == Some("disabled");
-                if !is_disabled {
-                    effort = Some(eff);
-                }
+            warnings,
+        )
+    {
+        if thinking_config.is_none() {
+            thinking_config = Some(rc.thinking);
+        }
+        if let Some(eff) = rc.effort {
+            let is_disabled = thinking_config
+                .as_ref()
+                .and_then(|t| t.get("type"))
+                .and_then(|t| t.as_str())
+                == Some("disabled");
+            if !is_disabled {
+                effort = Some(eff);
             }
         }
     }
 
-    // Newer models only allow disabling thinking at effort ≤ high; lower
-    // xhigh/max to high (TS L451-464).
+    // Newer models only allow disabling thinking at effort ≤ high; lower the
+    // effort to 'high' with a warning (TS L451-464).
     if caps.rejects_thinking_disabled_above_high_effort {
         let is_disabled = thinking_config
             .as_ref()
@@ -1228,6 +1212,16 @@ pub fn build_request_body_with_warnings(
         }
     }
 
+    (thinking_config, effort)
+}
+
+/// Derived fields from the resolved thinking config: the type string, whether
+/// thinking must be forwarded (enabled/adaptive/disabled — some models default
+/// thinking on, so omitting `disabled` would leave it enabled), the budget
+/// (enabled only), and the display value (adaptive only).
+fn derive_anthropic_thinking(
+    thinking_config: &Option<Value>,
+) -> (Option<String>, bool, Option<u32>, Option<Value>) {
     let thinking_type: Option<String> = thinking_config
         .as_ref()
         .and_then(|t| t.get("type"))
@@ -1236,11 +1230,9 @@ pub fn build_request_body_with_warnings(
 
     let is_thinking =
         thinking_type.as_deref() == Some("enabled") || thinking_type.as_deref() == Some("adaptive");
-    // `disabled` must still be forwarded to the API: some models default
-    // thinking on, so omitting it would leave thinking enabled.
     let send_thinking = is_thinking || thinking_type.as_deref() == Some("disabled");
 
-    let mut thinking_budget: Option<u32> = if thinking_type.as_deref() == Some("enabled") {
+    let thinking_budget: Option<u32> = if thinking_type.as_deref() == Some("enabled") {
         thinking_config
             .as_ref()
             .and_then(|t| t.get("budgetTokens"))
@@ -1258,79 +1250,101 @@ pub fn build_request_body_with_warnings(
         None
     };
 
-    let max_tokens = options.max_output_tokens.unwrap_or(caps.max_output_tokens);
+    (
+        thinking_type,
+        send_thinking,
+        thinking_budget,
+        thinking_display,
+    )
+}
 
-    let conversion = convert_prompt_to_anthropic_full_fallible(&options.prompt, false)?;
-    let system = conversion.system;
-    let messages = conversion.messages;
-    betas.extend(conversion.betas);
-    warnings.extend(conversion.warnings);
-
-    let mut body = json!({
-        "model": model_id,
-        "messages": messages,
-        "max_tokens": max_tokens,
-        "stream": stream,
-    });
-
-    if let Some(sys) = system {
-        body["system"] = json!(sys);
-    }
-
-    if send_thinking && let Some(ref tt) = thinking_type {
+/// Insert the `thinking` / `output_config` fields into the body.
+fn insert_anthropic_thinking(
+    body: &mut Value,
+    thinking_type: &Option<String>,
+    send_thinking: bool,
+    thinking_budget: &Option<u32>,
+    thinking_display: &Option<Value>,
+    effort: &Option<String>,
+) {
+    if send_thinking && let Some(tt) = thinking_type {
         let mut thinking_obj = json!({ "type": tt });
         if let Some(b) = thinking_budget {
             thinking_obj["budget_tokens"] = json!(b);
         }
         if let Some(d) = thinking_display {
-            thinking_obj["display"] = d;
+            thinking_obj["display"] = d.clone();
         }
         body["thinking"] = thinking_obj;
     }
 
-    if let Some(ref eff) = effort {
+    if let Some(eff) = effort {
         body["output_config"] = json!({ "effort": eff });
     }
+}
 
-    // thinking-enabled post-processing (TS L651-696).
-    if is_thinking {
-        if thinking_type.as_deref() == Some("enabled") && thinking_budget.is_none() {
-            warnings.push(Warning::Compatibility {
-                feature: "extended thinking".to_string(),
-                details: Some(
-                    "thinking budget is required when thinking is enabled. using default budget of 1024 tokens.".to_string(),
-                ),
-            });
-            thinking_budget = Some(1024);
-            body["thinking"]["budget_tokens"] = json!(1024);
-        }
-
-        if temperature.is_some() {
-            warnings.push(Warning::Unsupported {
-                feature: "temperature".to_string(),
-                details: Some("temperature is not supported when thinking is enabled".to_string()),
-            });
-            temperature = None;
-        }
-        if top_k.is_some() {
-            warnings.push(Warning::Unsupported {
-                feature: "topK".to_string(),
-                details: Some("topK is not supported when thinking is enabled".to_string()),
-            });
-            top_k = None;
-        }
-        if top_p.is_some() {
-            warnings.push(Warning::Unsupported {
-                feature: "topP".to_string(),
-                details: Some("topP is not supported when thinking is enabled".to_string()),
-            });
-            top_p = None;
-        }
-
-        let budget = thinking_budget.unwrap_or(0);
-        body["max_tokens"] = json!(max_tokens + budget);
+/// Thinking-enabled post-processing (TS L651-696): default budget warning,
+/// sampling-parameter stripping, and `max_tokens` adjustment. Returns the
+/// adjusted `max_tokens` (unchanged when thinking is not enabled).
+#[allow(clippy::too_many_arguments)]
+fn apply_anthropic_thinking_post_processing(
+    thinking_type: &Option<String>,
+    thinking_budget: &mut Option<u32>,
+    max_tokens: u32,
+    temperature: &mut Option<f64>,
+    top_k: &mut Option<f64>,
+    top_p: &mut Option<f64>,
+    warnings: &mut Vec<Warning>,
+) -> u32 {
+    let is_thinking =
+        thinking_type.as_deref() == Some("enabled") || thinking_type.as_deref() == Some("adaptive");
+    if !is_thinking {
+        return max_tokens;
     }
 
+    if thinking_type.as_deref() == Some("enabled") && thinking_budget.is_none() {
+        warnings.push(Warning::Compatibility {
+            feature: "extended thinking".to_string(),
+            details: Some(
+                "thinking budget is required when thinking is enabled. using default budget of 1024 tokens.".to_string(),
+            ),
+        });
+        *thinking_budget = Some(1024);
+    }
+
+    if temperature.is_some() {
+        warnings.push(Warning::Unsupported {
+            feature: "temperature".to_string(),
+            details: Some("temperature is not supported when thinking is enabled".to_string()),
+        });
+        *temperature = None;
+    }
+    if top_k.is_some() {
+        warnings.push(Warning::Unsupported {
+            feature: "topK".to_string(),
+            details: Some("topK is not supported when thinking is enabled".to_string()),
+        });
+        *top_k = None;
+    }
+    if top_p.is_some() {
+        warnings.push(Warning::Unsupported {
+            feature: "topP".to_string(),
+            details: Some("topP is not supported when thinking is enabled".to_string()),
+        });
+        *top_p = None;
+    }
+
+    max_tokens + thinking_budget.unwrap_or(0)
+}
+
+/// Insert the surviving sampling params + stop sequences into the body.
+fn insert_anthropic_sampling(
+    body: &mut Value,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<f64>,
+    options: &CallOptions,
+) {
     if let Some(temp) = temperature {
         body["temperature"] = json!(temp);
     }
@@ -1343,10 +1357,19 @@ pub fn build_request_body_with_warnings(
     if let Some(ref stop) = options.stop_sequences {
         body["stop_sequences"] = json!(stop);
     }
+}
 
-    // Tools — delegate to `prepare_tools_with_provider` so that provider-defined
-    // tools (web search, code execution, ...) are mapped alongside function
-    // tools, and the required beta headers / tool warnings are surfaced.
+/// Map user tools to `tools` / `tool_choice`, delegating to
+/// `prepare_tools_with_provider` (provider-defined tools, required beta
+/// headers, and tool warnings).
+fn apply_anthropic_tools(
+    body: &mut Value,
+    options: &CallOptions,
+    stream: bool,
+    caps: &ModelCapabilities,
+    betas: &mut BTreeSet<String>,
+    warnings: &mut Vec<Warning>,
+) {
     let disable_parallel_tool_use =
         anthropic_option(&options.provider_options, "disableParallelToolUse")
             .and_then(|v| v.as_bool())
@@ -1400,140 +1423,238 @@ pub fn build_request_body_with_warnings(
     if let Some(tool_choice) = prepared.tool_choice {
         body["tool_choice"] = tool_choice;
     }
+}
 
-    // providerOptions.anthropic.mcpServers → request body `mcp_servers` +
-    // `mcp-client-2025-04-04` beta header.
-    if let Some(mcp) = anthropic_option(&options.provider_options, "mcpServers")
-        && let Some(arr) = mcp.as_array()
-        && !arr.is_empty()
-    {
-        let mapped: Vec<Value> = arr
-            .iter()
-            .map(|server| {
-                let mut o = Map::new();
-                if let Some(t) = server.get("type") {
-                    o.insert("type".to_string(), t.clone());
-                }
-                if let Some(n) = server.get("name") {
-                    o.insert("name".to_string(), n.clone());
-                }
-                if let Some(u) = server.get("url") {
-                    o.insert("url".to_string(), u.clone());
-                }
-                if let Some(at) = server.get("authorizationToken") {
-                    o.insert("authorization_token".to_string(), at.clone());
-                }
-                if let Some(tc) = server.get("toolConfiguration") {
-                    let mut tc_obj = Map::new();
-                    if let Some(at) = tc.get("allowedTools") {
-                        tc_obj.insert("allowed_tools".to_string(), at.clone());
-                    }
-                    if let Some(en) = tc.get("enabled") {
-                        tc_obj.insert("enabled".to_string(), en.clone());
-                    }
-                    o.insert("tool_configuration".to_string(), Value::Object(tc_obj));
-                }
-                Value::Object(o)
-            })
-            .collect();
-        body["mcp_servers"] = json!(mapped);
-        betas.insert("mcp-client-2025-04-04".to_string());
+/// `providerOptions.anthropic.mcpServers` → `mcp_servers` + the
+/// `mcp-client-2025-04-04` beta header.
+fn append_anthropic_mcp_servers(
+    body: &mut Value,
+    options: &CallOptions,
+    betas: &mut BTreeSet<String>,
+) {
+    let Some(mcp) = anthropic_option(&options.provider_options, "mcpServers") else {
+        return;
+    };
+    let Some(arr) = mcp.as_array() else {
+        return;
+    };
+    if arr.is_empty() {
+        return;
     }
 
-    // providerOptions.anthropic.container — programmatic tool calling
-    // (string id) or agent skills (object with id + skills).
-    if let Some(container) = anthropic_option(&options.provider_options, "container") {
-        let skills = container.get("skills").and_then(|s| s.as_array());
-        if let Some(skills_arr) = skills.filter(|a| !a.is_empty()) {
-            let mut container_obj = Map::new();
-            if let Some(id) = container.get("id")
-                && !id.is_null()
-            {
-                container_obj.insert("id".to_string(), id.clone());
+    let mapped: Vec<Value> = arr
+        .iter()
+        .map(|server| {
+            let mut o = Map::new();
+            if let Some(t) = server.get("type") {
+                o.insert("type".to_string(), t.clone());
             }
-            let mut skills_mapped: Vec<Value> = Vec::new();
-            for skill in skills_arr {
-                let stype = skill.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                let skill_id = if stype == "custom" {
-                    match skill
-                        .get("providerReference")
-                        .and_then(|r| r.get("anthropic"))
-                    {
-                        Some(id) => id.clone(),
-                        None => {
-                            return Err(AiMuxError::Unsupported(format!(
-                                "skill provider reference is missing the 'anthropic' key: {}",
-                                skill
-                            )));
-                        }
-                    }
-                } else {
-                    skill.get("skillId").cloned().unwrap_or(Value::Null)
-                };
-                let mut s = Map::new();
-                s.insert("type".to_string(), json!(stype));
-                s.insert("skill_id".to_string(), skill_id);
-                if let Some(v) = skill.get("version")
-                    && !v.is_null()
-                {
-                    s.insert("version".to_string(), v.clone());
+            if let Some(n) = server.get("name") {
+                o.insert("name".to_string(), n.clone());
+            }
+            if let Some(u) = server.get("url") {
+                o.insert("url".to_string(), u.clone());
+            }
+            if let Some(at) = server.get("authorizationToken") {
+                o.insert("authorization_token".to_string(), at.clone());
+            }
+            if let Some(tc) = server.get("toolConfiguration") {
+                let mut tc_obj = Map::new();
+                if let Some(at) = tc.get("allowedTools") {
+                    tc_obj.insert("allowed_tools".to_string(), at.clone());
                 }
-                skills_mapped.push(Value::Object(s));
+                if let Some(en) = tc.get("enabled") {
+                    tc_obj.insert("enabled".to_string(), en.clone());
+                }
+                o.insert("tool_configuration".to_string(), Value::Object(tc_obj));
             }
-            container_obj.insert("skills".to_string(), json!(skills_mapped));
-            body["container"] = json!(container_obj);
-            betas.insert("code-execution-2025-08-25".to_string());
-            betas.insert("skills-2025-10-02".to_string());
-            betas.insert("files-api-2025-04-14".to_string());
+            Value::Object(o)
+        })
+        .collect();
+    body["mcp_servers"] = json!(mapped);
+    betas.insert("mcp-client-2025-04-04".to_string());
+}
 
-            // Warn when skills are configured without a code execution tool.
-            let has_code_exec = options
-                .tools
-                .as_ref()
-                .map(|t| {
-                    t.iter().any(|tool| match tool {
-                        Tool::Provider(pt) => {
-                            pt.id == "anthropic.code_execution_20250825"
-                                || pt.id == "anthropic.code_execution_20260120"
-                        }
-                        _ => false,
-                    })
-                })
-                .unwrap_or(false);
-            if !has_code_exec {
-                warnings.push(Warning::Other {
-                    message: "code execution tool is required when using skills".to_string(),
-                });
-            }
-        } else if let Some(id) = container.get("id")
+/// `providerOptions.anthropic.container` — programmatic tool calling (string
+/// id) or agent skills (object with id + skills). Skills require the code
+/// execution beta headers; returns an error when a custom skill's provider
+/// reference lacks the `anthropic` key.
+fn append_anthropic_container(
+    body: &mut Value,
+    options: &CallOptions,
+    betas: &mut BTreeSet<String>,
+    warnings: &mut Vec<Warning>,
+) -> Result<(), AiMuxError> {
+    let Some(container) = anthropic_option(&options.provider_options, "container") else {
+        return Ok(());
+    };
+    let skills = container.get("skills").and_then(|s| s.as_array());
+    if let Some(skills_arr) = skills.filter(|a| !a.is_empty()) {
+        let mut container_obj = Map::new();
+        if let Some(id) = container.get("id")
             && !id.is_null()
         {
-            body["container"] = id.clone();
+            container_obj.insert("id".to_string(), id.clone());
         }
+        let mut skills_mapped: Vec<Value> = Vec::new();
+        for skill in skills_arr {
+            let stype = skill.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let skill_id = if stype == "custom" {
+                match skill
+                    .get("providerReference")
+                    .and_then(|r| r.get("anthropic"))
+                {
+                    Some(id) => id.clone(),
+                    None => {
+                        return Err(AiMuxError::Unsupported(format!(
+                            "skill provider reference is missing the 'anthropic' key: {}",
+                            skill
+                        )));
+                    }
+                }
+            } else {
+                skill.get("skillId").cloned().unwrap_or(Value::Null)
+            };
+            let mut s = Map::new();
+            s.insert("type".to_string(), json!(stype));
+            s.insert("skill_id".to_string(), skill_id);
+            if let Some(v) = skill.get("version")
+                && !v.is_null()
+            {
+                s.insert("version".to_string(), v.clone());
+            }
+            skills_mapped.push(Value::Object(s));
+        }
+        container_obj.insert("skills".to_string(), json!(skills_mapped));
+        body["container"] = json!(container_obj);
+        betas.insert("code-execution-2025-08-25".to_string());
+        betas.insert("skills-2025-10-02".to_string());
+        betas.insert("files-api-2025-04-14".to_string());
+
+        // Warn when skills are configured without a code execution tool.
+        let has_code_exec = options
+            .tools
+            .as_ref()
+            .map(|t| {
+                t.iter().any(|tool| match tool {
+                    Tool::Provider(pt) => {
+                        pt.id == "anthropic.code_execution_20250825"
+                            || pt.id == "anthropic.code_execution_20260120"
+                    }
+                    _ => false,
+                })
+            })
+            .unwrap_or(false);
+        if !has_code_exec {
+            warnings.push(Warning::Other {
+                message: "code execution tool is required when using skills".to_string(),
+            });
+        }
+    } else if let Some(id) = container.get("id")
+        && !id.is_null()
+    {
+        body["container"] = id.clone();
+    }
+    Ok(())
+}
+
+/// Build the Anthropic request body, returning warnings alongside the body.
+///
+/// Implements the thinking/reasoning pipeline from the TS
+/// `anthropic-language-model.ts` `getArgs`: model-capability detection,
+/// `rejectsSamplingParameters` stripping, top-level `reasoning` → thinking/
+/// effort mapping (provider options take precedence), and thinking-enabled
+/// default budget. The single oversized function was split into focused
+/// helpers (issue M11); behavior is unchanged.
+pub fn build_request_body_with_warnings(
+    model_id: &str,
+    options: &CallOptions,
+    stream: bool,
+) -> Result<RequestBodyResult, AiMuxError> {
+    let mut warnings: Vec<Warning> = Vec::new();
+    let mut betas: BTreeSet<String> = BTreeSet::new();
+    let caps = get_model_capabilities(model_id);
+
+    // Unknown-model max output tokens warning (TS L305-314): for models we do
+    // not recognise, note the applied default limit when the caller did not
+    // set maxOutputTokens.
+    if !caps.is_known_model && options.max_output_tokens.is_none() {
+        warnings.push(Warning::Compatibility {
+            feature: "maxOutputTokens".to_string(),
+            details: Some(format!(
+                "The model \"{}\" is unknown. The max output tokens have been limited to {}. Set maxOutputTokens explicitly to override this limit.",
+                model_id, caps.max_output_tokens
+            )),
+        });
     }
 
-    // providerOptions.anthropic.contextManagement → request body
-    // `context_management` + `context-management-2025-06-27` beta (and
-    // `compact-2026-01-12` when a compact edit is present).
-    // TODO: implement build_context_management (context management API not yet implemented)
-    // if let Some(cm) = anthropic_option(&options.provider_options, "contextManagement") {
-    //     if let Some(mapped) = build_context_management(&cm, &mut warnings) {
-    //         let has_compact = cm
-    //             .get("edits")
-    //             .and_then(|e| e.as_array())
-    //             .map(|edits| {
-    //                 edits.iter().any(|e| {
-    //                     e.get("type").and_then(|t| t.as_str()) == Some("compact_20260112")
-    //                 })
-    //             })
-    //             .unwrap_or(false);
-    //         betas.insert("context-management-2025-06-27".to_string());
-    //         if has_compact {
-    //             betas.insert("compact-2026-01-12".to_string());
-    //         }
-    //         body["context_management"] = mapped;
-    //     }
-    // }
+    // rejectsSamplingParameters: strip temperature/topK/topP with warnings.
+    let (mut temperature, mut top_p, mut top_k) =
+        strip_anthropic_sampling_params(options, model_id, &caps, &mut warnings);
+
+    // providerOptions.anthropic.thinking / .effort + top-level `reasoning`.
+    let (thinking_config, thinking_effort) =
+        resolve_anthropic_thinking(model_id, options, &caps, &mut warnings);
+    let (thinking_type, send_thinking, mut thinking_budget, thinking_display) =
+        derive_anthropic_thinking(&thinking_config);
+
+    let max_tokens = options.max_output_tokens.unwrap_or(caps.max_output_tokens);
+
+    let conversion = convert_prompt_to_anthropic_full_fallible(&options.prompt, false)?;
+    let system = conversion.system;
+    let messages = conversion.messages;
+    betas.extend(conversion.betas);
+    warnings.extend(conversion.warnings);
+
+    let mut body = json!({
+        "model": model_id,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "stream": stream,
+    });
+
+    if let Some(sys) = system {
+        body["system"] = json!(sys);
+    }
+
+    insert_anthropic_thinking(
+        &mut body,
+        &thinking_type,
+        send_thinking,
+        &thinking_budget,
+        &thinking_display,
+        &thinking_effort,
+    );
+
+    // Thinking-enabled post-processing (TS L651-696): default budget,
+    // sampling-parameter stripping, `max_tokens` adjustment.
+    let adjusted_max_tokens = apply_anthropic_thinking_post_processing(
+        &thinking_type,
+        &mut thinking_budget,
+        max_tokens,
+        &mut temperature,
+        &mut top_k,
+        &mut top_p,
+        &mut warnings,
+    );
+    if adjusted_max_tokens != max_tokens {
+        body["max_tokens"] = json!(adjusted_max_tokens);
+    }
+
+    insert_anthropic_sampling(&mut body, temperature, top_p, top_k, options);
+
+    // Tools — provider-defined tools alongside function tools, plus the
+    // required beta headers / tool warnings.
+    apply_anthropic_tools(&mut body, options, stream, &caps, &mut betas, &mut warnings);
+
+    // providerOptions.anthropic.mcpServers → mcp_servers + beta header.
+    append_anthropic_mcp_servers(&mut body, options, &mut betas);
+
+    // providerOptions.anthropic.container — programmatic tool calling / skills.
+    append_anthropic_container(&mut body, options, &mut betas, &mut warnings)?;
+
+    // providerOptions.anthropic.contextManagement → context_management is not
+    // yet implemented (build_context_management pending).
 
     // Per-call request body overrides (RFC-0017): deep-merge user-supplied
     // JSON into the built body. `null` values delete the corresponding key.

--- a/aimux-providers/src/aws_polly.rs
+++ b/aimux-providers/src/aws_polly.rs
@@ -21,7 +21,6 @@ use async_trait::async_trait;
 use serde_json::{Map, Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::shared::{SharedProviderOptions, Warning};
 use aimux_core::speech_model::{
@@ -199,13 +198,6 @@ impl AwsPollyProvider {
 impl Provider for AwsPollyProvider {
     fn name(&self) -> &str {
         PROVIDER_NAME
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "Amazon Polly is a speech-only provider; language models are not supported."
-                .to_string(),
-        ))
     }
 }
 
@@ -488,6 +480,7 @@ fn parse_polly_error(status: u16, body: &str) -> AiMuxError {
         401 | 403 => AiMuxError::Auth(message),
         429 => AiMuxError::RateLimited {
             retry_after_ms: 1000,
+            message,
         },
         404 => AiMuxError::ModelNotFound(message),
         _ => AiMuxError::Provider(format!("HTTP {}: {}", status, message)),

--- a/aimux-providers/src/bedrock/embedding.rs
+++ b/aimux-providers/src/bedrock/embedding.rs
@@ -212,8 +212,7 @@ impl EmbeddingModel for BedrockEmbeddingModel {
         // Capture response headers (needed for token count extraction).
         let response_headers = resp.headers;
 
-        let raw_value: Value =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+        let raw_value: Value = serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         // Extract embeddings based on response format.
         let embeddings: Vec<Vec<f32>> = if raw_value.get("embedding").is_some() {

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -131,7 +131,7 @@ impl LanguageModel for BedrockModel {
         let response_headers = resp.headers;
 
         let data: BedrockConverseResponse =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+            serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         // Extract content from response.output.message.content
         let mut content = Vec::new();

--- a/aimux-providers/src/bedrock/reranking.rs
+++ b/aimux-providers/src/bedrock/reranking.rs
@@ -215,8 +215,7 @@ impl RerankingModel for BedrockRerankingModel {
         // Capture response headers.
         let response_headers = resp.headers;
 
-        let raw_body: Value =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+        let raw_body: Value = serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         let data: BedrockRerankingResponse =
             serde_json::from_value(raw_body.clone()).map_err(|e| {

--- a/aimux-providers/src/dataforseo.rs
+++ b/aimux-providers/src/dataforseo.rs
@@ -16,7 +16,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -127,12 +126,6 @@ impl DataforseoProvider {
 impl Provider for DataforseoProvider {
     fn name(&self) -> &str {
         PROVIDER_NAME
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "dataforseo does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/exa_ai.rs
+++ b/aimux-providers/src/exa_ai.rs
@@ -11,7 +11,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -67,12 +66,6 @@ impl ExaAiProvider {
 impl Provider for ExaAiProvider {
     fn name(&self) -> &str {
         "exa_ai"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "exa_ai does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/firecrawl.rs
+++ b/aimux-providers/src/firecrawl.rs
@@ -11,7 +11,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -73,12 +72,6 @@ impl FirecrawlProvider {
 impl Provider for FirecrawlProvider {
     fn name(&self) -> &str {
         "firecrawl"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "firecrawl does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/google/embedding.rs
+++ b/aimux-providers/src/google/embedding.rs
@@ -138,8 +138,7 @@ impl EmbeddingModel for GoogleEmbeddingModel {
 
             let response_headers = resp.headers;
 
-            let raw_value: Value =
-                serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+            let raw_value: Value = serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
             // Single embedding: response.embedding.values
             let embedding = raw_value
@@ -220,8 +219,7 @@ impl EmbeddingModel for GoogleEmbeddingModel {
 
         let response_headers = resp.headers;
 
-        let raw_value: Value =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+        let raw_value: Value = serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         // Batch embeddings: response.embeddings[].values
         let embeddings: Vec<Vec<f32>> = raw_value

--- a/aimux-providers/src/google/model.rs
+++ b/aimux-providers/src/google/model.rs
@@ -132,7 +132,7 @@ impl LanguageModel for GoogleModel {
         let response_headers = resp.headers;
 
         let data: GenerateContentResponse =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+            serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         let candidate = data
             .candidates
@@ -682,6 +682,7 @@ fn parse_google_error_body(body: &str) -> AiMuxError {
             401 => AiMuxError::Auth(msg),
             429 => AiMuxError::RateLimited {
                 retry_after_ms: 1000,
+                message: msg,
             },
             404 => AiMuxError::ModelNotFound(msg),
             _ => AiMuxError::Provider(format!("HTTP {}: {}", code, msg)),

--- a/aimux-providers/src/google/utils.rs
+++ b/aimux-providers/src/google/utils.rs
@@ -460,6 +460,20 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) -> Resu
             "partial args path exceeds maximum depth of {MAX_PARTIAL_ARG_DEPTH}"
         )));
     }
+    // Pre-validate every index before mutating any state:
+    // - an oversized *intermediate* index would let the array spreading loop
+    //   allocate unboundedly (audit round 3, A1);
+    // - a late failure would leave partially-built containers behind,
+    //   breaking error atomicity.
+    for segment in segments {
+        if let Segment::Index(index) = segment
+            && *index > MAX_PARTIAL_ARG_INDEX
+        {
+            return Err(AiMuxError::Json(format!(
+                "partial args array index {index} exceeds maximum of {MAX_PARTIAL_ARG_INDEX}"
+            )));
+        }
+    }
     let mut current = obj;
     for i in 0..segments.len() - 1 {
         let seg = &segments[i];
@@ -532,11 +546,6 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) -> Resu
                 .insert(k.clone(), value);
         }
         Segment::Index(i) => {
-            if *i > MAX_PARTIAL_ARG_INDEX {
-                return Err(AiMuxError::Json(format!(
-                    "partial args array index {i} exceeds maximum of {MAX_PARTIAL_ARG_INDEX}"
-                )));
-            }
             let arr = current.as_array_mut().ok_or_else(|| parent_must_be(last))?;
             while arr.len() <= *i {
                 arr.push(Value::Null);

--- a/aimux-providers/src/google/utils.rs
+++ b/aimux-providers/src/google/utils.rs
@@ -3,6 +3,7 @@
 //! Mirrors `get-model-path.ts`, `google-supported-file-url.ts`, and
 //! `google-json-accumulator.ts` from the TS SDK.
 
+use aimux_core::error::AiMuxError;
 use serde_json::{Map, Value};
 
 /// Resolve a model id into the URL path segment used by the Gemini API.
@@ -183,7 +184,15 @@ impl GoogleJsonAccumulator {
 
     /// Process a batch of partial args, returning the structured object and
     /// the JSON text delta for this call.
-    pub fn process_partial_args(&mut self, args: &[PartialArg]) -> ProcessResult {
+    ///
+    /// Returns [`AiMuxError::Json`] when a partial-arg path conflicts with the
+    /// already-accumulated structure (e.g. `$.a` was a string, then `$.a[0]`
+    /// arrives). `partialArgs` is provider-controlled input, so such conflicts
+    /// must not panic.
+    pub fn process_partial_args(
+        &mut self,
+        args: &[PartialArg],
+    ) -> Result<ProcessResult, AiMuxError> {
         let mut delta = String::new();
 
         for arg in args {
@@ -195,16 +204,15 @@ impl GoogleJsonAccumulator {
             let segments = parse_path(raw_path);
 
             let existing = get_nested_value(&self.accumulated, &segments);
-            let is_string_continuation = arg.string_value.is_some() && existing.is_some();
 
-            if is_string_continuation {
-                let s = arg.string_value.as_ref().unwrap();
+            if let (Some(s), Some(existing_val)) = (&arg.string_value, existing) {
+                // String continuation chunk.
                 let escaped = escape_json_string_inner(s);
-                let new_val = match existing {
-                    Some(Value::String(prev)) => Value::String(format!("{}{}", prev, s)),
+                let new_val = match existing_val {
+                    Value::String(prev) => Value::String(format!("{}{}", prev, s)),
                     _ => Value::String(s.clone()),
                 };
-                set_nested_value(&mut self.accumulated, &segments, new_val);
+                set_nested_value(&mut self.accumulated, &segments, new_val)?;
                 delta.push_str(&escaped);
                 continue;
             }
@@ -213,16 +221,16 @@ impl GoogleJsonAccumulator {
                 continue;
             };
 
-            set_nested_value(&mut self.accumulated, &segments, value);
+            set_nested_value(&mut self.accumulated, &segments, value)?;
             delta.push_str(&self.emit_navigation_to(&segments, arg, &value_json));
         }
 
         self.json_text.push_str(&delta);
 
-        ProcessResult {
+        Ok(ProcessResult {
             current_json: self.accumulated.clone(),
             text_delta: delta,
-        }
+        })
     }
 
     /// Finalize the accumulator, producing the complete JSON string and the
@@ -419,9 +427,15 @@ fn get_nested_value(obj: &Value, segments: &[Segment]) -> Option<Value> {
 }
 
 /// Set a value at a nested path, creating intermediate objects or arrays.
-fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) {
+///
+/// Returns [`AiMuxError::Json`] instead of panicking when the incoming path
+/// conflicts with the already-accumulated type (e.g. `$.a` was set to a
+/// string and a later `partialArgs` chunk targets `$.a[0].b`). The partial
+/// stream is provider-controlled (untrusted), so a conflict must surface as an
+/// error, not a process crash.
+fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) -> Result<(), AiMuxError> {
     if segments.is_empty() {
-        return;
+        return Ok(());
     }
     let mut current = obj;
     for i in 0..segments.len() - 1 {
@@ -442,18 +456,16 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) {
         if !exists {
             match seg {
                 Segment::Key(k) => {
+                    let parent = current.as_object_mut().ok_or_else(|| parent_must_be(seg))?;
                     let new_val = if next_is_index {
                         Value::Array(Vec::new())
                     } else {
                         Value::Object(Map::new())
                     };
-                    current
-                        .as_object_mut()
-                        .expect("parent must be object")
-                        .insert(k.clone(), new_val);
+                    parent.insert(k.clone(), new_val);
                 }
                 Segment::Index(i) => {
-                    let arr = current.as_array_mut().expect("parent must be array");
+                    let arr = current.as_array_mut().ok_or_else(|| parent_must_be(seg))?;
                     while arr.len() <= *i {
                         arr.push(Value::Null);
                     }
@@ -472,13 +484,18 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) {
         current = match seg {
             Segment::Key(k) => current
                 .as_object_mut()
-                .expect("parent must be object")
+                .ok_or_else(|| parent_must_be(seg))?
                 .get_mut(k)
-                .expect("key must exist after insertion"),
-            Segment::Index(i) => {
-                let arr = current.as_array_mut().expect("parent must be array");
-                &mut arr[*i]
-            }
+                .ok_or_else(|| {
+                    AiMuxError::Json(format!("partial args path conflict at {:?}", seg))
+                })?,
+            Segment::Index(i) => current
+                .as_array_mut()
+                .ok_or_else(|| parent_must_be(seg))?
+                .get_mut(*i)
+                .ok_or_else(|| {
+                    AiMuxError::Json(format!("partial args path conflict at {:?}", seg))
+                })?,
             Segment::Root => current,
         };
     }
@@ -488,11 +505,11 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) {
         Segment::Key(k) => {
             current
                 .as_object_mut()
-                .expect("final parent must be object")
+                .ok_or_else(|| parent_must_be(last))?
                 .insert(k.clone(), value);
         }
         Segment::Index(i) => {
-            let arr = current.as_array_mut().expect("final parent must be array");
+            let arr = current.as_array_mut().ok_or_else(|| parent_must_be(last))?;
             while arr.len() <= *i {
                 arr.push(Value::Null);
             }
@@ -502,6 +519,16 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) {
             *current = value;
         }
     }
+    Ok(())
+}
+
+/// Build the path-type-conflict error for a segment whose actual JSON type
+/// does not match the path's expectation (e.g. an index into a string).
+fn parent_must_be(seg: &Segment) -> AiMuxError {
+    AiMuxError::Json(format!(
+        "partial args path type conflict at {:?}: accumulated value does not match the path",
+        seg
+    ))
 }
 
 #[cfg(test)]
@@ -511,11 +538,13 @@ mod tests {
     #[test]
     fn smoke() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[PartialArg {
-            json_path: "$.location".to_string(),
-            string_value: Some("Boston".to_string()),
-            ..Default::default()
-        }]);
+        let r = acc
+            .process_partial_args(&[PartialArg {
+                json_path: "$.location".to_string(),
+                string_value: Some("Boston".to_string()),
+                ..Default::default()
+            }])
+            .unwrap();
         assert_eq!(r.text_delta, "{\"location\":\"Boston\"");
         assert_eq!(r.current_json["location"], "Boston");
     }

--- a/aimux-providers/src/google/utils.rs
+++ b/aimux-providers/src/google/utils.rs
@@ -433,16 +433,32 @@ fn get_nested_value(obj: &Value, segments: &[Segment]) -> Option<Value> {
     Some(current.clone())
 }
 
+/// Maximum array index accepted from a partialArgs path. `partialArgs` is
+/// provider-controlled; without a cap, a path like `$.a[1000000000]` makes
+/// the array-spreading loop allocate ~1 GiB of `Value::Null`, exhausting
+/// memory (audit finding, round 2).
+const MAX_PARTIAL_ARG_INDEX: usize = 100_000;
+
+/// Maximum path depth accepted from a partialArgs path (guards against
+/// pathologically deep nesting).
+const MAX_PARTIAL_ARG_DEPTH: usize = 64;
+
 /// Set a value at a nested path, creating intermediate objects or arrays.
 ///
 /// Returns [`AiMuxError::Json`] instead of panicking when the incoming path
 /// conflicts with the already-accumulated type (e.g. `$.a` was set to a
-/// string and a later `partialArgs` chunk targets `$.a[0].b`). The partial
-/// stream is provider-controlled (untrusted), so a conflict must surface as an
-/// error, not a process crash.
+/// string and a later `partialArgs` chunk targets `$.a[0].b`), or when the
+/// path exceeds the resource caps ([`MAX_PARTIAL_ARG_INDEX`],
+/// [`MAX_PARTIAL_ARG_DEPTH`]). The partial stream is provider-controlled
+/// (untrusted), so a conflict must surface as an error, not a process crash.
 fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) -> Result<(), AiMuxError> {
     if segments.is_empty() {
         return Ok(());
+    }
+    if segments.len() > MAX_PARTIAL_ARG_DEPTH {
+        return Err(AiMuxError::Json(format!(
+            "partial args path exceeds maximum depth of {MAX_PARTIAL_ARG_DEPTH}"
+        )));
     }
     let mut current = obj;
     for i in 0..segments.len() - 1 {
@@ -516,6 +532,11 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) -> Resu
                 .insert(k.clone(), value);
         }
         Segment::Index(i) => {
+            if *i > MAX_PARTIAL_ARG_INDEX {
+                return Err(AiMuxError::Json(format!(
+                    "partial args array index {i} exceeds maximum of {MAX_PARTIAL_ARG_INDEX}"
+                )));
+            }
             let arr = current.as_array_mut().ok_or_else(|| parent_must_be(last))?;
             while arr.len() <= *i {
                 arr.push(Value::Null);

--- a/aimux-providers/src/google/utils.rs
+++ b/aimux-providers/src/google/utils.rs
@@ -203,6 +203,13 @@ impl GoogleJsonAccumulator {
 
             let segments = parse_path(raw_path);
 
+            // Malformed/empty path (e.g. `$.[]`) parses to no segments; without
+            // this guard `emit_navigation_to` would slice `[..len-1]` on an
+            // empty slice and panic (audit finding H3 residual panic path).
+            if segments.is_empty() {
+                continue;
+            }
+
             let existing = get_nested_value(&self.accumulated, &segments);
 
             if let (Some(s), Some(existing_val)) = (&arg.string_value, existing) {

--- a/aimux-providers/src/google_pse.rs
+++ b/aimux-providers/src/google_pse.rs
@@ -16,7 +16,6 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -104,12 +103,6 @@ impl GooglePseProvider {
 impl Provider for GooglePseProvider {
     fn name(&self) -> &str {
         "google_pse"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "google_pse does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/jina_ai.rs
+++ b/aimux-providers/src/jina_ai.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::reranking_model::{
     RerankingCallOptions, RerankingDocuments, RerankingModel, RerankingRank, RerankingResponse,
@@ -97,12 +96,6 @@ impl JinaAiProvider {
 impl Provider for JinaAiProvider {
     fn name(&self) -> &str {
         "jina_ai"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "jina_ai does not support language models. Use reranking_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/linkup.rs
+++ b/aimux-providers/src/linkup.rs
@@ -15,7 +15,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -103,12 +102,6 @@ impl LinkupProvider {
 impl Provider for LinkupProvider {
     fn name(&self) -> &str {
         "linkup"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "linkup does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/mistral/model.rs
+++ b/aimux-providers/src/mistral/model.rs
@@ -611,6 +611,7 @@ fn stream_error_to_ai_error(err_obj: &Value) -> AiMuxError {
         401 => AiMuxError::Auth(message),
         429 => AiMuxError::RateLimited {
             retry_after_ms: 1000,
+            message,
         },
         404 => AiMuxError::ModelNotFound(message),
         _ => AiMuxError::Provider(format!("HTTP {}: {}", status, message)),

--- a/aimux-providers/src/open_responses.rs
+++ b/aimux-providers/src/open_responses.rs
@@ -862,19 +862,20 @@ fn build_request_body(
     };
 
     // Resolve reasoning effort from top-level reasoning option.
-    let resolved_reasoning_effort: Option<String> = if is_custom_reasoning(&options.reasoning) {
-        match options.reasoning.unwrap() {
-            ReasoningEffort::None => Some("none".to_string()),
-            ReasoningEffort::Minimal => Some("low".to_string()),
-            ReasoningEffort::Low => Some("low".to_string()),
-            ReasoningEffort::Medium => Some("medium".to_string()),
-            ReasoningEffort::High => Some("high".to_string()),
-            ReasoningEffort::Xhigh => Some("xhigh".to_string()),
-            ReasoningEffort::ProviderDefault => None,
-        }
-    } else {
-        None
-    };
+    let resolved_reasoning_effort: Option<String> =
+        if options.reasoning.is_some_and(ReasoningEffort::is_custom) {
+            match options.reasoning.unwrap() {
+                ReasoningEffort::None => Some("none".to_string()),
+                ReasoningEffort::Minimal => Some("low".to_string()),
+                ReasoningEffort::Low => Some("low".to_string()),
+                ReasoningEffort::Medium => Some("medium".to_string()),
+                ReasoningEffort::High => Some("high".to_string()),
+                ReasoningEffort::Xhigh => Some("xhigh".to_string()),
+                ReasoningEffort::ProviderDefault => None,
+            }
+        } else {
+            None
+        };
 
     // Resolve reasoning summary from provider options.
     let reasoning_summary: Option<String> = options
@@ -936,15 +937,6 @@ fn build_request_body(
     }
 
     (Value::Object(body), warnings)
-}
-
-/// Check whether the reasoning option is a custom (non-default) value.
-fn is_custom_reasoning(reasoning: &Option<ReasoningEffort>) -> bool {
-    match reasoning {
-        None => false,
-        Some(ReasoningEffort::ProviderDefault) => false,
-        Some(_) => true,
-    }
 }
 
 // == Prompt conversion ==

--- a/aimux-providers/src/openai/convert.rs
+++ b/aimux-providers/src/openai/convert.rs
@@ -11,148 +11,16 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 use super::OpenAICompatProfile;
+/// Public capability enum used by the conversion helpers (moved to
+/// `convert_common` in M10; re-exported for API compatibility).
+pub use super::convert_common::SystemMessageMode;
+use super::convert_common::{ModelCapabilities, get_model_capabilities};
 use std::collections::HashMap;
 
 // ── Model capabilities ──────────────────────────────────────────────────────
-
-/// Parsed GPT version info (mirrors TS `getGptVersion`).
-struct GptVersion {
-    major: u32,
-    minor: Option<u32>,
-    variant: Option<String>,
-}
-
-/// Extract GPT version from a model ID (e.g. `gpt-5.1-codex` → major=5, minor=1).
-fn get_gpt_version(model_id: &str) -> Option<GptVersion> {
-    // ^gpt-(\d+)(?:\.(\d+))?(?:-(.+))?$
-    let rest = model_id.strip_prefix("gpt-")?;
-    let (major_str, remainder) = rest
-        .find(|c: char| !c.is_ascii_digit())
-        .map(|i| (&rest[..i], &rest[i..]))
-        .unwrap_or((rest, ""));
-    if major_str.is_empty() {
-        return None;
-    }
-    let major: u32 = major_str.parse().ok()?;
-
-    // Check for minor version (.N)
-    let (minor, remainder) = if let Some(stripped) = remainder.strip_prefix('.') {
-        let (minor_str, after) = stripped
-            .find(|c: char| !c.is_ascii_digit())
-            .map(|i| (&stripped[..i], &stripped[i..]))
-            .unwrap_or((stripped, ""));
-        if minor_str.is_empty() {
-            return Some(GptVersion {
-                major,
-                minor: None,
-                variant: if remainder.is_empty() {
-                    None
-                } else {
-                    Some(remainder.trim_start_matches('-').to_string())
-                },
-            });
-        }
-        (minor_str.parse::<u32>().ok(), after)
-    } else {
-        (None, remainder)
-    };
-
-    let variant = if remainder.is_empty() {
-        None
-    } else {
-        Some(remainder.trim_start_matches('-').to_string())
-    };
-
-    Some(GptVersion {
-        major,
-        minor,
-        variant,
-    })
-}
-
-/// Extract o-series version (e.g. `o4-mini` → 4).
-fn get_o_series_version(model_id: &str) -> Option<u32> {
-    let rest = model_id.strip_prefix('o')?;
-    if rest.is_empty() || !rest.chars().next().unwrap().is_ascii_digit() {
-        return None;
-    }
-    let (digits, _) = rest
-        .find(|c: char| !c.is_ascii_digit())
-        .map(|i| (&rest[..i], &rest[i..]))
-        .unwrap_or((rest, ""));
-    digits.parse().ok()
-}
-
-/// Model capabilities relevant to request body construction.
-struct ModelCapabilities {
-    is_reasoning_model: bool,
-    system_message_mode: SystemMessageMode,
-    supports_flex_processing: bool,
-    supports_priority_processing: bool,
-    supports_non_reasoning_parameters: bool,
-}
-
-/// How system messages are mapped.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum SystemMessageMode {
-    System,
-    Developer,
-    Remove,
-}
-
-fn get_model_capabilities(model_id: &str) -> ModelCapabilities {
-    let o_version = get_o_series_version(model_id);
-    let gpt_version = get_gpt_version(model_id);
-    let is_gpt_chat_model = gpt_version.as_ref().is_some_and(|v| {
-        v.minor.is_none() && v.variant.as_deref().is_some_and(|s| s.starts_with("chat"))
-    });
-    let is_gpt_nano_model = gpt_version
-        .as_ref()
-        .is_some_and(|v| v.variant.as_deref().is_some_and(|s| s.starts_with("nano")));
-
-    let supports_flex_processing = o_version.is_some_and(|v| v >= 3)
-        || gpt_version
-            .as_ref()
-            .is_some_and(|v| v.major >= 5 && !is_gpt_chat_model);
-
-    let supports_priority_processing = model_id.starts_with("gpt-4")
-        || gpt_version
-            .as_ref()
-            .is_some_and(|v| v.major >= 5 && !is_gpt_nano_model && !is_gpt_chat_model)
-        || o_version.is_some_and(|v| v >= 3);
-
-    let is_reasoning_model = o_version.is_some()
-        || gpt_version
-            .as_ref()
-            .is_some_and(|v| v.major >= 5 && !is_gpt_chat_model);
-
-    let supports_non_reasoning_parameters = gpt_version
-        .as_ref()
-        .is_some_and(|v| v.major > 5 || (v.major == 5 && v.minor.unwrap_or(0) >= 1));
-
-    let system_message_mode = if is_reasoning_model {
-        SystemMessageMode::Developer
-    } else {
-        SystemMessageMode::System
-    };
-
-    ModelCapabilities {
-        is_reasoning_model,
-        system_message_mode,
-        supports_flex_processing,
-        supports_priority_processing,
-        supports_non_reasoning_parameters,
-    }
-}
-
-/// Check if a reasoning value is a custom (non-"provider-default") value.
-fn is_custom_reasoning(reasoning: &Option<ReasoningEffort>) -> bool {
-    match reasoning {
-        Some(ReasoningEffort::ProviderDefault) => false,
-        Some(_) => true,
-        None => false,
-    }
-}
+// `GptVersion` / `get_gpt_version` / `get_o_series_version` /
+// `ModelCapabilities` / `SystemMessageMode` / `get_model_capabilities` live in
+// `super::convert_common` and are shared with the Responses converter (M10).
 
 // ── Prepared tools ──────────────────────────────────────────────────────────
 
@@ -993,8 +861,13 @@ fn openai_option(
         .cloned()
 }
 
-/// Convert `CallOptions` to an OpenAI request body (without warnings).
-pub fn build_request_body(model_id: &str, options: &CallOptions, stream: bool) -> Value {
+/// Convert `CallOptions` to an OpenAI request body (without warnings), or an
+/// [`AiMuxError`] describing what failed.
+pub fn build_request_body(
+    model_id: &str,
+    options: &CallOptions,
+    stream: bool,
+) -> Result<Value, AiMuxError> {
     build_request_body_with_warnings(
         model_id,
         options,
@@ -1002,62 +875,72 @@ pub fn build_request_body(model_id: &str, options: &CallOptions, stream: bool) -
         "openai",
         &OpenAICompatProfile::full(),
     )
-    .body
+    .map(|r| r.body)
 }
 
 /// Convert `CallOptions` to an OpenAI request body, returning warnings.
 /// `provider` controls provider-specific behaviour (e.g. groq reads provider
 /// options from the `"groq"` key).
 /// `profile` declares provider capability differences (top_k, tools, etc.).
-pub fn build_request_body_with_warnings_fallible(
-    model_id: &str,
-    options: &CallOptions,
-    stream: bool,
+///
+/// Conversion errors propagate to the caller (fail-fast, issue H2): the old
+/// behaviour of silently returning `body: null` sent empty requests upstream
+/// and made conversion failures invisible.
+/// Look up a key from the provider-specific options (groq → "groq" then
+/// "openai"; otherwise "openai").
+fn provider_option(
+    provider_opts: &Option<HashMap<String, Value>>,
     provider: &str,
-    profile: &OpenAICompatProfile,
-) -> Result<RequestBodyResult, AiMuxError> {
-    let mut warnings: Vec<Warning> = Vec::new();
-    let caps = get_model_capabilities(model_id);
+    key: &str,
+) -> Option<Value> {
+    if provider == "groq"
+        && let Some(v) = provider_opts
+            .as_ref()
+            .and_then(|m| m.get("groq"))
+            .and_then(|o| o.get(key))
+            .cloned()
+    {
+        return Some(v);
+    }
+    openai_option(provider_opts, key)
+}
 
-    // Parse provider options — groq reads from the "groq" key (with "openai"
-    // fallback), other providers read from "openai".
-    let provider_opts = &options.provider_options;
-
-    // Helper: look up a key from the provider-specific options (groq → "groq"
-    // then "openai"; otherwise "openai").
-    let popt = |key: &str| -> Option<Value> {
-        if provider == "groq"
-            && let Some(v) = provider_opts
-                .as_ref()
-                .and_then(|m| m.get("groq"))
-                .and_then(|o| o.get(key))
-                .cloned()
-        {
-            return Some(v);
-        }
-        openai_option(provider_opts, key)
-    };
-
-    // Resolve reasoning effort — direct passthrough (v3: no built-in vendor
-    // normalization). Top-level `reasoning` maps verbatim to `reasoning_effort`
-    // (all levels sent as-is, including none/minimal/xhigh);
-    // `providerOptions.reasoningEffort` wins over top-level `reasoning`.
-    let resolved_reasoning_effort: Option<String> = popt("reasoningEffort")
+/// Resolve the effective reasoning effort — direct passthrough (v3: no built-in
+/// vendor normalization). `providerOptions.reasoningEffort` wins over top-level
+/// `reasoning`; custom top-level levels map verbatim to `reasoning_effort`.
+fn resolve_reasoning_effort(
+    provider_opts: &Option<HashMap<String, Value>>,
+    provider: &str,
+    reasoning: &Option<ReasoningEffort>,
+) -> Option<String> {
+    provider_option(provider_opts, provider, "reasoningEffort")
         .map(|v| v.as_str().map(|s| s.to_string()).unwrap_or(v.to_string()))
         .or_else(|| {
-            if is_custom_reasoning(&options.reasoning) {
-                options.reasoning.map(|r| r.to_string())
+            if reasoning.is_some_and(ReasoningEffort::is_custom) {
+                reasoning.map(|r| r.to_string())
             } else {
                 None
             }
-        });
+        })
+}
 
-    let is_reasoning_model = popt("forceReasoning")
+fn resolve_is_reasoning_model(
+    provider_opts: &Option<HashMap<String, Value>>,
+    provider: &str,
+    caps: &ModelCapabilities,
+) -> bool {
+    provider_option(provider_opts, provider, "forceReasoning")
         .map(|v| v.as_bool().unwrap_or(false))
-        .unwrap_or(caps.is_reasoning_model);
+        .unwrap_or(caps.is_reasoning_model)
+}
 
-    // Determine system message mode
-    let system_message_mode = popt("systemMessageMode")
+fn resolve_system_message_mode(
+    provider_opts: &Option<HashMap<String, Value>>,
+    provider: &str,
+    is_reasoning_model: bool,
+    caps: &ModelCapabilities,
+) -> SystemMessageMode {
+    provider_option(provider_opts, provider, "systemMessageMode")
         .and_then(|v| v.as_str().map(|s| s.to_string()))
         .map(|s| match s.as_str() {
             "developer" => SystemMessageMode::Developer,
@@ -1068,13 +951,408 @@ pub fn build_request_body_with_warnings_fallible(
             SystemMessageMode::Developer
         } else {
             caps.system_message_mode
-        });
+        })
+}
 
-    // top_k: only send when the provider supports it. The actual body
-    // insertion happens after `body` is created below.
-    let top_k_value = options.top_k;
+/// Insert `max_tokens` / `max_completion_tokens`.
+///
+/// `max_tokens_key` 是内部数据（非用户概念），指定该厂商唯一认的 key：
+/// - Some("max_tokens")            → 只发 max_tokens（如 stepfun/siliconflow/perplexity 等）
+/// - Some("max_completion_tokens") → 只发 max_completion_tokens（groq/heroku 等）
+/// - None                          → 现状推断：推理模型发 mct，非推理发 max_tokens。
+fn apply_max_tokens(
+    body: &mut Value,
+    options: &CallOptions,
+    provider_opts: &Option<HashMap<String, Value>>,
+    provider: &str,
+    profile: &OpenAICompatProfile,
+    is_reasoning_model: bool,
+) {
+    let max_completion_tokens_opt = provider_option(provider_opts, provider, "maxCompletionTokens")
+        .and_then(|v| v.as_u64().map(|n| n as u32));
+
+    let use_mct_key = match profile.max_tokens_key {
+        Some("max_tokens") => false,
+        Some("max_completion_tokens") => true,
+        _ => is_reasoning_model,
+    };
+
+    if let Some(max_tokens) = options.max_output_tokens {
+        let key = if use_mct_key {
+            "max_completion_tokens"
+        } else {
+            "max_tokens"
+        };
+        body[key] = json!(max_tokens);
+    }
+    // 显式 maxCompletionTokens 选项：只认 max_tokens 的厂商不发送 mct。
+    if let Some(mct) = max_completion_tokens_opt
+        && profile.max_tokens_key != Some("max_tokens")
+    {
+        body["max_completion_tokens"] = json!(mct);
+    }
+}
+
+/// Sampling parameters that survive the reasoning-model / search-preview
+/// capability filtering.
+#[derive(Default)]
+struct SamplingParams {
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    frequency_penalty: Option<f64>,
+    presence_penalty: Option<f64>,
+}
+
+/// Remove unsupported sampling settings for reasoning models and the search
+/// preview models, pushing a compatibility warning for each removal.
+fn strip_sampling_params(
+    options: &CallOptions,
+    model_id: &str,
+    caps: &ModelCapabilities,
+    is_reasoning_model: bool,
+    resolved_reasoning_effort: &Option<String>,
+    warnings: &mut Vec<Warning>,
+) -> SamplingParams {
+    let mut params = SamplingParams {
+        temperature: options.temperature,
+        top_p: options.top_p,
+        frequency_penalty: options.frequency_penalty,
+        presence_penalty: options.presence_penalty,
+    };
+
+    if is_reasoning_model {
+        let allow_non_reasoning = resolved_reasoning_effort.as_deref() == Some("none")
+            && caps.supports_non_reasoning_parameters;
+
+        if !allow_non_reasoning {
+            if params.temperature.is_some() {
+                params.temperature = None;
+                warnings.push(Warning::Unsupported {
+                    feature: "temperature".to_string(),
+                    details: Some("temperature is not supported for reasoning models".to_string()),
+                });
+            }
+            if params.top_p.is_some() {
+                params.top_p = None;
+                warnings.push(Warning::Unsupported {
+                    feature: "topP".to_string(),
+                    details: Some("topP is not supported for reasoning models".to_string()),
+                });
+            }
+        }
+
+        if params.frequency_penalty.is_some() {
+            params.frequency_penalty = None;
+            warnings.push(Warning::Unsupported {
+                feature: "frequencyPenalty".to_string(),
+                details: Some("frequencyPenalty is not supported for reasoning models".to_string()),
+            });
+        }
+        if params.presence_penalty.is_some() {
+            params.presence_penalty = None;
+            warnings.push(Warning::Unsupported {
+                feature: "presencePenalty".to_string(),
+                details: Some("presencePenalty is not supported for reasoning models".to_string()),
+            });
+        }
+    } else if (model_id.starts_with("gpt-4o-search-preview")
+        || model_id.starts_with("gpt-4o-mini-search-preview"))
+        && params.temperature.is_some()
+    {
+        params.temperature = None;
+        warnings.push(Warning::Unsupported {
+            feature: "temperature".to_string(),
+            details: Some(
+                "temperature is not supported for the search preview models and has been removed."
+                    .to_string(),
+            ),
+        });
+    }
+
+    params
+}
+
+/// Write the surviving sampling params (plus stop/seed) into the body.
+fn insert_sampling_params(body: &mut Value, params: &SamplingParams, options: &CallOptions) {
+    if let Some(temp) = params.temperature {
+        body["temperature"] = json!(temp);
+    }
+    if let Some(tp) = params.top_p {
+        body["top_p"] = json!(tp);
+    }
+    if let Some(fp) = params.frequency_penalty {
+        body["frequency_penalty"] = json!(fp);
+    }
+    if let Some(pp) = params.presence_penalty {
+        body["presence_penalty"] = json!(pp);
+    }
+    if let Some(ref stop) = options.stop_sequences {
+        body["stop"] = json!(stop);
+    }
+    if let Some(seed) = options.seed {
+        body["seed"] = json!(seed);
+    }
+}
+
+/// `response_format` → body, respecting the profile's capability flag and
+/// groq's structuredOutputs / strictJsonSchema semantics.
+fn apply_response_format(
+    body: &mut Value,
+    options: &CallOptions,
+    provider_opts: &Option<HashMap<String, Value>>,
+    provider: &str,
+    profile: &OpenAICompatProfile,
+    warnings: &mut Vec<Warning>,
+) {
+    if !profile.supports_response_format {
+        // Provider does not support response_format: drop it and warn when the
+        // caller requested a (non-default) format. `Text` is the no-op default
+        // and needs no warning.
+        if let Some(ref rf) = options.response_format
+            && !matches!(rf, ResponseFormat::Text)
+        {
+            warnings.push(Warning::Unsupported {
+                feature: "responseFormat".to_string(),
+                details: Some("response_format is not supported by this provider".to_string()),
+            });
+        }
+        return;
+    }
+    let Some(ref rf) = options.response_format else {
+        return;
+    };
+    match rf {
+        ResponseFormat::Text => {}
+        ResponseFormat::Json {
+            schema,
+            name,
+            description,
+        } => {
+            // Groq: structuredOutputs defaults to true, strictJsonSchema
+            // defaults to true. When structuredOutputs is false and a schema
+            // is provided, emit a warning and use json_object.
+            let (structured_outputs, strict_json_schema) = if provider == "groq" {
+                (
+                    provider_option(provider_opts, provider, "structuredOutputs")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true),
+                    provider_option(provider_opts, provider, "strictJsonSchema")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true),
+                )
+            } else {
+                (true, true)
+            };
+
+            if schema.is_some() && structured_outputs {
+                let mut schema_obj = json!({});
+                if let Some(s) = schema {
+                    schema_obj["schema"] = s.clone();
+                }
+                schema_obj["name"] = json!(name.clone().unwrap_or_else(|| "response".to_string()));
+                if let Some(d) = description {
+                    schema_obj["description"] = json!(d);
+                }
+                schema_obj["strict"] = json!(strict_json_schema);
+                body["response_format"] = json!({
+                    "type": "json_schema",
+                    "json_schema": schema_obj,
+                });
+            } else if schema.is_some() && !structured_outputs {
+                // Schema provided but structuredOutputs disabled → json_object + warning
+                body["response_format"] = json!({ "type": "json_object" });
+                warnings.push(Warning::Unsupported {
+                    feature: "responseFormat".to_string(),
+                    details: Some(
+                        "JSON response format schema is only supported with structuredOutputs"
+                            .to_string(),
+                    ),
+                });
+            } else {
+                body["response_format"] = json!({ "type": "json_object" });
+            }
+        }
+    }
+}
+
+/// Pass through the simple provider-specific options that map 1:1 to a body
+/// field (plus Groq's `reasoning_format`).
+fn apply_provider_option_passthrough(
+    body: &mut Value,
+    provider_opts: &Option<HashMap<String, Value>>,
+    provider: &str,
+) {
+    let mut set = |key: &str, body_key: &str| {
+        if let Some(val) = provider_option(provider_opts, provider, key) {
+            body[body_key] = val;
+        }
+    };
+    set("logitBias", "logit_bias");
+    set("user", "user");
+    set("parallelToolCalls", "parallel_tool_calls");
+    set("textVerbosity", "verbosity");
+    set("store", "store");
+    set("metadata", "metadata");
+    set("prediction", "prediction");
+    set("promptCacheKey", "prompt_cache_key");
+    set("promptCacheRetention", "prompt_cache_retention");
+    set("promptCacheOptions", "prompt_cache_options");
+    set("safetyIdentifier", "safety_identifier");
+    // M3 (RFC-0016): logprobs request support. Previously `logprobs` /
+    // `topLogprobs` were silently dropped by the provider_options whitelist —
+    // the only option that "quietly did nothing". Pass-through as-is (OpenAI
+    // expects `logprobs: bool` and `top_logprobs: int`).
+    set("logprobs", "logprobs");
+    set("topLogprobs", "top_logprobs");
+    // Groq: reasoning_format provider option
+    if provider == "groq"
+        && let Some(val) = provider_option(provider_opts, provider, "reasoningFormat")
+    {
+        body["reasoning_format"] = val;
+    }
+}
+
+/// `service_tier` with model-capability validation (Groq passes it through
+/// without validation).
+fn apply_service_tier(
+    body: &mut Value,
+    provider_opts: &Option<HashMap<String, Value>>,
+    provider: &str,
+    caps: &ModelCapabilities,
+    warnings: &mut Vec<Warning>,
+) {
+    if provider == "groq" {
+        if let Some(val) = provider_option(provider_opts, provider, "serviceTier") {
+            body["service_tier"] = val;
+        }
+        return;
+    }
+    let service_tier = provider_option(provider_opts, provider, "serviceTier")
+        .and_then(|v| v.as_str().map(|s| s.to_string()));
+    if let Some(ref st) = service_tier {
+        match st.as_str() {
+            "flex" => {
+                if caps.supports_flex_processing {
+                    body["service_tier"] = json!(st);
+                } else {
+                    warnings.push(Warning::Unsupported {
+                        feature: "serviceTier".to_string(),
+                        details: Some(
+                            "flex processing is only available for o3, o4-mini, and gpt-5 models"
+                                .to_string(),
+                        ),
+                    });
+                }
+            }
+            "priority" => {
+                if caps.supports_priority_processing {
+                    body["service_tier"] = json!(st);
+                } else {
+                    warnings.push(Warning::Unsupported {
+                        feature: "serviceTier".to_string(),
+                        details: Some(
+                            "priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported".to_string(),
+                        ),
+                    });
+                }
+            }
+            _ => {
+                body["service_tier"] = json!(st);
+            }
+        }
+    }
+}
+
+/// Function tools → `tools` / `tool_choice` (Groq also maps provider-defined
+/// tools such as browser_search). Drops both when the profile declares no tool
+/// support, warning when the caller supplied any.
+fn apply_tools(
+    body: &mut Value,
+    options: &CallOptions,
+    provider: &str,
+    profile: &OpenAICompatProfile,
+    model_id: &str,
+    warnings: &mut Vec<Warning>,
+) {
+    let function_tools: Option<Vec<FunctionTool>> = options.tools.as_ref().map(|tools| {
+        tools
+            .iter()
+            .filter_map(|t| match t {
+                Tool::Function(ft) => Some(ft.clone()),
+                Tool::Provider(_) => None,
+            })
+            .collect()
+    });
+
+    let supports_tools = profile.supports_tools;
+    if !supports_tools && options.tools.as_ref().is_some_and(|t| !t.is_empty()) {
+        warnings.push(Warning::Unsupported {
+            feature: "tools".to_string(),
+            details: Some("tools are not supported by this provider".to_string()),
+        });
+    }
+
+    let prepared = if !supports_tools {
+        PreparedTools {
+            tools: None,
+            tool_choice: None,
+            tool_warnings: Vec::new(),
+        }
+    } else if provider == "groq" {
+        prepare_tools_groq(
+            &function_tools,
+            options.tools.as_ref(),
+            Some(&options.tool_choice),
+            model_id,
+        )
+    } else {
+        prepare_tools(&function_tools, Some(&options.tool_choice))
+    };
+
+    if let Some(tools) = prepared.tools {
+        body["tools"] = json!(tools);
+        if let Some(tc) = prepared.tool_choice {
+            body["tool_choice"] = tc;
+        }
+    }
+
+    // Convert tool warnings to Warning type
+    for tw in prepared.tool_warnings {
+        warnings.push(Warning::Unsupported {
+            feature: tw.feature,
+            details: tw.details,
+        });
+    }
+}
+
+/// Convert `CallOptions` to an OpenAI request body, returning warnings.
+/// `provider` controls provider-specific behaviour (e.g. groq reads provider
+/// options from the `"groq"` key).
+/// `profile` declares provider capability differences (top_k, tools, etc.).
+///
+/// Conversion errors propagate to the caller (fail-fast, issue H2): the old
+/// behaviour of silently returning `body: null` sent empty requests upstream
+/// and made conversion failures invisible.
+pub fn build_request_body_with_warnings(
+    model_id: &str,
+    options: &CallOptions,
+    stream: bool,
+    provider: &str,
+    profile: &OpenAICompatProfile,
+) -> Result<RequestBodyResult, AiMuxError> {
+    let mut warnings: Vec<Warning> = Vec::new();
+    let caps = get_model_capabilities(model_id);
+    let provider_opts = &options.provider_options;
+
+    let resolved_reasoning_effort =
+        resolve_reasoning_effort(provider_opts, provider, &options.reasoning);
+    let is_reasoning_model = resolve_is_reasoning_model(provider_opts, provider, &caps);
+    let system_message_mode =
+        resolve_system_message_mode(provider_opts, provider, is_reasoning_model, &caps);
+
+    // top_k: only send when the provider supports it.
     let top_k_supported = profile.supports_top_k;
-    if top_k_value.is_some() && !top_k_supported {
+    if options.top_k.is_some() && !top_k_supported {
         warnings.push(Warning::Unsupported {
             feature: "topK".to_string(),
             details: None,
@@ -1100,342 +1378,54 @@ pub fn build_request_body_with_warnings_fallible(
         }
     }
 
-    // top_k: only send when the provider supports it.
-    if let Some(tk) = top_k_value
-        && top_k_supported
-    {
+    if let Some(tk) = options.top_k.filter(|_| top_k_supported) {
         body["top_k"] = json!(tk);
     }
 
-    // Max tokens / max_completion_tokens。
-    //
-    // `max_tokens_key` 是内部数据（非用户概念），指定该厂商唯一认的 key：
-    // - Some("max_tokens")            → 只发 max_tokens（如 stepfun/siliconflow/perplexity 等）
-    // - Some("max_completion_tokens") → 只发 max_completion_tokens（groq/heroku 等）
-    // - None                          → 现状推断：推理模型发 mct，非推理发 max_tokens。
-    let max_completion_tokens_opt =
-        popt("maxCompletionTokens").and_then(|v| v.as_u64().map(|n| n as u32));
+    apply_max_tokens(
+        &mut body,
+        options,
+        provider_opts,
+        provider,
+        profile,
+        is_reasoning_model,
+    );
 
-    // 推理模型用 mct 还是 max_tokens：由 max_tokens_key 决定，None/未知值走现状推断。
-    let use_mct_key = match profile.max_tokens_key {
-        Some("max_tokens") => false,
-        Some("max_completion_tokens") => true,
-        _ => is_reasoning_model,
-    };
+    let sampling = strip_sampling_params(
+        options,
+        model_id,
+        &caps,
+        is_reasoning_model,
+        &resolved_reasoning_effort,
+        &mut warnings,
+    );
+    insert_sampling_params(&mut body, &sampling, options);
 
-    if let Some(max_tokens) = options.max_output_tokens {
-        let key = if use_mct_key {
-            "max_completion_tokens"
-        } else {
-            "max_tokens"
-        };
-        body[key] = json!(max_tokens);
-    }
-    // 显式 maxCompletionTokens 选项：只认 max_tokens 的厂商不发送 mct。
-    if let Some(mct) = max_completion_tokens_opt
-        && profile.max_tokens_key != Some("max_tokens")
-    {
-        body["max_completion_tokens"] = json!(mct);
-    }
+    apply_response_format(
+        &mut body,
+        options,
+        provider_opts,
+        provider,
+        profile,
+        &mut warnings,
+    );
+    apply_provider_option_passthrough(&mut body, provider_opts, provider);
 
-    // Temperature, top_p, frequency_penalty, presence_penalty
-    let mut temperature = options.temperature;
-    let mut top_p = options.top_p;
-    let mut frequency_penalty = options.frequency_penalty;
-    let mut presence_penalty = options.presence_penalty;
-
-    // Remove unsupported settings for reasoning models
-    if is_reasoning_model {
-        let allow_non_reasoning = resolved_reasoning_effort.as_deref() == Some("none")
-            && caps.supports_non_reasoning_parameters;
-
-        if !allow_non_reasoning {
-            if temperature.is_some() {
-                temperature = None;
-                warnings.push(Warning::Unsupported {
-                    feature: "temperature".to_string(),
-                    details: Some("temperature is not supported for reasoning models".to_string()),
-                });
-            }
-            if top_p.is_some() {
-                top_p = None;
-                warnings.push(Warning::Unsupported {
-                    feature: "topP".to_string(),
-                    details: Some("topP is not supported for reasoning models".to_string()),
-                });
-            }
-        }
-
-        if frequency_penalty.is_some() {
-            frequency_penalty = None;
-            warnings.push(Warning::Unsupported {
-                feature: "frequencyPenalty".to_string(),
-                details: Some("frequencyPenalty is not supported for reasoning models".to_string()),
-            });
-        }
-        if presence_penalty.is_some() {
-            presence_penalty = None;
-            warnings.push(Warning::Unsupported {
-                feature: "presencePenalty".to_string(),
-                details: Some("presencePenalty is not supported for reasoning models".to_string()),
-            });
-        }
-    } else if (model_id.starts_with("gpt-4o-search-preview")
-        || model_id.starts_with("gpt-4o-mini-search-preview"))
-        && temperature.is_some()
-    {
-        temperature = None;
-        warnings.push(Warning::Unsupported {
-            feature: "temperature".to_string(),
-            details: Some(
-                "temperature is not supported for the search preview models and has been removed."
-                    .to_string(),
-            ),
-        });
-    }
-
-    if let Some(temp) = temperature {
-        body["temperature"] = json!(temp);
-    }
-    if let Some(tp) = top_p {
-        body["top_p"] = json!(tp);
-    }
-    if let Some(fp) = frequency_penalty {
-        body["frequency_penalty"] = json!(fp);
-    }
-    if let Some(pp) = presence_penalty {
-        body["presence_penalty"] = json!(pp);
-    }
-    if let Some(ref stop) = options.stop_sequences {
-        body["stop"] = json!(stop);
-    }
-    if let Some(seed) = options.seed {
-        body["seed"] = json!(seed);
-    }
-
-    // Response format
-    if !profile.supports_response_format {
-        // Provider does not support response_format: drop it and warn when the
-        // caller requested a (non-default) format. `Text` is the no-op default
-        // and needs no warning.
-        if let Some(ref rf) = options.response_format
-            && !matches!(rf, ResponseFormat::Text)
-        {
-            warnings.push(Warning::Unsupported {
-                feature: "responseFormat".to_string(),
-                details: Some("response_format is not supported by this provider".to_string()),
-            });
-        }
-    } else if let Some(ref rf) = options.response_format {
-        match rf {
-            ResponseFormat::Text => {}
-            ResponseFormat::Json {
-                schema,
-                name,
-                description,
-            } => {
-                // Groq: structuredOutputs defaults to true, strictJsonSchema
-                // defaults to true. When structuredOutputs is false and a schema
-                // is provided, emit a warning and use json_object.
-                let (structured_outputs, strict_json_schema) = if provider == "groq" {
-                    (
-                        popt("structuredOutputs")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(true),
-                        popt("strictJsonSchema")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(true),
-                    )
-                } else {
-                    (true, true)
-                };
-
-                if schema.is_some() && structured_outputs {
-                    let mut schema_obj = json!({});
-                    if let Some(s) = schema {
-                        schema_obj["schema"] = s.clone();
-                    }
-                    schema_obj["name"] =
-                        json!(name.clone().unwrap_or_else(|| "response".to_string()));
-                    if let Some(d) = description {
-                        schema_obj["description"] = json!(d);
-                    }
-                    schema_obj["strict"] = json!(strict_json_schema);
-                    body["response_format"] = json!({
-                        "type": "json_schema",
-                        "json_schema": schema_obj,
-                    });
-                } else if schema.is_some() && !structured_outputs {
-                    // Schema provided but structuredOutputs disabled → json_object + warning
-                    body["response_format"] = json!({ "type": "json_object" });
-                    warnings.push(Warning::Unsupported {
-                        feature: "responseFormat".to_string(),
-                        details: Some(
-                            "JSON response format schema is only supported with structuredOutputs"
-                                .to_string(),
-                        ),
-                    });
-                } else {
-                    body["response_format"] = json!({ "type": "json_object" });
-                }
-            }
-        }
-    }
-
-    // Provider-specific options
-    if let Some(val) = popt("logitBias") {
-        body["logit_bias"] = val;
-    }
-    if let Some(val) = popt("user") {
-        body["user"] = val;
-    }
-    if let Some(val) = popt("parallelToolCalls") {
-        body["parallel_tool_calls"] = val;
-    }
-    if let Some(val) = popt("textVerbosity") {
-        body["verbosity"] = val;
-    }
-    if let Some(val) = popt("store") {
-        body["store"] = val;
-    }
-    if let Some(val) = popt("metadata") {
-        body["metadata"] = val;
-    }
-    if let Some(val) = popt("prediction") {
-        body["prediction"] = val;
-    }
-    if let Some(val) = popt("promptCacheKey") {
-        body["prompt_cache_key"] = val;
-    }
-    if let Some(val) = popt("promptCacheRetention") {
-        body["prompt_cache_retention"] = val;
-    }
-    if let Some(val) = popt("promptCacheOptions") {
-        body["prompt_cache_options"] = val;
-    }
-    if let Some(val) = popt("safetyIdentifier") {
-        body["safety_identifier"] = val;
-    }
-    // M3 (RFC-0016): logprobs request support. Previously `logprobs` /
-    // `topLogprobs` were silently dropped by the provider_options whitelist —
-    // the only option that "quietly did nothing". Pass-through as-is (OpenAI
-    // expects `logprobs: bool` and `top_logprobs: int`).
-    if let Some(val) = popt("logprobs") {
-        body["logprobs"] = val;
-    }
-    if let Some(val) = popt("topLogprobs") {
-        body["top_logprobs"] = val;
-    }
-
-    // Groq: reasoning_format provider option
-    if provider == "groq"
-        && let Some(val) = popt("reasoningFormat")
-    {
-        body["reasoning_format"] = val;
-    }
-
-    // Reasoning effort
+    // Reasoning effort (v3 passthrough; 注：旧的"reasoning 无映射提示"warning
+    // 块已删除——v3 直传语义下该分支不可达：custom 值此时必已进 resolved)。
     if let Some(ref effort) = resolved_reasoning_effort {
         body["reasoning_effort"] = json!(effort);
     }
-    // 注：旧的"reasoning 无映射提示"warning 块（is_custom_reasoning &&
-    // resolved_reasoning_effort.is_none()）已删除——v3 直传语义下该分支不可达：
-    // is_custom_reasoning=true 时 resolved 必为 Some（见上方 resolved 解析）。
 
-    // Service tier
-    if provider == "groq" {
-        // Groq passes service_tier through without model-capability validation.
-        if let Some(val) = popt("serviceTier") {
-            body["service_tier"] = val;
-        }
-    } else {
-        let service_tier = popt("serviceTier").and_then(|v| v.as_str().map(|s| s.to_string()));
-        if let Some(ref st) = service_tier {
-            match st.as_str() {
-                "flex" => {
-                    if caps.supports_flex_processing {
-                        body["service_tier"] = json!(st);
-                    } else {
-                        warnings.push(Warning::Unsupported {
-                            feature: "serviceTier".to_string(),
-                            details: Some(
-                                "flex processing is only available for o3, o4-mini, and gpt-5 models"
-                                    .to_string(),
-                            ),
-                        });
-                    }
-                }
-                "priority" => {
-                    if caps.supports_priority_processing {
-                        body["service_tier"] = json!(st);
-                    } else {
-                        warnings.push(Warning::Unsupported {
-                            feature: "serviceTier".to_string(),
-                            details: Some(
-                                "priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported".to_string(),
-                            ),
-                        });
-                    }
-                }
-                _ => {
-                    body["service_tier"] = json!(st);
-                }
-            }
-        }
-    }
-
-    // Tools
-    let function_tools: Option<Vec<FunctionTool>> = options.tools.as_ref().map(|tools| {
-        tools
-            .iter()
-            .filter_map(|t| match t {
-                Tool::Function(ft) => Some(ft.clone()),
-                Tool::Provider(_) => None,
-            })
-            .collect()
-    });
-
-    // When the provider profile declares no tool support, drop tools/tool_choice
-    // entirely and warn if the caller supplied any.
-    let supports_tools = profile.supports_tools;
-    if !supports_tools && options.tools.as_ref().is_some_and(|t| !t.is_empty()) {
-        warnings.push(Warning::Unsupported {
-            feature: "tools".to_string(),
-            details: Some("tools are not supported by this provider".to_string()),
-        });
-    }
-
-    // Groq: handle provider-defined tools (browser_search) alongside function tools.
-    let prepared = if !supports_tools {
-        PreparedTools {
-            tools: None,
-            tool_choice: None,
-            tool_warnings: Vec::new(),
-        }
-    } else if provider == "groq" {
-        prepare_tools_groq(
-            &function_tools,
-            options.tools.as_ref(),
-            Some(&options.tool_choice),
-            model_id,
-        )
-    } else {
-        prepare_tools(&function_tools, Some(&options.tool_choice))
-    };
-    if let Some(tools) = prepared.tools {
-        body["tools"] = json!(tools);
-        if let Some(tc) = prepared.tool_choice {
-            body["tool_choice"] = tc;
-        }
-    }
-
-    // Convert tool warnings to Warning type
-    for tw in prepared.tool_warnings {
-        warnings.push(Warning::Unsupported {
-            feature: tw.feature,
-            details: tw.details,
-        });
-    }
+    apply_service_tier(&mut body, provider_opts, provider, &caps, &mut warnings);
+    apply_tools(
+        &mut body,
+        options,
+        provider,
+        profile,
+        model_id,
+        &mut warnings,
+    );
 
     // 厂商特化后处理已整体退役（RFC-0017 阶段 2）：不内置任何厂商映射，
     // thinking 注入 / effort 重映射等差异由用户 bodyOverrides 定义。
@@ -1450,12 +1440,6 @@ pub fn build_request_body_with_warnings_fallible(
 
     Ok(RequestBodyResult { body, warnings })
 }
-
-/// Recursively deep-merge `patch` into `target` (RFC-0017).
-///
-/// - Objects: merge key-by-key (recursive).
-/// - Scalars / arrays: `patch` overwrites `target`.
-/// - `null` in `patch`: deletes the key from `target` (explicit removal).
 pub fn deep_merge_json(target: &mut Value, patch: &Value) {
     match (target, patch) {
         (Value::Object(t), Value::Object(p)) => {
@@ -1472,21 +1456,6 @@ pub fn deep_merge_json(target: &mut Value, patch: &Value) {
         }
         (target, patch) => *target = patch.clone(),
     }
-}
-
-/// Convert `CallOptions` to an OpenAI request body, returning warnings.
-pub fn build_request_body_with_warnings(
-    model_id: &str,
-    options: &CallOptions,
-    stream: bool,
-    provider: &str,
-    profile: &OpenAICompatProfile,
-) -> RequestBodyResult {
-    build_request_body_with_warnings_fallible(model_id, options, stream, provider, profile)
-        .unwrap_or_else(|_| RequestBodyResult {
-            body: Value::Null,
-            warnings: Vec::new(),
-        })
 }
 
 /// Parse OpenAI finish reason string into `FinishReason`.

--- a/aimux-providers/src/openai/convert_common.rs
+++ b/aimux-providers/src/openai/convert_common.rs
@@ -1,0 +1,143 @@
+//! Shared model-capability / version helpers used by both the OpenAI Chat
+//! Completions converter (`convert.rs`) and the Responses API converter
+//! (`responses/convert.rs`).
+//!
+//! These were previously copy-pasted (~140 lines) between the two modules;
+//! any change had to be applied twice (issue M10).
+
+/// Parsed GPT version info (mirrors TS `getGptVersion`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GptVersion {
+    pub major: u32,
+    pub minor: Option<u32>,
+    pub variant: Option<String>,
+}
+
+/// Extract GPT version from a model ID (e.g. `gpt-5.1-codex` → major=5, minor=1).
+pub fn get_gpt_version(model_id: &str) -> Option<GptVersion> {
+    let rest = model_id.strip_prefix("gpt-")?;
+    let (major_str, remainder) = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .map(|i| (&rest[..i], &rest[i..]))
+        .unwrap_or((rest, ""));
+    if major_str.is_empty() {
+        return None;
+    }
+    let major: u32 = major_str.parse().ok()?;
+
+    let (minor, remainder) = if let Some(stripped) = remainder.strip_prefix('.') {
+        let (minor_str, after) = stripped
+            .find(|c: char| !c.is_ascii_digit())
+            .map(|i| (&stripped[..i], &stripped[i..]))
+            .unwrap_or((stripped, ""));
+        if minor_str.is_empty() {
+            return Some(GptVersion {
+                major,
+                minor: None,
+                variant: if remainder.is_empty() {
+                    None
+                } else {
+                    Some(remainder.trim_start_matches('-').to_string())
+                },
+            });
+        }
+        (
+            minor_str.parse::<u32>().ok(),
+            if after.is_empty() {
+                None
+            } else {
+                Some(after.trim_start_matches('-').to_string())
+            },
+        )
+    } else {
+        (
+            None,
+            if remainder.is_empty() {
+                None
+            } else {
+                Some(remainder.trim_start_matches('-').to_string())
+            },
+        )
+    };
+
+    Some(GptVersion {
+        major,
+        minor,
+        variant: remainder,
+    })
+}
+
+/// Extract o-series version (e.g. `o3-mini` → 3). Mirrors TS `getOSeriesVersion`.
+pub fn get_o_series_version(model_id: &str) -> Option<u32> {
+    let rest = model_id.strip_prefix('o')?;
+    let (digits, _) = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .map(|i| (&rest[..i], &rest[i..]))
+        .unwrap_or((rest, ""));
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse::<u32>().ok()
+}
+
+/// Model capabilities relevant to request body construction.
+pub struct ModelCapabilities {
+    pub is_reasoning_model: bool,
+    pub system_message_mode: SystemMessageMode,
+    pub supports_flex_processing: bool,
+    pub supports_priority_processing: bool,
+    pub supports_non_reasoning_parameters: bool,
+}
+
+/// How system messages are mapped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemMessageMode {
+    System,
+    Developer,
+    Remove,
+}
+
+pub fn get_model_capabilities(model_id: &str) -> ModelCapabilities {
+    let o_version = get_o_series_version(model_id);
+    let gpt_version = get_gpt_version(model_id);
+    let is_gpt_chat_model = gpt_version.as_ref().is_some_and(|v| {
+        v.minor.is_none() && v.variant.as_deref().is_some_and(|s| s.starts_with("chat"))
+    });
+    let is_gpt_nano_model = gpt_version
+        .as_ref()
+        .is_some_and(|v| v.variant.as_deref().is_some_and(|s| s.starts_with("nano")));
+
+    let supports_flex_processing = o_version.is_some_and(|v| v >= 3)
+        || gpt_version
+            .as_ref()
+            .is_some_and(|v| v.major >= 5 && !is_gpt_chat_model);
+
+    let supports_priority_processing = model_id.starts_with("gpt-4")
+        || gpt_version
+            .as_ref()
+            .is_some_and(|v| v.major >= 5 && !is_gpt_nano_model && !is_gpt_chat_model)
+        || o_version.is_some_and(|v| v >= 3);
+
+    let is_reasoning_model = o_version.is_some()
+        || gpt_version
+            .as_ref()
+            .is_some_and(|v| v.major >= 5 && !is_gpt_chat_model);
+
+    let supports_non_reasoning_parameters = gpt_version
+        .as_ref()
+        .is_some_and(|v| v.major > 5 || (v.major == 5 && v.minor.unwrap_or(0) >= 1));
+
+    let system_message_mode = if is_reasoning_model {
+        SystemMessageMode::Developer
+    } else {
+        SystemMessageMode::System
+    };
+
+    ModelCapabilities {
+        is_reasoning_model,
+        system_message_mode,
+        supports_flex_processing,
+        supports_priority_processing,
+        supports_non_reasoning_parameters,
+    }
+}

--- a/aimux-providers/src/openai/mod.rs
+++ b/aimux-providers/src/openai/mod.rs
@@ -4,6 +4,7 @@
 //! Together.ai, Groq, Fireworks, DeepSeek, etc.).
 
 pub mod convert;
+mod convert_common;
 pub mod embedding;
 pub mod files;
 pub mod image;

--- a/aimux-providers/src/openai/model.rs
+++ b/aimux-providers/src/openai/model.rs
@@ -27,9 +27,7 @@ use aimux_provider_utils::{
 use aimux_stream::SseStream;
 
 use super::OpenAIConfig;
-use super::convert::{
-    RequestBodyResult, build_request_body_with_warnings_fallible, parse_finish_reason,
-};
+use super::convert::{RequestBodyResult, build_request_body_with_warnings, parse_finish_reason};
 use super::types::{ChatCompletionResponse, StreamChunk, UsageResponse};
 
 /// An OpenAI-compatible language model.
@@ -270,7 +268,7 @@ pub async fn execute_generate(
     retry_config: &RetryConfig,
 ) -> Result<GenerateResult, AiMuxError> {
     let request_result =
-        build_request_body_with_warnings_fallible(model_id, options, false, provider, profile)?;
+        build_request_body_with_warnings(model_id, options, false, provider, profile)?;
     let body = request_result.body;
 
     let resp = send_timed(
@@ -425,7 +423,7 @@ pub async fn execute_stream(
     retry_config: &RetryConfig,
 ) -> Result<StreamResult, AiMuxError> {
     let request_result =
-        build_request_body_with_warnings_fallible(model_id, options, true, provider, profile)?;
+        build_request_body_with_warnings(model_id, options, true, provider, profile)?;
     // M9 (RFC-0016): keep the warnings computed while building the body —
     // they are emitted in `StreamStart` below instead of being dropped.
     let RequestBodyResult { body, warnings } = request_result;
@@ -853,9 +851,10 @@ fn stream_error_to_ai_error(err_obj: &Value) -> AiMuxError {
     let status = code as u16;
 
     match status {
-        401 => AiMuxError::Auth(message),
+        401 => AiMuxError::Auth(message.clone()),
         429 => AiMuxError::RateLimited {
             retry_after_ms: 1000,
+            message,
         },
         404 => AiMuxError::ModelNotFound(message),
         _ => AiMuxError::Provider(format!("HTTP {}: {}", status, message)),

--- a/aimux-providers/src/openai/responses/convert.rs
+++ b/aimux-providers/src/openai/responses/convert.rs
@@ -30,6 +30,13 @@ use super::types::ResponsesUsage;
 // converter (issue M10).
 use crate::openai::convert_common::{ModelCapabilities, SystemMessageMode, get_model_capabilities};
 
+/// Compatibility alias: the Responses-specific enum name was merged into the
+/// shared [`SystemMessageMode`] during M10. Keeping the alias lets existing
+/// import paths (`openai::responses::convert::ResponsesSystemMessageMode`)
+/// keep compiling while the module signature uses the shared type.
+#[doc(hidden)]
+pub use crate::openai::convert_common::SystemMessageMode as ResponsesSystemMessageMode;
+
 // -- Provider options helper -------------------------------------------------
 
 /// Get a value from `provider_options.openai.<key>`.

--- a/aimux-providers/src/openai/responses/convert.rs
+++ b/aimux-providers/src/openai/responses/convert.rs
@@ -1,4 +1,4 @@
-﻿//! Conversion between `LanguageModelPrompt` and the OpenAI Responses API
+//! Conversion between `LanguageModelPrompt` and the OpenAI Responses API
 //! `input` format, plus request-body construction, tool preparation, usage
 //! conversion, and finish-reason mapping.
 //!
@@ -24,152 +24,11 @@ use aimux_core::types::{FinishReason, FinishReasonUnified, ReasoningEffort, Usag
 use super::types::ResponsesUsage;
 
 // -- Model capabilities ------------------------------------------------------
-
-/// Parsed GPT version info (mirrors TS `getGptVersion`).
-struct GptVersion {
-    major: u32,
-    minor: Option<u32>,
-    variant: Option<String>,
-}
-
-/// Extract GPT version from a model ID (e.g. `gpt-5.1-codex` -> major=5, minor=1).
-fn get_gpt_version(model_id: &str) -> Option<GptVersion> {
-    let rest = model_id.strip_prefix("gpt-")?;
-    let (major_str, remainder) = rest
-        .find(|c: char| !c.is_ascii_digit())
-        .map(|i| (&rest[..i], &rest[i..]))
-        .unwrap_or((rest, ""));
-    if major_str.is_empty() {
-        return None;
-    }
-    let major: u32 = major_str.parse().ok()?;
-
-    let (minor, remainder) = if let Some(stripped) = remainder.strip_prefix('.') {
-        let (minor_str, after) = stripped
-            .find(|c: char| !c.is_ascii_digit())
-            .map(|i| (&stripped[..i], &stripped[i..]))
-            .unwrap_or((stripped, ""));
-        if minor_str.is_empty() {
-            return Some(GptVersion {
-                major,
-                minor: None,
-                variant: if remainder.is_empty() {
-                    None
-                } else {
-                    Some(remainder.trim_start_matches('-').to_string())
-                },
-            });
-        }
-        (
-            minor_str.parse::<u32>().ok(),
-            if after.is_empty() {
-                None
-            } else {
-                Some(after.trim_start_matches('-').to_string())
-            },
-        )
-    } else {
-        (
-            None,
-            if remainder.is_empty() {
-                None
-            } else {
-                Some(remainder.trim_start_matches('-').to_string())
-            },
-        )
-    };
-
-    Some(GptVersion {
-        major,
-        minor,
-        variant: remainder,
-    })
-}
-
-/// Extract o-series version (e.g. `o3-mini` -> 3). Mirrors TS `getOSeriesVersion`.
-fn get_o_series_version(model_id: &str) -> Option<u32> {
-    let rest = model_id.strip_prefix('o')?;
-    let (digits, _) = rest
-        .find(|c: char| !c.is_ascii_digit())
-        .map(|i| (&rest[..i], &rest[i..]))
-        .unwrap_or((rest, ""));
-    if digits.is_empty() {
-        return None;
-    }
-    digits.parse::<u32>().ok()
-}
-
-/// Model capabilities relevant to Responses request body construction.
-///
-/// Mirrors TS `getOpenAILanguageModelCapabilities`.
-struct ResponsesModelCapabilities {
-    is_reasoning_model: bool,
-    system_message_mode: ResponsesSystemMessageMode,
-    supports_flex_processing: bool,
-    supports_priority_processing: bool,
-    supports_non_reasoning_parameters: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum ResponsesSystemMessageMode {
-    System,
-    Developer,
-    Remove,
-}
-
-fn get_model_capabilities(model_id: &str) -> ResponsesModelCapabilities {
-    let o_version = get_o_series_version(model_id);
-    let gpt_version = get_gpt_version(model_id);
-    let is_gpt_chat_model = gpt_version.as_ref().is_some_and(|v| {
-        v.minor.is_none() && v.variant.as_deref().is_some_and(|s| s.starts_with("chat"))
-    });
-    let is_gpt_nano_model = gpt_version
-        .as_ref()
-        .is_some_and(|v| v.variant.as_deref().is_some_and(|s| s.starts_with("nano")));
-
-    let supports_flex_processing = o_version.is_some_and(|v| v >= 3)
-        || gpt_version
-            .as_ref()
-            .is_some_and(|v| v.major >= 5 && !is_gpt_chat_model);
-
-    let supports_priority_processing = model_id.starts_with("gpt-4")
-        || gpt_version
-            .as_ref()
-            .is_some_and(|v| v.major >= 5 && !is_gpt_nano_model && !is_gpt_chat_model)
-        || o_version.is_some_and(|v| v >= 3);
-
-    let is_reasoning_model = o_version.is_some()
-        || gpt_version
-            .as_ref()
-            .is_some_and(|v| v.major >= 5 && !is_gpt_chat_model);
-
-    let supports_non_reasoning_parameters = gpt_version
-        .as_ref()
-        .is_some_and(|v| v.major > 5 || (v.major == 5 && v.minor.unwrap_or(0) >= 1));
-
-    let system_message_mode = if is_reasoning_model {
-        ResponsesSystemMessageMode::Developer
-    } else {
-        ResponsesSystemMessageMode::System
-    };
-
-    ResponsesModelCapabilities {
-        is_reasoning_model,
-        system_message_mode,
-        supports_flex_processing,
-        supports_priority_processing,
-        supports_non_reasoning_parameters,
-    }
-}
-
-/// Check if a reasoning value is a custom (non-"provider-default") value.
-fn is_custom_reasoning(reasoning: &Option<ReasoningEffort>) -> bool {
-    match reasoning {
-        Some(ReasoningEffort::ProviderDefault) => false,
-        Some(_) => true,
-        None => false,
-    }
-}
+// `GptVersion` / `get_gpt_version` / `get_o_series_version` /
+// `ModelCapabilities` / `SystemMessageMode` / `get_model_capabilities` live in
+// `crate::openai::convert_common` and are shared with the Chat Completions
+// converter (issue M10).
+use crate::openai::convert_common::{ModelCapabilities, SystemMessageMode, get_model_capabilities};
 
 // -- Provider options helper -------------------------------------------------
 
@@ -206,7 +65,7 @@ pub struct ResponsesInputResult {
 /// response chain).
 pub fn convert_to_responses_input(
     prompt: &LanguageModelPrompt,
-    system_message_mode: ResponsesSystemMessageMode,
+    system_message_mode: SystemMessageMode,
     store: bool,
     has_previous_response_id: bool,
 ) -> ResponsesInputResult {
@@ -216,19 +75,19 @@ pub fn convert_to_responses_input(
     for msg in prompt {
         match msg.role {
             Role::System => match system_message_mode {
-                ResponsesSystemMessageMode::System => {
+                SystemMessageMode::System => {
                     input.push(json!({
                         "role": "system",
                         "content": join_text_parts(&msg.content),
                     }));
                 }
-                ResponsesSystemMessageMode::Developer => {
+                SystemMessageMode::Developer => {
                     input.push(json!({
                         "role": "developer",
                         "content": join_text_parts(&msg.content),
                     }));
                 }
-                ResponsesSystemMessageMode::Remove => {
+                SystemMessageMode::Remove => {
                     warnings.push(Warning::Other {
                         message: "system messages are removed for this model".to_string(),
                     });
@@ -608,20 +467,8 @@ pub struct ResponsesRequestBodyResult {
     pub body: Value,
     pub warnings: Vec<Warning>,
 }
-
-/// Build the Responses API request body from `CallOptions`.
-///
-/// Mirrors TS `getArgs`. `stream` adds `"stream": true` to the body.
-pub fn build_responses_request_body(
-    model_id: &str,
-    options: &CallOptions,
-    stream: bool,
-) -> ResponsesRequestBodyResult {
-    let mut warnings: Vec<Warning> = Vec::new();
-    let caps = get_model_capabilities(model_id);
-    let provider_opts = &options.provider_options;
-
-    // -- Warnings for unsupported call options --
+/// Compatibility warnings for call options the Responses API does not carry.
+fn push_unsupported_call_option_warnings(options: &CallOptions, warnings: &mut Vec<Warning>) {
     if options.top_k.is_some() {
         warnings.push(Warning::Unsupported {
             feature: "topK".to_string(),
@@ -652,8 +499,16 @@ pub fn build_responses_request_body(
             details: None,
         });
     }
+}
 
-    // -- Reasoning resolution --
+/// Resolve the Responses reasoning config: `reasoningEffort` (provider option
+/// wins over top-level `reasoning`), `reasoningSummary` (defaults to "detailed"
+/// when an effort other than "none" applies), and whether the model reasons.
+fn resolve_responses_reasoning(
+    provider_opts: &Option<HashMap<String, Value>>,
+    options: &CallOptions,
+    caps: &ModelCapabilities,
+) -> (Option<String>, Option<String>, bool) {
     let resolved_reasoning_effort: Option<String> = openai_option(provider_opts, "reasoningEffort")
         .map(|v| {
             v.as_str()
@@ -661,7 +516,7 @@ pub fn build_responses_request_body(
                 .unwrap_or_else(|| v.to_string())
         })
         .or_else(|| {
-            if is_custom_reasoning(&options.reasoning) {
+            if options.reasoning.is_some_and(ReasoningEffort::is_custom) {
                 options.reasoning.map(|r| r.to_string())
             } else {
                 None
@@ -690,7 +545,18 @@ pub fn build_responses_request_body(
         .map(|v| v.as_bool().unwrap_or(false))
         .unwrap_or(caps.is_reasoning_model);
 
-    // -- conversation + previousResponseId conflict --
+    (
+        resolved_reasoning_effort,
+        resolved_reasoning_summary,
+        is_reasoning_model,
+    )
+}
+
+/// Warn when `conversation` and `previousResponseId` are both set.
+fn warn_conversation_conflict(
+    provider_opts: &Option<HashMap<String, Value>>,
+    warnings: &mut Vec<Warning>,
+) {
     let has_conversation = openai_option(provider_opts, "conversation").is_some();
     let has_previous_response_id = openai_option(provider_opts, "previousResponseId").is_some();
     if has_conversation && has_previous_response_id {
@@ -701,49 +567,37 @@ pub fn build_responses_request_body(
             ),
         });
     }
+}
 
-    // -- System message mode --
-    let system_message_mode = openai_option(provider_opts, "systemMessageMode")
+fn resolve_responses_system_message_mode(
+    provider_opts: &Option<HashMap<String, Value>>,
+    is_reasoning_model: bool,
+    caps: &ModelCapabilities,
+) -> SystemMessageMode {
+    openai_option(provider_opts, "systemMessageMode")
         .and_then(|v| v.as_str().map(|s| s.to_string()))
         .map(|s| match s.as_str() {
-            "developer" => ResponsesSystemMessageMode::Developer,
-            "remove" => ResponsesSystemMessageMode::Remove,
-            _ => ResponsesSystemMessageMode::System,
+            "developer" => SystemMessageMode::Developer,
+            "remove" => SystemMessageMode::Remove,
+            _ => SystemMessageMode::System,
         })
         .unwrap_or(if is_reasoning_model {
-            ResponsesSystemMessageMode::Developer
+            SystemMessageMode::Developer
         } else {
             caps.system_message_mode
-        });
+        })
+}
 
-    // -- Input conversion --
-    let store_bool = openai_option(provider_opts, "store")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
-    let input_result = convert_to_responses_input(
-        &options.prompt,
-        system_message_mode,
-        store_bool,
-        has_previous_response_id,
-    );
-    warnings.extend(input_result.warnings);
-
-    // -- Base body --
-    let mut body = json!({
-        "model": model_id,
-        "input": input_result.input,
-    });
-
-    if stream {
-        body["stream"] = json!(true);
-    }
-
-    // max_output_tokens
-    if let Some(max_tokens) = options.max_output_tokens {
-        body["max_output_tokens"] = json!(max_tokens);
-    }
-
-    // temperature / top_p (subject to reasoning-model restrictions)
+/// temperature / top_p, subject to reasoning-model restrictions.
+fn apply_responses_sampling(
+    body: &mut Value,
+    options: &CallOptions,
+    provider_opts: &Option<HashMap<String, Value>>,
+    caps: &ModelCapabilities,
+    is_reasoning_model: bool,
+    resolved_reasoning_effort: &Option<String>,
+    warnings: &mut Vec<Warning>,
+) {
     let mut temperature = options.temperature;
     let mut top_p = options.top_p;
 
@@ -767,37 +621,18 @@ pub fn build_responses_request_body(
             }
         }
     } else {
-        if openai_option(provider_opts, "reasoningEffort").is_some() {
-            warnings.push(Warning::Unsupported {
-                feature: "reasoningEffort".to_string(),
-                details: Some(
-                    "reasoningEffort is not supported for non-reasoning models".to_string(),
-                ),
-            });
-        }
-        if openai_option(provider_opts, "reasoningSummary").is_some() {
-            warnings.push(Warning::Unsupported {
-                feature: "reasoningSummary".to_string(),
-                details: Some(
-                    "reasoningSummary is not supported for non-reasoning models".to_string(),
-                ),
-            });
-        }
-        if openai_option(provider_opts, "reasoningMode").is_some() {
-            warnings.push(Warning::Unsupported {
-                feature: "reasoningMode".to_string(),
-                details: Some(
-                    "reasoningMode is not supported for non-reasoning models".to_string(),
-                ),
-            });
-        }
-        if openai_option(provider_opts, "reasoningContext").is_some() {
-            warnings.push(Warning::Unsupported {
-                feature: "reasoningContext".to_string(),
-                details: Some(
-                    "reasoningContext is not supported for non-reasoning models".to_string(),
-                ),
-            });
+        for key in [
+            "reasoningEffort",
+            "reasoningSummary",
+            "reasoningMode",
+            "reasoningContext",
+        ] {
+            if openai_option(provider_opts, key).is_some() {
+                warnings.push(Warning::Unsupported {
+                    feature: key.to_string(),
+                    details: Some(format!("{key} is not supported for non-reasoning models")),
+                });
+            }
         }
     }
 
@@ -807,8 +642,14 @@ pub fn build_responses_request_body(
     if let Some(p) = top_p {
         body["top_p"] = json!(p);
     }
+}
 
-    // -- Response format (text.format) --
+/// `text.format` (json_schema / json_object) plus `verbosity`.
+fn apply_responses_text_format(
+    body: &mut Value,
+    options: &CallOptions,
+    provider_opts: &Option<HashMap<String, Value>>,
+) {
     if let Some(ref rf) = options.response_format {
         match rf {
             ResponseFormat::Text => {}
@@ -840,7 +681,6 @@ pub fn build_responses_request_body(
         }
     }
 
-    // textVerbosity
     if let Some(verbosity) = openai_option(provider_opts, "textVerbosity") {
         let text = body.get_mut("text").and_then(|t| t.as_object_mut());
         match text {
@@ -852,8 +692,14 @@ pub fn build_responses_request_body(
             }
         }
     }
+}
 
-    // -- include (computed) --
+/// The computed `include` list (store=false on reasoning models adds
+/// `reasoning.encrypted_content`).
+fn resolve_responses_include(
+    provider_opts: &Option<HashMap<String, Value>>,
+    is_reasoning_model: bool,
+) -> Option<Vec<Value>> {
     let mut include: Option<Vec<Value>> =
         openai_option(provider_opts, "include").and_then(|v| v.as_array().cloned());
 
@@ -875,54 +721,41 @@ pub fn build_responses_request_body(
         add_include("reasoning.encrypted_content", &mut include);
     }
 
-    if let Some(inc) = include {
-        body["include"] = json!(inc);
-    }
+    include
+}
 
-    // -- store (only sent when explicitly set) --
-    if let Some(s) = openai_option(provider_opts, "store").and_then(|v| v.as_bool()) {
-        body["store"] = json!(s);
-    }
+/// Pass-through of the remaining Responses provider options (only sent when
+/// set).
+fn apply_responses_provider_options(
+    body: &mut Value,
+    provider_opts: &Option<HashMap<String, Value>>,
+) {
+    let mut set = |key: &str, body_key: &str| {
+        if let Some(v) = openai_option(provider_opts, key) {
+            body[body_key] = v;
+        }
+    };
+    set("conversation", "conversation");
+    set("maxToolCalls", "max_tool_calls");
+    set("metadata", "metadata");
+    set("parallelToolCalls", "parallel_tool_calls");
+    set("previousResponseId", "previous_response_id");
+    set("user", "user");
+    set("instructions", "instructions");
+    set("promptCacheKey", "prompt_cache_key");
+    set("promptCacheOptions", "prompt_cache_options");
+    set("promptCacheRetention", "prompt_cache_retention");
+    set("safetyIdentifier", "safety_identifier");
+    set("truncation", "truncation");
+}
 
-    // -- Other provider options (only sent when set) --
-    if let Some(v) = openai_option(provider_opts, "conversation") {
-        body["conversation"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "maxToolCalls") {
-        body["max_tool_calls"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "metadata") {
-        body["metadata"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "parallelToolCalls") {
-        body["parallel_tool_calls"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "previousResponseId") {
-        body["previous_response_id"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "user") {
-        body["user"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "instructions") {
-        body["instructions"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "promptCacheKey") {
-        body["prompt_cache_key"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "promptCacheOptions") {
-        body["prompt_cache_options"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "promptCacheRetention") {
-        body["prompt_cache_retention"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "safetyIdentifier") {
-        body["safety_identifier"] = v;
-    }
-    if let Some(v) = openai_option(provider_opts, "truncation") {
-        body["truncation"] = v;
-    }
-
-    // -- service_tier (with capability validation) --
+/// `service_tier` with model-capability validation.
+fn apply_responses_service_tier(
+    body: &mut Value,
+    provider_opts: &Option<HashMap<String, Value>>,
+    caps: &ModelCapabilities,
+    warnings: &mut Vec<Warning>,
+) {
     if let Some(st) =
         openai_option(provider_opts, "serviceTier").and_then(|v| v.as_str().map(|s| s.to_string()))
     {
@@ -947,33 +780,137 @@ pub fn build_responses_request_body(
             }
         }
     }
+}
+
+/// `reasoning` block for reasoning models.
+fn apply_responses_reasoning_block(
+    body: &mut Value,
+    provider_opts: &Option<HashMap<String, Value>>,
+    is_reasoning_model: bool,
+    resolved_reasoning_effort: &Option<String>,
+    resolved_reasoning_summary: &Option<String>,
+) {
+    if !is_reasoning_model {
+        return;
+    }
+    let effort = resolved_reasoning_effort.as_ref();
+    let summary = resolved_reasoning_summary.as_ref();
+    let mode = openai_option(provider_opts, "reasoningMode")
+        .and_then(|v| v.as_str().map(|s| s.to_string()));
+    let context = openai_option(provider_opts, "reasoningContext")
+        .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+    if effort.is_some() || summary.is_some() || mode.is_some() || context.is_some() {
+        let mut reasoning = json!({});
+        if let Some(e) = effort {
+            reasoning["effort"] = json!(e);
+        }
+        if let Some(s) = summary {
+            reasoning["summary"] = json!(s);
+        }
+        if let Some(m) = mode {
+            reasoning["mode"] = json!(m);
+        }
+        if let Some(c) = context {
+            reasoning["context"] = json!(c);
+        }
+        body["reasoning"] = reasoning;
+    }
+}
+
+/// Build the OpenAI Responses API request body (without warnings).
+///
+/// Splits the original ~380-line function into focused helpers (issue M11);
+/// behavior is unchanged.
+pub fn build_responses_request_body(
+    model_id: &str,
+    options: &CallOptions,
+    stream: bool,
+) -> ResponsesRequestBodyResult {
+    let mut warnings: Vec<Warning> = Vec::new();
+    let caps = get_model_capabilities(model_id);
+    let provider_opts = &options.provider_options;
+
+    // -- Warnings for unsupported call options --
+    push_unsupported_call_option_warnings(options, &mut warnings);
+
+    // -- Reasoning resolution --
+    let (resolved_reasoning_effort, resolved_reasoning_summary, is_reasoning_model) =
+        resolve_responses_reasoning(provider_opts, options, &caps);
+
+    // -- conversation + previousResponseId conflict --
+    warn_conversation_conflict(provider_opts, &mut warnings);
+
+    // -- System message mode --
+    let system_message_mode =
+        resolve_responses_system_message_mode(provider_opts, is_reasoning_model, &caps);
+
+    // -- Input conversion --
+    let store_bool = openai_option(provider_opts, "store")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let has_previous_response_id = openai_option(provider_opts, "previousResponseId").is_some();
+    let input_result = convert_to_responses_input(
+        &options.prompt,
+        system_message_mode,
+        store_bool,
+        has_previous_response_id,
+    );
+    warnings.extend(input_result.warnings);
+
+    // -- Base body --
+    let mut body = json!({
+        "model": model_id,
+        "input": input_result.input,
+    });
+
+    if stream {
+        body["stream"] = json!(true);
+    }
+
+    if let Some(max_tokens) = options.max_output_tokens {
+        body["max_output_tokens"] = json!(max_tokens);
+    }
+
+    // temperature / top_p (subject to reasoning-model restrictions)
+    apply_responses_sampling(
+        &mut body,
+        options,
+        provider_opts,
+        &caps,
+        is_reasoning_model,
+        &resolved_reasoning_effort,
+        &mut warnings,
+    );
+
+    // -- Response format (text.format) + verbosity --
+    apply_responses_text_format(&mut body, options, provider_opts);
+
+    // -- include (computed) --
+    let include = resolve_responses_include(provider_opts, is_reasoning_model);
+    if let Some(inc) = include {
+        body["include"] = json!(inc);
+    }
+
+    // -- store (only sent when explicitly set) --
+    if let Some(s) = openai_option(provider_opts, "store").and_then(|v| v.as_bool()) {
+        body["store"] = json!(s);
+    }
+
+    // -- Other provider options (only sent when set) --
+    apply_responses_provider_options(&mut body, provider_opts);
+
+    // -- service_tier (with capability validation) --
+    apply_responses_service_tier(&mut body, provider_opts, &caps, &mut warnings);
 
     // -- reasoning block (reasoning models only) --
-    if is_reasoning_model {
-        let effort = resolved_reasoning_effort.as_ref();
-        let summary = resolved_reasoning_summary.as_ref();
-        let mode = openai_option(provider_opts, "reasoningMode")
-            .and_then(|v| v.as_str().map(|s| s.to_string()));
-        let context = openai_option(provider_opts, "reasoningContext")
-            .and_then(|v| v.as_str().map(|s| s.to_string()));
-
-        if effort.is_some() || summary.is_some() || mode.is_some() || context.is_some() {
-            let mut reasoning = json!({});
-            if let Some(e) = effort {
-                reasoning["effort"] = json!(e);
-            }
-            if let Some(s) = summary {
-                reasoning["summary"] = json!(s);
-            }
-            if let Some(m) = mode {
-                reasoning["mode"] = json!(m);
-            }
-            if let Some(c) = context {
-                reasoning["context"] = json!(c);
-            }
-            body["reasoning"] = reasoning;
-        }
-    }
+    apply_responses_reasoning_block(
+        &mut body,
+        provider_opts,
+        is_reasoning_model,
+        &resolved_reasoning_effort,
+        &resolved_reasoning_summary,
+    );
 
     // -- Tools --
     let prepared = prepare_responses_tools(&options.tools, Some(&options.tool_choice));

--- a/aimux-providers/src/parallel_ai.rs
+++ b/aimux-providers/src/parallel_ai.rs
@@ -15,7 +15,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -78,12 +77,6 @@ impl ParallelAiProvider {
 impl Provider for ParallelAiProvider {
     fn name(&self) -> &str {
         "parallel_ai"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "parallel_ai does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/recraft.rs
+++ b/aimux-providers/src/recraft.rs
@@ -18,7 +18,6 @@ use aimux_core::error::AiMuxError;
 use aimux_core::image_model::{
     ImageCallOptions, ImageModel, ImageOutputs, ImageResponse, ImageResult,
 };
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::shared::Warning;
 use aimux_provider_utils::response::{DEFAULT_ERROR_STRUCTURE, api_call_to_provider_error};
@@ -86,12 +85,6 @@ impl RecraftProvider {
 impl Provider for RecraftProvider {
     fn name(&self) -> &str {
         PROVIDER_NAME
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "Recraft is an image-only provider; language models are not supported.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/runwayml.rs
+++ b/aimux-providers/src/runwayml.rs
@@ -17,7 +17,6 @@ use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::shared::Warning;
 use aimux_core::video_model::{
@@ -113,12 +112,6 @@ impl RunwaymlProvider {
 impl Provider for RunwaymlProvider {
     fn name(&self) -> &str {
         PROVIDER_NAME
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(format!(
-            "{PROVIDER_NAME} is a video-only provider and does not support language models"
-        )))
     }
 }
 

--- a/aimux-providers/src/searxng.rs
+++ b/aimux-providers/src/searxng.rs
@@ -15,7 +15,6 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -82,12 +81,6 @@ impl SearxngProvider {
 impl Provider for SearxngProvider {
     fn name(&self) -> &str {
         "searxng"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "searxng does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/serper.rs
+++ b/aimux-providers/src/serper.rs
@@ -11,7 +11,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -67,12 +66,6 @@ impl SerperProvider {
 impl Provider for SerperProvider {
     fn name(&self) -> &str {
         "serper"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "serper does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/stability.rs
+++ b/aimux-providers/src/stability.rs
@@ -14,12 +14,12 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use serde_json::Value;
 
+use aimux_core::Provider;
 use aimux_core::error::AiMuxError;
 use aimux_core::image_model::{
     ImageCallOptions, ImageModel, ImageOutputs, ImageResponse, ImageResult,
 };
 use aimux_core::shared::Warning;
-use aimux_core::{LanguageModel, Provider};
 use aimux_provider_utils::response::ErrorStructure;
 use aimux_provider_utils::{
     HttpBody, HttpMethod, HttpRequest, MultipartForm, RetryConfig, load_api_key, send,
@@ -96,11 +96,6 @@ impl StabilityProvider {
 impl Provider for StabilityProvider {
     fn name(&self) -> &str {
         "stability"
-    }
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "Stability is an image-only provider and does not support language models.".into(),
-        ))
     }
 }
 

--- a/aimux-providers/src/tavily.rs
+++ b/aimux-providers/src/tavily.rs
@@ -10,7 +10,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -72,12 +71,6 @@ impl TavilyProvider {
 impl Provider for TavilyProvider {
     fn name(&self) -> &str {
         "tavily"
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "tavily does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/tinyfish.rs
+++ b/aimux-providers/src/tinyfish.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -101,12 +100,6 @@ impl TinyfishProvider {
 impl Provider for TinyfishProvider {
     fn name(&self) -> &str {
         PROVIDER_NAME
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "tinyfish does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/src/vertex/anthropic_model.rs
+++ b/aimux-providers/src/vertex/anthropic_model.rs
@@ -169,7 +169,7 @@ impl LanguageModel for VertexAnthropicModel {
         .map_err(api_call_to_provider_error)?;
 
         let data: AnthropicResponse =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+            serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         let mut content = Vec::new();
         for block in &data.content {

--- a/aimux-providers/src/vertex/embedding.rs
+++ b/aimux-providers/src/vertex/embedding.rs
@@ -157,8 +157,7 @@ impl EmbeddingModel for VertexEmbeddingModel {
 
             let response_headers = resp.headers;
 
-            let raw_value: Value =
-                serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+            let raw_value: Value = serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
             let embedding = raw_value
                 .get("embedding")
@@ -238,8 +237,7 @@ impl EmbeddingModel for VertexEmbeddingModel {
 
         let response_headers = resp.headers;
 
-        let raw_value: Value =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+        let raw_value: Value = serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         // Batch: response.predictions[].embeddings.values
         let (embeddings, total_tokens): (Vec<Vec<f32>>, u32) = raw_value

--- a/aimux-providers/src/vertex/model.rs
+++ b/aimux-providers/src/vertex/model.rs
@@ -148,7 +148,7 @@ impl LanguageModel for VertexModel {
         let response_headers = resp.headers;
 
         let data: GenerateContentResponse =
-            serde_json::from_slice(&resp.body).map_err(|e| AiMuxError::Http(e.to_string()))?;
+            serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
         let candidate = data
             .candidates

--- a/aimux-providers/src/voyage/mod.rs
+++ b/aimux-providers/src/voyage/mod.rs
@@ -69,14 +69,4 @@ impl Provider for VoyageProvider {
     fn name(&self) -> &str {
         "voyage"
     }
-
-    fn language_model(
-        &self,
-        _model_id: &str,
-    ) -> Result<Box<dyn aimux_core::language_model::LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "Voyage AI does not support language models. Use embedding_model() instead."
-                .to_string(),
-        ))
-    }
 }

--- a/aimux-providers/src/xai/convert.rs
+++ b/aimux-providers/src/xai/convert.rs
@@ -64,14 +64,6 @@ pub fn supports_reasoning_effort(model_id: &str) -> bool {
     !is_model_without_reasoning_effort(model_id)
 }
 
-pub fn is_custom_reasoning(reasoning: &Option<ReasoningEffort>) -> bool {
-    match reasoning {
-        Some(ReasoningEffort::ProviderDefault) => false,
-        Some(_) => true,
-        None => false,
-    }
-}
-
 // ── Usage conversion ─────────────────────────────────────────────────────────
 
 pub fn convert_xai_usage(usage: &XaiUsageResponse) -> aimux_core::types::Usage {
@@ -485,7 +477,7 @@ pub fn build_request_body_with_warnings(
     let mut reasoning_effort: Option<String> = xai_option(xai_opts, "reasoningEffort")
         .map(|v| v.as_str().map(|s| s.to_string()).unwrap_or(v.to_string()));
 
-    if reasoning_effort.is_none() && is_custom_reasoning(&options.reasoning) {
+    if reasoning_effort.is_none() && options.reasoning.is_some_and(ReasoningEffort::is_custom) {
         let reasoning = options.reasoning.unwrap();
         if !supports_reasoning_effort(model_id) {
             warnings.push(Warning::Unsupported {

--- a/aimux-providers/src/xai/responses/convert.rs
+++ b/aimux-providers/src/xai/responses/convert.rs
@@ -1,4 +1,4 @@
-﻿//! Conversion functions for the xAI Responses API.
+//! Conversion functions for the xAI Responses API.
 //!
 //! Mirrors the TS sources:
 //! - `convert-to-xai-responses-input.ts`
@@ -18,8 +18,8 @@ use serde_json::{Value, json};
 
 use super::types::XaiResponsesUsage;
 use crate::xai::convert::{
-    is_custom_reasoning, remove_additional_properties_false, resolve_full_media_type,
-    resolve_provider_reference, supports_reasoning_effort,
+    remove_additional_properties_false, resolve_full_media_type, resolve_provider_reference,
+    supports_reasoning_effort,
 };
 
 // ── Finish reason ────────────────────────────────────────────────────────────
@@ -588,7 +588,7 @@ pub fn build_responses_request_body(
     let mut reasoning_effort: Option<String> = xai_option(xai_opts, "reasoningEffort")
         .map(|v| v.as_str().map(|s| s.to_string()).unwrap_or(v.to_string()));
 
-    if reasoning_effort.is_none() && is_custom_reasoning(&options.reasoning) {
+    if reasoning_effort.is_none() && options.reasoning.is_some_and(ReasoningEffort::is_custom) {
         let reasoning = options.reasoning.unwrap();
         if !supports_reasoning_effort(model_id) {
             warnings.push(Warning::Unsupported {

--- a/aimux-providers/src/you_com.rs
+++ b/aimux-providers/src/you_com.rs
@@ -15,7 +15,6 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use aimux_core::error::AiMuxError;
-use aimux_core::language_model::LanguageModel;
 use aimux_core::provider::Provider;
 use aimux_core::search_model::{
     SearchCallOptions, SearchModel, SearchResponse, SearchResult, SearchResultItem,
@@ -102,12 +101,6 @@ impl YouComProvider {
 impl Provider for YouComProvider {
     fn name(&self) -> &str {
         PROVIDER_NAME
-    }
-
-    fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
-        Err(AiMuxError::Unsupported(
-            "you_com does not support language models. Use search_model() instead.".to_string(),
-        ))
     }
 }
 

--- a/aimux-providers/tests/body_overrides_test.rs
+++ b/aimux-providers/tests/body_overrides_test.rs
@@ -44,7 +44,7 @@ fn opts_with_overrides(prompt: LanguageModelPrompt, body_overrides: Value) -> Ca
 #[test]
 fn body_overrides_injects_new_field() {
     let opts = opts_with_overrides(user_prompt(), json!({ "enable_thinking": false }));
-    let body = build_request_body("gpt-4o", &opts, false);
+    let body = build_request_body("gpt-4o", &opts, false).unwrap();
     assert_eq!(body["enable_thinking"], json!(false));
     assert_eq!(body["model"], json!("gpt-4o"));
 }
@@ -53,7 +53,7 @@ fn body_overrides_injects_new_field() {
 #[test]
 fn body_overrides_injects_nested_object() {
     let opts = opts_with_overrides(user_prompt(), json!({ "thinking": { "type": "disabled" } }));
-    let body = build_request_body("gpt-4o", &opts, false);
+    let body = build_request_body("gpt-4o", &opts, false).unwrap();
     assert_eq!(body["thinking"], json!({ "type": "disabled" }));
 }
 
@@ -64,7 +64,7 @@ fn body_overrides_injects_nested_object() {
 fn body_overrides_overwrites_existing_field() {
     let mut opts = opts_with_overrides(user_prompt(), json!({ "temperature": 0.1 }));
     opts.temperature = Some(0.9); // set by standard option
-    let body = build_request_body("gpt-4o", &opts, false);
+    let body = build_request_body("gpt-4o", &opts, false).unwrap();
     // body_overrides wins over standard option
     assert_eq!(body["temperature"], json!(0.1));
 }
@@ -89,6 +89,7 @@ fn body_overrides_overwrites_vendor_override_field() {
         "deepseek",
         &aimux_providers::openai::OpenAICompatProfile::deepseek(),
     )
+    .unwrap()
     .body;
     assert_eq!(body["thinking"], json!({ "type": "enabled" }));
 }
@@ -105,7 +106,7 @@ fn body_overrides_deep_merges_nested_objects() {
         user_prompt(),
         json!({ "stream_options": { "include_usage": false } }),
     );
-    let body = build_request_body("gpt-4o", &opts, true);
+    let body = build_request_body("gpt-4o", &opts, true).unwrap();
     assert_eq!(body["stream_options"]["include_usage"], json!(false));
 }
 
@@ -119,7 +120,7 @@ fn body_overrides_null_deletes_key() {
         user_prompt(),
         json!({ "stream_options": null, "temperature": null }),
     );
-    let body = build_request_body("gpt-4o", &opts, true);
+    let body = build_request_body("gpt-4o", &opts, true).unwrap();
     assert!(
         body.get("stream_options").is_none(),
         "stream_options should be deleted by null"
@@ -137,7 +138,7 @@ fn body_overrides_null_deletes_nested_key() {
         user_prompt(),
         json!({ "stream_options": { "include_usage": null } }),
     );
-    let body = build_request_body("gpt-4o", &opts, true);
+    let body = build_request_body("gpt-4o", &opts, true).unwrap();
     // stream_options still exists but include_usage is gone
     assert!(body.get("stream_options").is_some());
     assert!(body["stream_options"].get("include_usage").is_none());
@@ -150,7 +151,7 @@ fn body_overrides_null_deletes_nested_key() {
 #[test]
 fn no_body_overrides_leaves_body_unchanged() {
     let opts = CallOptions::new(user_prompt());
-    let body = build_request_body("gpt-4o", &opts, false);
+    let body = build_request_body("gpt-4o", &opts, false).unwrap();
     assert_eq!(body["model"], json!("gpt-4o"));
     assert!(body.get("enable_thinking").is_none());
 }
@@ -190,7 +191,9 @@ fn max_tokens_key_max_tokens_reasoning_model() {
         max_tokens_key: Some("max_tokens"),
         ..aimux_providers::openai::OpenAICompatProfile::full()
     };
-    let body = build_request_body_with_warnings("o4-mini", &opts, false, "openai", &profile).body;
+    let body = build_request_body_with_warnings("o4-mini", &opts, false, "openai", &profile)
+        .unwrap()
+        .body;
     assert_eq!(body["max_tokens"], json!(100));
     assert!(
         body.get("max_completion_tokens").is_none(),
@@ -211,7 +214,9 @@ fn max_tokens_key_max_completion_tokens_non_reasoning() {
         max_tokens_key: Some("max_completion_tokens"),
         ..aimux_providers::openai::OpenAICompatProfile::full()
     };
-    let body = build_request_body_with_warnings("gpt-4o", &opts, false, "openai", &profile).body;
+    let body = build_request_body_with_warnings("gpt-4o", &opts, false, "openai", &profile)
+        .unwrap()
+        .body;
     assert_eq!(body["max_completion_tokens"], json!(100));
     assert!(
         body.get("max_tokens").is_none(),
@@ -238,7 +243,8 @@ fn groq_none_passthrough_no_warning() {
         false,
         "groq",
         &aimux_providers::openai::OpenAICompatProfile::groq(),
-    );
+    )
+    .unwrap();
     assert_eq!(result.body["reasoning_effort"], json!("none"));
     let reasoning_warning = result
         .warnings
@@ -265,7 +271,8 @@ fn no_warning_when_reasoning_translated() {
         false,
         "openai",
         &aimux_providers::openai::OpenAICompatProfile::full(),
-    );
+    )
+    .unwrap();
     assert_eq!(result.body["reasoning_effort"], json!("none"));
     let reasoning_warning = result
         .warnings

--- a/aimux-providers/tests/convert_golden_test.rs
+++ b/aimux-providers/tests/convert_golden_test.rs
@@ -1,0 +1,245 @@
+//! Golden equivalence tests for the three request-body converters that were
+//! split during M11 (#76).
+//!
+//! The splits were pure reorganization; these tests pin each converter's FULL
+//! request body + warning list for a representative option matrix so any
+//! future refactor (or a regression like the Anthropic default-budget drop)
+//! is caught by an exact comparison, not by a partial assertion.
+
+use serde_json::json;
+
+use aimux_core::content::ContentPart;
+use aimux_core::language_model_message::{LanguageModelPrompt, LanguageModelPromptMessage};
+use aimux_core::message::Role;
+use aimux_core::options::{CallOptions, ResponseFormat, ToolChoice};
+use aimux_core::tool::{FunctionTool, Tool};
+
+use aimux_providers::anthropic::convert::build_request_body_with_warnings as anthropic_build;
+use aimux_providers::openai::convert::build_request_body_with_warnings as openai_build;
+use aimux_providers::openai::responses::convert::build_responses_request_body;
+
+fn user_prompt() -> LanguageModelPrompt {
+    vec![LanguageModelPromptMessage {
+        role: Role::User,
+        content: vec![ContentPart::text("Hello")],
+        ..Default::default()
+    }]
+}
+
+fn weather_tool() -> FunctionTool {
+    FunctionTool {
+        name: "weather".to_string(),
+        description: Some("current weather".to_string()),
+        input_schema: json!({
+            "type": "object",
+            "properties": { "location": { "type": "string" } },
+            "required": ["location"],
+            "additionalProperties": false
+        }),
+        strict: None,
+        provider_options: None,
+        input_examples: None,
+    }
+}
+
+fn json_schema_format() -> ResponseFormat {
+    ResponseFormat::Json {
+        schema: Some(json!({
+            "type": "object",
+            "properties": { "answer": { "type": "string" } },
+            "required": ["answer"]
+        })),
+        name: Some("qa".to_string()),
+        description: Some("answer extraction".to_string()),
+    }
+}
+
+// ── OpenAI Chat Completions ─────────────────────────────────────────────────
+
+#[test]
+fn openai_chat_golden() {
+    let options = CallOptions {
+        prompt: user_prompt(),
+        max_output_tokens: Some(2048),
+        temperature: Some(0.7),
+        reasoning: Some(aimux_core::types::ReasoningEffort::High),
+        tools: Some(vec![Tool::Function(weather_tool())]),
+        tool_choice: ToolChoice::Auto,
+        response_format: Some(json_schema_format()),
+        body_overrides: Some(json!({ "user": "override-me" })),
+        ..CallOptions::default()
+    };
+
+    let result = openai_build(
+        "o3-mini",
+        &options,
+        false,
+        "openai",
+        &aimux_providers::openai::OpenAICompatProfile::full(),
+    )
+    .expect("openai chat build");
+
+    assert_eq!(
+        result.body,
+        json!({
+            "model": "o3-mini",
+            "messages": [ { "role": "user", "content": "Hello" } ],
+            "max_completion_tokens": 2048,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "schema": {
+                        "type": "object",
+                        "properties": { "answer": { "type": "string" } },
+                        "required": ["answer"]
+                    },
+                    "name": "qa",
+                    "description": "answer extraction",
+                    "strict": true
+                }
+            },
+            "reasoning_effort": "high",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "description": "current weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": { "location": { "type": "string" } },
+                            "required": ["location"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            ],
+            "tool_choice": "auto",
+            "user": "override-me"
+        }),
+        "openai chat body diverged: {}",
+        result.body
+    );
+    // `temperature` is stripped for reasoning models with a warning; the
+    // body override `user` lands after built-in fields.
+    assert_eq!(result.body.get("temperature"), None);
+    assert_eq!(
+        serde_json::to_value(&result.warnings).unwrap(),
+        json!([{ "Unsupported": { "feature": "temperature",
+                 "details": "temperature is not supported for reasoning models" } }])
+    );
+}
+
+// ── OpenAI Responses API ────────────────────────────────────────────────────
+
+#[test]
+fn responses_golden() {
+    let mut provider = std::collections::HashMap::new();
+    provider.insert(
+        "openai".to_string(),
+        json!({
+            "reasoningEffort": "high",
+            "textVerbosity": "low",
+            "metadata": { "k": "v" }
+        }),
+    );
+    let options = CallOptions {
+        prompt: user_prompt(),
+        seed: Some(42),
+        top_k: Some(0.2),
+        response_format: Some(json_schema_format()),
+        provider_options: Some(provider),
+        ..CallOptions::default()
+    };
+
+    let result = build_responses_request_body("o3-mini", &options, false);
+
+    assert_eq!(
+        result.body,
+        json!({
+            "model": "o3-mini",
+            "input": [
+                { "role": "user", "content": [ { "type": "input_text", "text": "Hello" } ] }
+            ],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "strict": true,
+                    "name": "qa",
+                    "description": "answer extraction",
+                    "schema": {
+                        "type": "object",
+                        "properties": { "answer": { "type": "string" } },
+                        "required": ["answer"]
+                    }
+                },
+                "verbosity": "low"
+            },
+            "metadata": { "k": "v" },
+            "reasoning": { "effort": "high", "summary": "detailed" }
+        }),
+        "responses body diverged: {}",
+        result.body
+    );
+
+    // top_k / seed are unsupported in the Responses API → compatibility
+    // warnings, and the model is a reasoning model so it exposes `reasoning`.
+    assert_eq!(
+        serde_json::to_value(&result.warnings).unwrap(),
+        json!([
+            { "Unsupported": { "feature": "topK", "details": null } },
+            { "Unsupported": { "feature": "seed", "details": null } }
+        ])
+    );
+}
+
+// ── Anthropic ───────────────────────────────────────────────────────────────
+
+#[test]
+fn anthropic_golden() {
+    let mut provider = std::collections::HashMap::new();
+    provider.insert(
+        "anthropic".to_string(),
+        json!({
+            "thinking": { "type": "enabled", "budgetTokens": 4096 }
+        }),
+    );
+    let options = CallOptions {
+        prompt: user_prompt(),
+        max_output_tokens: Some(1000),
+        temperature: Some(0.7),
+        top_k: Some(0.5),
+        stop_sequences: Some(vec!["END".to_string()]),
+        provider_options: Some(provider),
+        ..CallOptions::default()
+    };
+
+    let result = anthropic_build("claude-sonnet-4-5", &options, false).expect("anthropic build");
+
+    assert_eq!(
+        result.body,
+        json!({
+            "model": "claude-sonnet-4-5",
+            "messages": [ { "role": "user", "content": [ { "type": "text", "text": "Hello" } ] } ],
+            "max_tokens": 1000 + 4096,
+            "stream": false,
+            "thinking": { "type": "enabled", "budget_tokens": 4096 },
+            "stop_sequences": ["END"]
+        }),
+        "anthropic body diverged: {}",
+        result.body
+    );
+
+    // Thinking enabled strips temperature/topK with warnings.
+    assert_eq!(result.body.get("temperature"), None);
+    assert_eq!(result.body.get("top_k"), None);
+    assert_eq!(
+        serde_json::to_value(&result.warnings).unwrap(),
+        json!([
+            { "Unsupported": { "feature": "temperature",
+              "details": "temperature is not supported when thinking is enabled" } },
+            { "Unsupported": { "feature": "topK",
+              "details": "topK is not supported when thinking is enabled" } }
+        ])
+    );
+}

--- a/aimux-providers/tests/dataforseo_test.rs
+++ b/aimux-providers/tests/dataforseo_test.rs
@@ -234,7 +234,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model("dataforseo-search") {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("dataforseo does not support language models"),
+                msg.contains("provider 'dataforseo' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/aimux-providers/tests/deepseek_chat_test.rs
+++ b/aimux-providers/tests/deepseek_chat_test.rs
@@ -791,7 +791,8 @@ async fn should_convert_user_text_part_to_string_content() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         result.body["messages"],
@@ -821,7 +822,8 @@ async fn should_convert_image_file_parts_to_image_url() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     // Image file parts are converted to image_url (OpenAI-compatible behaviour).
     let messages_str = result.body["messages"].to_string();
@@ -860,7 +862,8 @@ async fn should_accept_top_level_only_mediatype_without_error() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     // Top-level media type "image" is resolved to image_url (OpenAI-compatible).
     let messages_str = result.body["messages"].to_string();
@@ -902,7 +905,8 @@ async fn should_stringify_arguments_to_tool_calls() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     let messages = result.body["messages"].as_array().expect("messages array");
     assert_eq!(messages.len(), 2);
@@ -963,7 +967,8 @@ async fn should_handle_text_output_type_in_tool_results() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     let messages = result.body["messages"].as_array().expect("messages array");
     assert_eq!(messages.len(), 2);
@@ -1021,7 +1026,8 @@ async fn should_pass_through_strict_mode_when_strict_is_true() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         result.body["tools"],
@@ -1059,7 +1065,8 @@ async fn should_pass_through_strict_mode_when_strict_is_false() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         result.body["tools"],
@@ -1097,7 +1104,8 @@ async fn should_not_include_strict_mode_when_strict_is_undefined() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         result.body["tools"],
@@ -1158,7 +1166,8 @@ async fn should_pass_through_strict_mode_for_multiple_tools() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
 
     let tools_arr = result.body["tools"].as_array().expect("tools array");
     assert_eq!(tools_arr.len(), 3);

--- a/aimux-providers/tests/google_pse_test.rs
+++ b/aimux-providers/tests/google_pse_test.rs
@@ -263,7 +263,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model("google-pse-search") {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("google_pse does not support language models"),
+                msg.contains("provider 'google_pse' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/aimux-providers/tests/google_remaining_test.rs
+++ b/aimux-providers/tests/google_remaining_test.rs
@@ -1,4 +1,4 @@
-﻿//! Remaining Google provider tests — ported from the TS SDK test suite.
+//! Remaining Google provider tests — ported from the TS SDK test suite.
 //!
 //! Covers the pure-function and config tests that were not already exercised
 //! by `google_model_test.rs` / `google_provider_tools_test.rs`:
@@ -718,7 +718,9 @@ mod json_accumulator_tests {
     #[test]
     fn accumulate_simple_string_with_will_continue() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[s_continue("$.location", "Boston")]);
+        let r = acc
+            .process_partial_args(&[s_continue("$.location", "Boston")])
+            .unwrap();
         assert_eq!(r.current_json, json!({ "location": "Boston" }));
         assert_eq!(r.text_delta, "{\"location\":\"Boston");
     }
@@ -726,8 +728,11 @@ mod json_accumulator_tests {
     #[test]
     fn continue_string_across_chunks() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[s_continue("$.location", "Boston")]);
-        let r = acc.process_partial_args(&[s("$.location", ", MA")]);
+        acc.process_partial_args(&[s_continue("$.location", "Boston")])
+            .unwrap();
+        let r = acc
+            .process_partial_args(&[s("$.location", ", MA")])
+            .unwrap();
         assert_eq!(r.current_json, json!({ "location": "Boston, MA" }));
         assert_eq!(r.text_delta, ", MA");
     }
@@ -735,7 +740,9 @@ mod json_accumulator_tests {
     #[test]
     fn accumulate_complete_string() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[s("$.location", "Boston")]);
+        let r = acc
+            .process_partial_args(&[s("$.location", "Boston")])
+            .unwrap();
         assert_eq!(r.current_json, json!({ "location": "Boston" }));
         assert_eq!(r.text_delta, "{\"location\":\"Boston\"");
     }
@@ -743,7 +750,9 @@ mod json_accumulator_tests {
     #[test]
     fn accumulate_number() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[n("$.brightness", 50.0)]);
+        let r = acc
+            .process_partial_args(&[n("$.brightness", 50.0)])
+            .unwrap();
         assert_eq!(r.current_json, json!({ "brightness": 50 }));
         assert_eq!(r.text_delta, "{\"brightness\":50");
     }
@@ -751,7 +760,7 @@ mod json_accumulator_tests {
     #[test]
     fn accumulate_boolean() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[b("$.enabled", true)]);
+        let r = acc.process_partial_args(&[b("$.enabled", true)]).unwrap();
         assert_eq!(r.current_json, json!({ "enabled": true }));
         assert_eq!(r.text_delta, "{\"enabled\":true");
     }
@@ -759,7 +768,7 @@ mod json_accumulator_tests {
     #[test]
     fn accumulate_null() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[null_arg("$.nickname")]);
+        let r = acc.process_partial_args(&[null_arg("$.nickname")]).unwrap();
         assert_eq!(r.current_json, json!({ "nickname": null }));
         assert_eq!(r.text_delta, "{\"nickname\":null");
     }
@@ -767,10 +776,12 @@ mod json_accumulator_tests {
     #[test]
     fn accumulate_multiple_args_with_commas() {
         let mut acc = GoogleJsonAccumulator::new();
-        let first = acc.process_partial_args(&[n("$.brightness", 50.0)]);
+        let first = acc
+            .process_partial_args(&[n("$.brightness", 50.0)])
+            .unwrap();
         assert_eq!(first.text_delta, "{\"brightness\":50");
 
-        let second = acc.process_partial_args(&[b("$.enabled", true)]);
+        let second = acc.process_partial_args(&[b("$.enabled", true)]).unwrap();
         assert_eq!(
             second.current_json,
             json!({ "brightness": 50, "enabled": true })
@@ -781,11 +792,13 @@ mod json_accumulator_tests {
     #[test]
     fn accumulate_multiple_args_single_call() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[
-            n("$.brightness", 50.0),
-            b("$.enabled", false),
-            null_arg("$.nickname"),
-        ]);
+        let r = acc
+            .process_partial_args(&[
+                n("$.brightness", 50.0),
+                b("$.enabled", false),
+                null_arg("$.nickname"),
+            ])
+            .unwrap();
         assert_eq!(
             r.current_json,
             json!({ "brightness": 50, "enabled": false, "nickname": null })
@@ -799,8 +812,9 @@ mod json_accumulator_tests {
     #[test]
     fn escape_special_chars_in_continued_strings() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[s_continue("$.query", "Boston \"Lo")]);
-        let r = acc.process_partial_args(&[s("$.query", "gan\"")]);
+        acc.process_partial_args(&[s_continue("$.query", "Boston \"Lo")])
+            .unwrap();
+        let r = acc.process_partial_args(&[s("$.query", "gan\"")]).unwrap();
         assert_eq!(r.current_json, json!({ "query": "Boston \"Logan\"" }));
         // The continuation delta is the escaped inner content of `gan"`.
         assert_eq!(r.text_delta, "gan\\\"");
@@ -809,7 +823,7 @@ mod json_accumulator_tests {
     #[test]
     fn skip_args_with_empty_path() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[s("$.", "ignored")]);
+        let r = acc.process_partial_args(&[s("$.", "ignored")]).unwrap();
         assert_eq!(r.current_json, json!({}));
         assert_eq!(r.text_delta, "");
     }
@@ -817,10 +831,12 @@ mod json_accumulator_tests {
     #[test]
     fn skip_args_with_no_resolvable_value() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[PartialArg {
-            json_path: "$.something".to_string(),
-            ..Default::default()
-        }]);
+        let r = acc
+            .process_partial_args(&[PartialArg {
+                json_path: "$.something".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
         assert_eq!(r.current_json, json!({}));
         assert_eq!(r.text_delta, "");
     }
@@ -828,7 +844,7 @@ mod json_accumulator_tests {
     #[test]
     fn empty_partial_args_returns_empty_delta() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[]);
+        let r = acc.process_partial_args(&[]).unwrap();
         assert_eq!(r.current_json, json!({}));
         assert_eq!(r.text_delta, "");
     }
@@ -838,7 +854,9 @@ mod json_accumulator_tests {
     #[test]
     fn build_nested_object_from_dotted_path() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[s("$.recipe.name", "Lasagna")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.name", "Lasagna")])
+            .unwrap();
         assert_eq!(r.current_json, json!({ "recipe": { "name": "Lasagna" } }));
         assert_eq!(r.text_delta, "{\"recipe\":{\"name\":\"Lasagna\"");
     }
@@ -846,7 +864,9 @@ mod json_accumulator_tests {
     #[test]
     fn build_nested_object_with_array_from_indexed_path() {
         let mut acc = GoogleJsonAccumulator::new();
-        let amount = acc.process_partial_args(&[s("$.recipe.ingredients[0].amount", "16 oz")]);
+        let amount = acc
+            .process_partial_args(&[s("$.recipe.ingredients[0].amount", "16 oz")])
+            .unwrap();
         assert_eq!(
             amount.current_json,
             json!({ "recipe": { "ingredients": [{ "amount": "16 oz" }] } })
@@ -856,8 +876,9 @@ mod json_accumulator_tests {
             "{\"recipe\":{\"ingredients\":[{\"amount\":\"16 oz\""
         );
 
-        let name =
-            acc.process_partial_args(&[s("$.recipe.ingredients[0].name", "Lasagna noodles")]);
+        let name = acc
+            .process_partial_args(&[s("$.recipe.ingredients[0].name", "Lasagna noodles")])
+            .unwrap();
         assert_eq!(
             name.current_json,
             json!({ "recipe": { "ingredients": [{ "amount": "16 oz", "name": "Lasagna noodles" }] } })
@@ -870,17 +891,25 @@ mod json_accumulator_tests {
         let mut acc = GoogleJsonAccumulator::new();
         let mut deltas = Vec::new();
 
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[0].amount", "16 oz")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[0].amount", "16 oz")])
+            .unwrap();
         deltas.push(r.text_delta.clone());
 
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[0].name", "Noodles")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[0].name", "Noodles")])
+            .unwrap();
         deltas.push(r.text_delta.clone());
 
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[1].amount", "1 lb")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[1].amount", "1 lb")])
+            .unwrap();
         deltas.push(r.text_delta.clone());
         assert_eq!(r.text_delta, "},{\"amount\":\"1 lb\"");
 
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[1].name", "Beef")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[1].name", "Beef")])
+            .unwrap();
         deltas.push(r.text_delta.clone());
         assert_eq!(r.text_delta, ",\"name\":\"Beef\"");
 
@@ -904,10 +933,14 @@ mod json_accumulator_tests {
     #[test]
     fn string_continuation_on_nested_paths() {
         let mut acc = GoogleJsonAccumulator::new();
-        let start = acc.process_partial_args(&[s_continue("$.recipe.steps[0]", "Preheat oven")]);
+        let start = acc
+            .process_partial_args(&[s_continue("$.recipe.steps[0]", "Preheat oven")])
+            .unwrap();
         assert_eq!(start.text_delta, "{\"recipe\":{\"steps\":[\"Preheat oven");
 
-        let cont = acc.process_partial_args(&[s("$.recipe.steps[0]", " to 375°F.")]);
+        let cont = acc
+            .process_partial_args(&[s("$.recipe.steps[0]", " to 375°F.")])
+            .unwrap();
         assert_eq!(
             cont.current_json,
             json!({ "recipe": { "steps": ["Preheat oven to 375°F."] } })
@@ -918,10 +951,14 @@ mod json_accumulator_tests {
     #[test]
     fn mixed_nested_and_flat_paths() {
         let mut acc = GoogleJsonAccumulator::new();
-        let loc = acc.process_partial_args(&[s("$.location", "Boston")]);
+        let loc = acc
+            .process_partial_args(&[s("$.location", "Boston")])
+            .unwrap();
         assert_eq!(loc.text_delta, "{\"location\":\"Boston\"");
 
-        let details = acc.process_partial_args(&[s("$.details.zip", "02101")]);
+        let details = acc
+            .process_partial_args(&[s("$.details.zip", "02101")])
+            .unwrap();
         assert_eq!(
             details.current_json,
             json!({ "details": { "zip": "02101" }, "location": "Boston" })
@@ -939,10 +976,14 @@ mod json_accumulator_tests {
     #[test]
     fn array_elements_direct_string_values() {
         let mut acc = GoogleJsonAccumulator::new();
-        let first = acc.process_partial_args(&[s("$.steps[0]", "Step one")]);
+        let first = acc
+            .process_partial_args(&[s("$.steps[0]", "Step one")])
+            .unwrap();
         assert_eq!(first.text_delta, "{\"steps\":[\"Step one\"");
 
-        let second = acc.process_partial_args(&[s("$.steps[1]", "Step two")]);
+        let second = acc
+            .process_partial_args(&[s("$.steps[1]", "Step two")])
+            .unwrap();
         assert_eq!(
             second.current_json,
             json!({ "steps": ["Step one", "Step two"] })
@@ -953,7 +994,7 @@ mod json_accumulator_tests {
     #[test]
     fn deeply_nested_paths() {
         let mut acc = GoogleJsonAccumulator::new();
-        let r = acc.process_partial_args(&[s("$.a.b.c.d", "deep")]);
+        let r = acc.process_partial_args(&[s("$.a.b.c.d", "deep")]).unwrap();
         assert_eq!(
             r.current_json,
             json!({ "a": { "b": { "c": { "d": "deep" } } } })
@@ -970,7 +1011,8 @@ mod json_accumulator_tests {
     #[test]
     fn finalize_continued_string() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[s_continue("$.location", "Boston")]);
+        acc.process_partial_args(&[s_continue("$.location", "Boston")])
+            .unwrap();
         let f = acc.finalize();
         assert_eq!(f.closing_delta, "\"}");
         assert_eq!(f.final_json, "{\"location\":\"Boston\"}");
@@ -979,7 +1021,8 @@ mod json_accumulator_tests {
     #[test]
     fn finalize_complete_string() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[s("$.location", "Boston")]);
+        acc.process_partial_args(&[s("$.location", "Boston")])
+            .unwrap();
         let f = acc.finalize();
         assert_eq!(f.closing_delta, "}");
         assert_eq!(f.final_json, "{\"location\":\"Boston\"}");
@@ -988,7 +1031,8 @@ mod json_accumulator_tests {
     #[test]
     fn finalize_multiple_args() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[n("$.brightness", 50.0), b("$.enabled", true)]);
+        acc.process_partial_args(&[n("$.brightness", 50.0), b("$.enabled", true)])
+            .unwrap();
         let f = acc.finalize();
         assert_eq!(f.closing_delta, "}");
         assert_eq!(f.final_json, "{\"brightness\":50,\"enabled\":true}");
@@ -997,8 +1041,10 @@ mod json_accumulator_tests {
     #[test]
     fn finalize_continued_string_with_continuation() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[s_continue("$.location", "Boston")]);
-        acc.process_partial_args(&[s("$.location", ", MA")]);
+        acc.process_partial_args(&[s_continue("$.location", "Boston")])
+            .unwrap();
+        acc.process_partial_args(&[s("$.location", ", MA")])
+            .unwrap();
         let f = acc.finalize();
         assert_eq!(f.closing_delta, "\"}");
         assert_eq!(f.final_json, "{\"location\":\"Boston, MA\"}");
@@ -1015,8 +1061,10 @@ mod json_accumulator_tests {
     #[test]
     fn finalize_nested_structure() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[s("$.recipe.ingredients[0].name", "Noodles")]);
-        acc.process_partial_args(&[s("$.recipe.name", "Lasagna")]);
+        acc.process_partial_args(&[s("$.recipe.ingredients[0].name", "Noodles")])
+            .unwrap();
+        acc.process_partial_args(&[s("$.recipe.name", "Lasagna")])
+            .unwrap();
         let f = acc.finalize();
         let parsed: Value = serde_json::from_str(&f.final_json).unwrap();
         assert_eq!(
@@ -1033,9 +1081,12 @@ mod json_accumulator_tests {
     #[test]
     fn finalize_nested_arrays_with_string_continuation() {
         let mut acc = GoogleJsonAccumulator::new();
-        acc.process_partial_args(&[s_continue("$.recipe.steps[0]", "Preheat")]);
-        acc.process_partial_args(&[s("$.recipe.steps[0]", " oven.")]);
-        acc.process_partial_args(&[s("$.recipe.steps[1]", "Cook.")]);
+        acc.process_partial_args(&[s_continue("$.recipe.steps[0]", "Preheat")])
+            .unwrap();
+        acc.process_partial_args(&[s("$.recipe.steps[0]", " oven.")])
+            .unwrap();
+        acc.process_partial_args(&[s("$.recipe.steps[1]", "Cook.")])
+            .unwrap();
         let f = acc.finalize();
         let parsed: Value = serde_json::from_str(&f.final_json).unwrap();
         assert_eq!(
@@ -1053,13 +1104,15 @@ mod json_accumulator_tests {
         let mut acc = GoogleJsonAccumulator::new();
         let mut deltas = Vec::new();
 
-        let r = acc.process_partial_args(&[n("$.brightness", 50.0)]);
+        let r = acc
+            .process_partial_args(&[n("$.brightness", 50.0)])
+            .unwrap();
         deltas.push(r.text_delta);
 
-        let r = acc.process_partial_args(&[b("$.enabled", true)]);
+        let r = acc.process_partial_args(&[b("$.enabled", true)]).unwrap();
         deltas.push(r.text_delta);
 
-        let r = acc.process_partial_args(&[s("$.name", "test")]);
+        let r = acc.process_partial_args(&[s("$.name", "test")]).unwrap();
         deltas.push(r.text_delta);
 
         let f = acc.finalize();
@@ -1077,21 +1130,37 @@ mod json_accumulator_tests {
         let mut acc = GoogleJsonAccumulator::new();
         let mut deltas = Vec::new();
 
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[0].amount", "16 oz")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[0].amount", "16 oz")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[0].name", "Noodles")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[0].name", "Noodles")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[1].amount", "1 lb")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[1].amount", "1 lb")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s("$.recipe.ingredients[1].name", "Beef")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.ingredients[1].name", "Beef")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s("$.recipe.name", "Lasagna")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.name", "Lasagna")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s_continue("$.recipe.steps[0]", "Preheat")]);
+        let r = acc
+            .process_partial_args(&[s_continue("$.recipe.steps[0]", "Preheat")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s("$.recipe.steps[0]", " oven.")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.steps[0]", " oven.")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s("$.recipe.steps[1]", "Cook.")]);
+        let r = acc
+            .process_partial_args(&[s("$.recipe.steps[1]", "Cook.")])
+            .unwrap();
         deltas.push(r.text_delta);
 
         let f = acc.finalize();
@@ -1104,11 +1173,13 @@ mod json_accumulator_tests {
         let mut acc = GoogleJsonAccumulator::new();
         let mut deltas = Vec::new();
 
-        let r = acc.process_partial_args(&[s_continue("$.location", "Bos")]);
+        let r = acc
+            .process_partial_args(&[s_continue("$.location", "Bos")])
+            .unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[s("$.location", "ton")]);
+        let r = acc.process_partial_args(&[s("$.location", "ton")]).unwrap();
         deltas.push(r.text_delta);
-        let r = acc.process_partial_args(&[n("$.count", 42.0)]);
+        let r = acc.process_partial_args(&[n("$.count", 42.0)]).unwrap();
         deltas.push(r.text_delta);
 
         let f = acc.finalize();

--- a/aimux-providers/tests/google_remaining_test.rs
+++ b/aimux-providers/tests/google_remaining_test.rs
@@ -18,6 +18,7 @@ use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use aimux_core::content::ContentPart;
+use aimux_core::error::AiMuxError;
 use aimux_core::language_model::LanguageModel;
 use aimux_core::language_model_message::{LanguageModelPrompt, LanguageModelPromptMessage};
 use aimux_core::message::Role;
@@ -863,6 +864,36 @@ mod json_accumulator_tests {
             .unwrap();
         // The malformed arg is ignored; the well-formed one still lands.
         assert_eq!(r.current_json, json!({ "ok": "y" }));
+    }
+
+    /// Regression (audit round 2): an oversized array index must produce an
+    /// error instead of expanding an array with ~1e6+ Null entries (OOM).
+    #[test]
+    fn oversized_array_index_is_rejected() {
+        let mut acc = GoogleJsonAccumulator::new();
+        let err = acc
+            .process_partial_args(&[PartialArg {
+                json_path: "$.a[1000000]".to_string(),
+                string_value: Some("x".to_string()),
+                ..Default::default()
+            }])
+            .unwrap_err();
+        assert!(matches!(err, AiMuxError::Json(_)));
+    }
+
+    /// Regression (audit round 2): an overly deep path must be rejected.
+    #[test]
+    fn overdeep_path_is_rejected() {
+        let mut acc = GoogleJsonAccumulator::new();
+        let deep = format!("${}", ".a".repeat(100));
+        let err = acc
+            .process_partial_args(&[PartialArg {
+                json_path: deep,
+                string_value: Some("x".to_string()),
+                ..Default::default()
+            }])
+            .unwrap_err();
+        assert!(matches!(err, AiMuxError::Json(_)));
     }
 
     #[test]

--- a/aimux-providers/tests/google_remaining_test.rs
+++ b/aimux-providers/tests/google_remaining_test.rs
@@ -841,6 +841,30 @@ mod json_accumulator_tests {
         assert_eq!(r.text_delta, "");
     }
 
+    /// Regression (audit finding on H3): a malformed empty path like `$.[]`
+    /// parses to zero segments; it must be skipped instead of panicking with a
+    /// slice underflow in `emit_navigation_to`.
+    #[test]
+    fn malformed_empty_path_is_skipped_not_panicked() {
+        let mut acc = GoogleJsonAccumulator::new();
+        let r = acc
+            .process_partial_args(&[
+                PartialArg {
+                    json_path: "$.[]".to_string(),
+                    string_value: Some("x".to_string()),
+                    ..Default::default()
+                },
+                PartialArg {
+                    json_path: "$.ok".to_string(),
+                    string_value: Some("y".to_string()),
+                    ..Default::default()
+                },
+            ])
+            .unwrap();
+        // The malformed arg is ignored; the well-formed one still lands.
+        assert_eq!(r.current_json, json!({ "ok": "y" }));
+    }
+
     #[test]
     fn empty_partial_args_returns_empty_delta() {
         let mut acc = GoogleJsonAccumulator::new();

--- a/aimux-providers/tests/google_remaining_test.rs
+++ b/aimux-providers/tests/google_remaining_test.rs
@@ -881,6 +881,34 @@ mod json_accumulator_tests {
         assert!(matches!(err, AiMuxError::Json(_)));
     }
 
+    /// Regression (audit round 3, A1): an oversized **intermediate** index
+    /// (not the last segment) must also be rejected — previously only the
+    /// leaf segment was checked, so `$.a[1000000000].b` could still force
+    /// ~1 GiB of array allocation before failing.
+    #[test]
+    fn intermediate_oversized_index_is_rejected_atomically() {
+        let mut acc = GoogleJsonAccumulator::new();
+        let err = acc
+            .process_partial_args(&[PartialArg {
+                json_path: "$.a[1000000].b".to_string(),
+                string_value: Some("x".to_string()),
+                ..Default::default()
+            }])
+            .unwrap_err();
+        assert!(matches!(err, AiMuxError::Json(_)));
+
+        // Error atomicity: the rejected arg must not leave partially-built
+        // containers (`a: []`) behind — a subsequent valid write lands cleanly.
+        let r = acc
+            .process_partial_args(&[PartialArg {
+                json_path: "$.ok".to_string(),
+                string_value: Some("y".to_string()),
+                ..Default::default()
+            }])
+            .unwrap();
+        assert_eq!(r.current_json, json!({ "ok": "y" }));
+    }
+
     /// Regression (audit round 2): an overly deep path must be rejected.
     #[test]
     fn overdeep_path_is_rejected() {

--- a/aimux-providers/tests/jina_ai_test.rs
+++ b/aimux-providers/tests/jina_ai_test.rs
@@ -315,7 +315,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model(MODEL) {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("jina_ai does not support language models"),
+                msg.contains("provider 'jina_ai' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/aimux-providers/tests/linkup_test.rs
+++ b/aimux-providers/tests/linkup_test.rs
@@ -274,7 +274,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model("linkup-search") {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("linkup does not support language models"),
+                msg.contains("provider 'linkup' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/aimux-providers/tests/openai_convert_extended_test.rs
+++ b/aimux-providers/tests/openai_convert_extended_test.rs
@@ -399,7 +399,7 @@ mod request_body_extended {
             ),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &opts, false);
+        let body = build_request_body("gpt-3.5-turbo", &opts, false).unwrap();
         assert_eq!(body["logit_bias"], json!({ "50256": -100 }));
         assert_eq!(body["parallel_tool_calls"], json!(false));
         assert_eq!(body["user"], json!("test-user-id"));
@@ -412,7 +412,7 @@ mod request_body_extended {
             reasoning: Some(ReasoningEffort::ProviderDefault),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("o4-mini", &opts, false);
+        let body = build_request_body("o4-mini", &opts, false).unwrap();
         assert_eq!(
             body,
             json!({ "model": "o4-mini", "messages": [{ "role": "user", "content": "Hello" }] })
@@ -426,7 +426,7 @@ mod request_body_extended {
             reasoning: Some(ReasoningEffort::Medium),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("o4-mini", &opts, false);
+        let body = build_request_body("o4-mini", &opts, false).unwrap();
         assert_eq!(body["reasoning_effort"], json!("medium"));
     }
 
@@ -438,7 +438,7 @@ mod request_body_extended {
             provider_options: po(json!({ "reasoningEffort": "high" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("o4-mini", &opts, false);
+        let body = build_request_body("o4-mini", &opts, false).unwrap();
         assert_eq!(body["reasoning_effort"], json!("high"));
     }
 
@@ -449,7 +449,7 @@ mod request_body_extended {
             provider_options: po(json!({ "reasoningEffort": "low" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("o4-mini", &opts, false);
+        let body = build_request_body("o4-mini", &opts, false).unwrap();
         assert_eq!(body["reasoning_effort"], json!("low"));
     }
 
@@ -460,7 +460,7 @@ mod request_body_extended {
             provider_options: po(json!({ "reasoningEffort": "xhigh" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-5.1-codex-max", &opts, false);
+        let body = build_request_body("gpt-5.1-codex-max", &opts, false).unwrap();
         assert_eq!(body["reasoning_effort"], json!("xhigh"));
     }
 
@@ -471,7 +471,7 @@ mod request_body_extended {
             provider_options: po(json!({ "reasoningEffort": "max" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-5.6", &opts, false);
+        let body = build_request_body("gpt-5.6", &opts, false).unwrap();
         assert_eq!(body["reasoning_effort"], json!("max"));
     }
 
@@ -482,7 +482,7 @@ mod request_body_extended {
             provider_options: po(json!({ "textVerbosity": "low" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-4o", &opts, false);
+        let body = build_request_body("gpt-4o", &opts, false).unwrap();
         assert_eq!(body["verbosity"], json!("low"));
     }
 
@@ -502,7 +502,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("temperature").is_none() || result.body["temperature"].is_null());
         assert!(result.body.get("top_p").is_none() || result.body["top_p"].is_null());
         assert!(
@@ -523,7 +524,7 @@ mod request_body_extended {
             max_output_tokens: Some(1000),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("o4-mini", &opts, false);
+        let body = build_request_body("o4-mini", &opts, false).unwrap();
         assert_eq!(body["max_completion_tokens"], json!(1000));
         assert!(body.get("max_tokens").is_none());
     }
@@ -542,7 +543,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert_eq!(result.body["temperature"], json!(0.5));
         assert_eq!(result.body["reasoning_effort"], json!("none"));
         assert!(result.warnings.is_empty());
@@ -562,7 +564,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("temperature").is_none() || result.body["temperature"].is_null());
         assert_eq!(result.warnings.len(), 1);
     }
@@ -582,7 +585,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("temperature").is_none() || result.body["temperature"].is_null());
         assert!(result.body.get("top_p").is_none() || result.body["top_p"].is_null());
         assert_eq!(result.warnings.len(), 2);
@@ -604,7 +608,7 @@ mod request_body_extended {
             provider_options: po(json!({ "forceReasoning": true })),
             ..default_opts(vec![])
         };
-        let body = build_request_body("stealth-reasoning-model", &opts, false);
+        let body = build_request_body("stealth-reasoning-model", &opts, false).unwrap();
         assert_eq!(body["messages"][0]["role"], json!("developer"));
         assert_eq!(body["messages"][1]["content"], json!("Hello"));
     }
@@ -624,7 +628,7 @@ mod request_body_extended {
             prompt: p,
             ..default_opts(vec![])
         };
-        let body = build_request_body("o1", &opts, false);
+        let body = build_request_body("o1", &opts, false).unwrap();
         assert_eq!(body["messages"][0]["role"], json!("developer"));
     }
 
@@ -644,7 +648,7 @@ mod request_body_extended {
             provider_options: po(json!({ "systemMessageMode": "developer" })),
             ..default_opts(vec![])
         };
-        let body = build_request_body("gpt-4o", &opts, false);
+        let body = build_request_body("gpt-4o", &opts, false).unwrap();
         assert_eq!(body["messages"][0]["role"], json!("developer"));
     }
 
@@ -663,7 +667,7 @@ mod request_body_extended {
             prompt: p,
             ..default_opts(vec![])
         };
-        let body = build_request_body("gpt-4o", &opts, false);
+        let body = build_request_body("gpt-4o", &opts, false).unwrap();
         assert_eq!(body["messages"][0]["role"], json!("system"));
     }
 
@@ -674,7 +678,7 @@ mod request_body_extended {
             provider_options: po(json!({ "maxCompletionTokens": 255 })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("o4-mini", &opts, false);
+        let body = build_request_body("o4-mini", &opts, false).unwrap();
         assert_eq!(body["max_completion_tokens"], json!(255));
     }
 
@@ -687,7 +691,7 @@ mod request_body_extended {
             ),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &opts, false);
+        let body = build_request_body("gpt-3.5-turbo", &opts, false).unwrap();
         assert_eq!(
             body["prediction"],
             json!({ "type": "content", "content": "Hello, World!" })
@@ -701,7 +705,7 @@ mod request_body_extended {
             provider_options: po(json!({ "store": true })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &opts, false);
+        let body = build_request_body("gpt-3.5-turbo", &opts, false).unwrap();
         assert_eq!(body["store"], json!(true));
     }
 
@@ -712,7 +716,7 @@ mod request_body_extended {
             provider_options: po(json!({ "metadata": { "custom": "value" } })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &opts, false);
+        let body = build_request_body("gpt-3.5-turbo", &opts, false).unwrap();
         assert_eq!(body["metadata"], json!({ "custom": "value" }));
     }
 
@@ -723,7 +727,7 @@ mod request_body_extended {
             provider_options: po(json!({ "promptCacheKey": "test-cache-key-123" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &opts, false);
+        let body = build_request_body("gpt-3.5-turbo", &opts, false).unwrap();
         assert_eq!(body["prompt_cache_key"], json!("test-cache-key-123"));
     }
 
@@ -734,7 +738,7 @@ mod request_body_extended {
             provider_options: po(json!({ "promptCacheRetention": "24h" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &opts, false);
+        let body = build_request_body("gpt-3.5-turbo", &opts, false).unwrap();
         assert_eq!(body["prompt_cache_retention"], json!("24h"));
     }
 
@@ -747,7 +751,7 @@ mod request_body_extended {
             ),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-5.6", &opts, false);
+        let body = build_request_body("gpt-5.6", &opts, false).unwrap();
         assert_eq!(
             body["prompt_cache_options"],
             json!({ "mode": "explicit", "ttl": "30m" })
@@ -761,7 +765,7 @@ mod request_body_extended {
             provider_options: po(json!({ "safetyIdentifier": "test-safety-identifier-123" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &opts, false);
+        let body = build_request_body("gpt-3.5-turbo", &opts, false).unwrap();
         assert_eq!(
             body["safety_identifier"],
             json!("test-safety-identifier-123")
@@ -781,7 +785,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("temperature").is_none() || result.body["temperature"].is_null());
         assert_eq!(result.warnings.len(), 1);
         assert!(
@@ -802,7 +807,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("temperature").is_none() || result.body["temperature"].is_null());
         assert_eq!(result.warnings.len(), 1);
     }
@@ -820,7 +826,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("temperature").is_none() || result.body["temperature"].is_null());
         assert_eq!(result.warnings.len(), 1);
     }
@@ -832,7 +839,7 @@ mod request_body_extended {
             provider_options: po(json!({ "serviceTier": "flex" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("o4-mini", &opts, false);
+        let body = build_request_body("o4-mini", &opts, false).unwrap();
         assert_eq!(body["service_tier"], json!("flex"));
     }
 
@@ -849,7 +856,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("service_tier").is_none() || result.body["service_tier"].is_null());
         assert_eq!(result.warnings.len(), 1);
         assert!(
@@ -870,7 +878,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert_eq!(result.body["service_tier"], json!("flex"));
         assert!(result.warnings.is_empty());
     }
@@ -882,7 +891,7 @@ mod request_body_extended {
             provider_options: po(json!({ "serviceTier": "priority" })),
             ..default_opts(test_prompt())
         };
-        let body = build_request_body("gpt-4o-mini", &opts, false);
+        let body = build_request_body("gpt-4o-mini", &opts, false).unwrap();
         assert_eq!(body["service_tier"], json!("priority"));
     }
 
@@ -899,7 +908,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert!(result.body.get("service_tier").is_none() || result.body["service_tier"].is_null());
         assert_eq!(result.warnings.len(), 1);
     }
@@ -917,7 +927,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert_eq!(result.body["service_tier"], json!("priority"));
         assert!(result.warnings.is_empty());
     }
@@ -935,7 +946,8 @@ mod request_body_extended {
             false,
             "openai",
             &OpenAICompatProfile::full(),
-        );
+        )
+        .unwrap();
         assert_eq!(result.body["service_tier"], json!("priority"));
         assert!(result.warnings.is_empty());
     }

--- a/aimux-providers/tests/openai_convert_test.rs
+++ b/aimux-providers/tests/openai_convert_test.rs
@@ -515,7 +515,7 @@ mod build_request_body_tests {
     #[test]
     fn passes_model_and_messages() {
         let options = default_options(test_prompt());
-        let body = build_request_body("gpt-3.5-turbo", &options, false);
+        let body = build_request_body("gpt-3.5-turbo", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -539,7 +539,7 @@ mod build_request_body_tests {
             provider_options: Some(provider_options),
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &options, false);
+        let body = build_request_body("gpt-3.5-turbo", &options, false).unwrap();
         assert_eq!(body["logprobs"], json!(true));
         assert_eq!(body["top_logprobs"], json!(3));
     }
@@ -561,7 +561,7 @@ mod build_request_body_tests {
             },
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-3.5-turbo", &options, false);
+        let body = build_request_body("gpt-3.5-turbo", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -589,7 +589,7 @@ mod build_request_body_tests {
             response_format: Some(ResponseFormat::Text),
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -610,7 +610,7 @@ mod build_request_body_tests {
             }),
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -634,7 +634,7 @@ mod build_request_body_tests {
             }),
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -667,7 +667,7 @@ mod build_request_body_tests {
             }),
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body["response_format"],
             json!({
@@ -693,7 +693,7 @@ mod build_request_body_tests {
             }),
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -724,7 +724,7 @@ mod build_request_body_tests {
             }),
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -752,7 +752,7 @@ mod build_request_body_tests {
             tool_choice: ToolChoice::Required,
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body,
             json!({
@@ -790,7 +790,7 @@ mod build_request_body_tests {
             },
             ..default_options(test_prompt())
         };
-        let body = build_request_body("gpt-4o-2024-08-06", &options, false);
+        let body = build_request_body("gpt-4o-2024-08-06", &options, false).unwrap();
         assert_eq!(
             body,
             json!({

--- a/aimux-providers/tests/parallel_ai_test.rs
+++ b/aimux-providers/tests/parallel_ai_test.rs
@@ -206,7 +206,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model("parallel-search") {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("parallel_ai does not support language models"),
+                msg.contains("provider 'parallel_ai' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/aimux-providers/tests/reasoning_map_test.rs
+++ b/aimux-providers/tests/reasoning_map_test.rs
@@ -68,7 +68,8 @@ fn i4_deepseek_retired_no_thinking_injection() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
     assert_eq!(result.body["reasoning_effort"], json!("none"));
     assert!(
         result.body.get("thinking").is_none(),
@@ -86,7 +87,8 @@ fn i4_deepseek_no_thinking_when_reasoning_unset() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
     assert!(result.body.get("thinking").is_none());
     assert!(result.body.get("reasoning_effort").is_none());
 }
@@ -111,7 +113,8 @@ fn i5_body_overrides_injects_thinking_disabled() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
     assert_eq!(result.body["thinking"], json!({ "type": "disabled" }));
     assert_eq!(result.body["reasoning_effort"], json!("none"));
 }
@@ -131,7 +134,8 @@ fn i5_body_overrides_injects_thinking_enabled() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
     assert_eq!(result.body["thinking"], json!({ "type": "enabled" }));
 }
 
@@ -202,7 +206,8 @@ fn assert_vendor_key(
         false,
         provider,
         profile,
-    );
+    )
+    .unwrap();
     assert_eq!(
         result.body[expected_key],
         json!(100),
@@ -269,7 +274,8 @@ fn max_tokens_key_none_keeps_inference() {
         false,
         "openai",
         &profile,
-    );
+    )
+    .unwrap();
     assert_eq!(reasoning.body["max_completion_tokens"], json!(100));
     assert!(reasoning.body.get("max_tokens").is_none());
 
@@ -279,7 +285,8 @@ fn max_tokens_key_none_keeps_inference() {
         false,
         "openai",
         &profile,
-    );
+    )
+    .unwrap();
     assert_eq!(non_reasoning.body["max_tokens"], json!(100));
     assert!(non_reasoning.body.get("max_completion_tokens").is_none());
 }
@@ -306,7 +313,8 @@ fn no_reasoning_warning_on_direct_passthrough() {
             false,
             "deepseek",
             &OpenAICompatProfile::deepseek(),
-        );
+        )
+        .unwrap();
         assert!(
             !has_reasoning_warning(&result.warnings),
             "effort={} 直传不应产生 reasoning warning: {:?}",
@@ -331,7 +339,8 @@ fn reasoning_effort_passthrough_all_seven_levels() {
         false,
         "deepseek",
         &OpenAICompatProfile::deepseek(),
-    );
+    )
+    .unwrap();
     assert!(
         default_body.body.get("reasoning_effort").is_none(),
         "provider-default 不应发 reasoning_effort"
@@ -351,7 +360,8 @@ fn reasoning_effort_passthrough_all_seven_levels() {
             false,
             "deepseek",
             &OpenAICompatProfile::deepseek(),
-        );
+        )
+        .unwrap();
         assert_eq!(
             result.body["reasoning_effort"],
             json!(expected),

--- a/aimux-providers/tests/searxng_test.rs
+++ b/aimux-providers/tests/searxng_test.rs
@@ -188,7 +188,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model("searxng-search") {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("searxng does not support language models"),
+                msg.contains("provider 'searxng' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/aimux-providers/tests/tinyfish_test.rs
+++ b/aimux-providers/tests/tinyfish_test.rs
@@ -211,7 +211,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model("tinyfish-search") {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("tinyfish does not support language models"),
+                msg.contains("provider 'tinyfish' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/aimux-providers/tests/you_com_test.rs
+++ b/aimux-providers/tests/you_com_test.rs
@@ -192,7 +192,7 @@ fn language_model_returns_unsupported_error() {
     match provider.language_model("youcom-search") {
         Err(AiMuxError::Unsupported(msg)) => {
             assert!(
-                msg.contains("you_com does not support language models"),
+                msg.contains("provider 'you_com' does not provide language models"),
                 "unexpected message: {msg}"
             );
         }

--- a/bindings/node/src/types/AiMuxError.ts
+++ b/bindings/node/src/types/AiMuxError.ts
@@ -3,4 +3,4 @@
 /**
  * Unified error type for all aimux operations.
  */
-export type AiMuxError = { "Provider": string } | { "Http": string } | { "Json": string } | { "Stream": string } | { "Tool": string } | { "InvalidArgument": string } | { "InvalidPrompt": string } | { "RateLimited": { retry_after_ms: number, } } | { "Auth": string } | { "TokenExpired": string } | { "ModelNotFound": string } | { "Unsupported": string } | { "NoSuchModel": string } | { "UnknownProvider": string } | { "ApiCall": string } | { "Timeout": string } | "Aborted" | { "Other": string };
+export type AiMuxError = { "Provider": string } | { "Http": string } | { "Json": string } | { "Stream": string } | { "Tool": string } | { "InvalidArgument": string } | { "InvalidPrompt": string } | { "RateLimited": { retry_after_ms: number, message: string, } } | { "Auth": string } | { "TokenExpired": string } | { "ModelNotFound": string } | { "Unsupported": string } | { "NoSuchModel": string } | { "UnknownProvider": string } | { "ApiCall": string } | { "Timeout": string } | "Aborted" | { "Other": string };


### PR DESCRIPTION
## What

Closes the 12 tech-debt / soundness / bug issues from the quality audit batch:

### High priority

- **#65 [H2]** `build_request_body_with_warnings` (OpenAI) no longer swallows conversion errors into `body: null` — it returns `Result` and errors propagate (fail-fast). `build_request_body` does the same.
- **#66 [H3]** `set_nested_value` in `google/utils.rs` replaces 7 `expect()`s with `Result` errors; `process_partial_args` returns `Result` so malformed (untrusted) `partialArgs` streams surface as `AiMuxError::Json` instead of panicking.

### Core / error handling

- **#69 [M3]** `AiMuxError::Timeout` added to `is_retryable()` — timeouts now retry like other transient errors.
- **#70 [M4]** `status_code()` derives status structurally: `Auth`/`TokenExpired` → 401, `RateLimited` → 429, `ModelNotFound` → 404 (string-prefix parsing kept only for `Http`/`Provider`/`ApiCall`). FFI error envelopes now carry real status codes for the most important cases.
- **#71 [M5]** 10 × `serde_json::from_slice` errors in bedrock/google/vertex mislabeled `AiMuxError::Http` → now `AiMuxError::Json` (non-retryable parse errors).
- **#72 [M6]** 429 handling in the shared HTTP layer keeps the provider response body; `RateLimited { retry_after_ms, message }` now carries the provider message (quota vs rate-limit distinguishable). All constructors updated (http.rs, response.rs, openai/mistral/google/aws-polly models).

### FFI

- **#67 [M1]** `into_cstring_raw` never returns null — interior NUL bytes are replaced with U+FFFD (logged); the C-side ownership contract always holds.
- **#68 [M2]** Module docs now describe reentrant FFI calls as a tokio `block_on` **panic** crossing the `extern "C"` boundary (UB) instead of a deadlock.
- **#73 [M7]** A `thread_local!` re-entry guard in `ffi_block_on` detects FFI calls made from inside callbacks and returns an error envelope instead of panicking across the C boundary.

### Architecture (providers)

- **#74 [M9]** `Provider::language_model` now has a default implementation returning `Unsupported`; the 17 non-LLM providers (Tavily, Stability, Recraft, …) dropped their boilerplate overrides.
- **#75 [M10]** Shared helpers extracted: `ReasoningEffort::is_custom()` in aimux-core replaces 6 copy-pasted `is_custom_reasoning` functions; model-capability parsing (`get_gpt_version`, `get_o_series_version`, `get_model_capabilities`, `SystemMessageMode`) moved to `openai/convert_common.rs` shared by the Chat and Responses converters (~140 duplicated lines removed).
- **#76 [M11]** Split the 3 oversized convert functions into focused helpers: `openai::convert::build_request_body_with_warnings` (~430 → 1 helper each < 100 lines), `anthropic::convert::build_request_body_with_warnings` (~430 → 8 helpers), `openai::responses::convert::build_responses_request_body` (~380 → 11 helpers). Behavior preserved.

### Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets` — 0 warnings ✓
- `cargo test --workspace` — full pass ✓
- ts-rs regenerated `bindings/node/src/types/AiMuxError.ts` (RateLimited shape) ✓

## Notes

- Issue #64 ([H1] callback panic / `catch_unwind`) is intentionally **not** touched: the workspace's release profile uses `panic = "abort"`, where `catch_unwind` is a no-op. The runtime re-entry guard (#73) is the effective protection available under that profile.
- The `RateLimited` variant gained a `message` field (also visible in the TS bindings).
Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71
Closes #72
Closes #73
Closes #74
Closes #75
Closes #76

---

## 双模型审计与整改（gpt-5.6-sol + glm-5.2）

合入前用两个模型对全部 12 项修复做了同口径四维审计（架构 / 必要性 / 理性 / 安全性）。两份结论**一致**确认以下问题，已在 follow-up commit `b7c5d15` 中修复：

1. **[阻断] M11 Anthropic 默认 thinking budget 回归** — 拆分后默认 `budget_tokens: 1024` 只计入 `max_tokens`，未写回 `body["thinking"]`，请求会被 API 拒绝。已修复并补 2 个回归测试（默认/显式 budget）。
2. **[高] H3 残留 panic** — 畸形路径 `$.[]` 解析为空 segments 后在 `emit_navigation_to` 切片下溢 panic。现在跳过空路径并补回归测试。
3. **[中] M6 serde 兼容** — `RateLimited.message` 加 `#[serde(default)]`，旧版错误 JSON 可继续反序列化。
4. **[中] M6 429 body 无界** — 错误体截断至 64 KiB（UTF-8 安全截断 + 尺寸标记），避免内存/日志膨胀与敏感信息外泄。
5. **[中] M10 公共类型** — 恢复 `ResponsesSystemMessageMode` 兼容别名，保留原导入路径。
6. **[低] M2 文档措辞** — 明确 `panic="abort"` 下是进程终止，仅 unwind 跨 `extern "C"` 才是 UB。
7. 新增 M4/M6 单元测试（status_code 映射、Timeout 可重试、RateLimited 反序列化兼容）。

审计通过项（无整改）：H2、M1 主体、M3、M4、M5、M7、M9 主体、M10 主体、M11 openai+responses 拆分。

---

## 第二轮双模型审计（gpt-5.6-sol + glm-5.2）与整改

### 审计结论（两模型对整改提交 b7c5d15 的核验）

| 整改项 | gpt-5.6-sol | glm-5.2 |
|---|---|---|
| Anthropic 默认 budget 写回 | ✅ 已修复 | ✅ 已修复 |
| H3 空路径跳过 | ✅（但新发现索引 OOM，见下） | ✅ 已修复 |
| M6 serde 兼容 | ✅ 已修复 | ✅ 已修复（必要性低） |
| M6 body 截断 | ⚠️ 部分（输出限长，读取期仍完整缓冲） | ✅ 已修复（峰值内存判预存残留） |
| M10 兼容别名 | ✅ 已修复 | ✅ 已修复 |
| M2 文档措辞 | ⚠️ 部分（仍需精确化） | ✅ 已修复且准确 |
| M4/M6 单测 | ✅ 已修复 | ✅ 已修复 |

**分歧点**：gpt-5.6-sol 发现 glm-5.2 未发现的**高优先级新问题**——Google `parse_path` 对超大数组索引无上限（`$.a[1000000]` → `while arr.len() <= i { push(Null) }` → OOM），并指出 `resp.bytes()` 仍完整缓冲错误体。glm-5.2 总体判"可合入"（残留均非阻塞），gpt-5.6-sol 判"暂不建议合入（修复 OOM 项后即可）"。

### 第二轮整改（commit `13b42b3`）

1. **[高/H3]** `set_nested_value` 增加 `MAX_PARTIAL_ARG_INDEX`（10 万）与 `MAX_PARTIAL_ARG_DEPTH`（64）资源上限，超限返回 `AiMuxError::Json`，消除 provider 可控路径的 OOM；新增 2 个回归测试。
2. **[中/M6]** `read_error_body` 改为**流式分块读取**：只保留前 64 KiB，仍统计全量字节数用于截断标记——读取期内存峰值从此有界。
3. **[低/M2]** FFI 文档措辞再精确化：Rust 非 unwind `extern "C"` ABI 不允许 panic 传播（进程终止），不再过度声称跨边界即 UB。

验证：`cargo fmt -- --check` ✓、`clippy --workspace` 0 警告 ✓、`cargo test --workspace` 147 套件全绿 ✓。

至此两模型审计确认的**全部问题均已修复**；残余项仅为非阻塞的后续增强（golden 等价测试、`eprintln` 日志约定、M9 provider 专属错误文案），已记录为合并后跟踪项。

---

## 第三轮双模型审计（gpt-5.6-sol + glm-5.2，独立互证）与整改

两模型本轮**独立命中同一组残留问题**（glm-5.2 用外部 crate 实证复现，未改仓库文件）：

1. **[高] A1：中间段索引绕过上限** — `MAX_PARTIAL_ARG_INDEX` 只盖住叶段（`$.a[1000000000]`），`$.a[1000000000].b` 这类中间段索引仍能触发无界数组展开（OOM）。修复：`set_nested_value` 入口**一次性预校验全部 segment**（任何修改前返回错误，同时恢复错误原子性——不再留下半成品容器），补充 `intermediate_oversized_index_is_rejected_atomically` 回归测试。
2. **[中] B1：截断标记丢失** — `601745e` 把截断门阈改为仅按解码长度判断，>64KiB 的合法 UTF-8 错误体被静默截断而无标记（wiremock 实证：64546 字节消息无 marker）。修复：门阈改为 `total > MAX || s.len() > MAX`，并新增 e2e 测试 `truncates_large_error_body_with_marker`（修复前会失败）；`total` 改用 `saturating_add`。

验证：`cargo fmt -- --check` ✓；`clippy --workspace` 0 警告 ✓；`cargo test --workspace` 147 套件全绿 ✓。

两模型均确认的“接受项”：M1 eprintln（可关闭）、M3 Timeout 语义（可关闭）、M9 默认实现（可关闭）；TS `message` 必填与 `#[serde(default)]` 非对称、M11 拆分缺 golden 等价测试 → 建议合并后转正式 issue 跟踪（已记）。

---

## 遗留项收口（commit `1946030`）

之前列为"非阻塞遗留"的三项已全部处理：

1. **M11 golden 等价测试（原为缺失项）** — 新增 `convert_golden_test.rs`：对三个被拆分的转换器（openai chat / openai responses / anthropic）分别断言**完整请求体 + 完整 warning 列表**（代表性选项集）。这类全量对比正是当初能抓住 anthropic budget 回归的测试形态，今后任何等价性破坏都会被精确锁定。
2. **M1 `eprintln!`（原为代码质量项）** — NUL 替换告警改走 `tracing::warn!`（RFC-0014 日志体系，宿主经 `aimux_init_logging` 配置），不再直写宿主 stderr；`aimux-ffi` 增加 `tracing` 依赖。
3. **TS 绑定 `message` 非对称（原为文档项）** — 判定为**设计意图**并在 `error.rs` 文档中固化：`#[serde(default)]` 只放宽旧载荷的**反序列化**；序列化恒带 `message`，TS 必填反映的是当前输出契约。

验证：fmt ✓ / clippy 0 警告 ✓ / 148 套件全绿 ✓（新增 golden 套件）。
