### PR TITLE
feat(core): RFC-0023 P1 录制核心 — 数据模型 + Recorder + JsonlRecorder + 层 A 接入 (#48)

### DIFF
--- a/aimux-core/src/generate.rs
+++ b/aimux-core/src/generate.rs
@@ -105,6 +105,7 @@ impl GenerateTextOptions {
             timeout: self.timeout,
             session_id: self.session_id,
             abort_signal: self.abort_signal,
+            call_id: None,
             include_raw_chunks: self.include_raw_chunks,
         }
     }
@@ -202,7 +203,16 @@ pub async fn generate_text(
     let lm_prompt = convert_to_language_model_prompt(&messages, instructions);
 
     // 2. Build CallOptions.
-    let call_options = options.into_call_options(lm_prompt);
+    let mut call_options = options.into_call_options(lm_prompt);
+
+    // 2a. RFC-0023: call_id + recorder 快照绑定(见 generate_text)。
+    let call_id = crate::recording::new_call_id();
+    call_options.call_id = Some(call_id.clone());
+    let recorder = crate::recording::recorder();
+    if let Some(rec) = &recorder {
+        rec.record_input(&call_id, &call_options, model.provider(), model.model_id());
+        rec.record_provider(&call_id, &model.config_snapshot());
+    }
 
     // 2b. Session grouping (RFC-0024): explicit session_id first, opt-in
     //     prompt-prefix inference as fallback. Recorded before the call so
@@ -230,7 +240,21 @@ pub async fn generate_text(
         model = %model.model_id(),
         modality = "text",
     );
-    let result = do_generate_with_logging(model, &call_options, span, started).await?;
+    let result = match do_generate_with_logging(model, &call_options, span, started).await {
+        Ok(r) => r,
+        Err(e) => {
+            if let Some(rec) = &recorder {
+                rec.record_outcome(&call_id, &crate::recording::OutcomeRecord::from_error(&e));
+            }
+            return Err(e);
+        }
+    };
+    if let Some(rec) = &recorder {
+        rec.record_outcome(
+            &call_id,
+            &crate::recording::OutcomeRecord::from_generate_result(&result),
+        );
+    }
 
     // 4. Extract text and tool calls from content.
     let mut text = String::new();
@@ -309,7 +333,16 @@ pub async fn stream_text(
     let lm_prompt = convert_to_language_model_prompt(&messages, instructions);
 
     // 2. Build CallOptions.
-    let call_options = options.into_call_options(lm_prompt);
+    let mut call_options = options.into_call_options(lm_prompt);
+
+    // 2a. RFC-0023: call_id + recorder 快照绑定(见 generate_text)。
+    let call_id = crate::recording::new_call_id();
+    call_options.call_id = Some(call_id.clone());
+    let recorder = crate::recording::recorder();
+    if let Some(rec) = &recorder {
+        rec.record_input(&call_id, &call_options, model.provider(), model.model_id());
+        rec.record_provider(&call_id, &model.config_snapshot());
+    }
 
     // 2b. Session grouping (RFC-0024): explicit session_id first, opt-in
     //     prompt-prefix inference as fallback. Recorded before the call so
@@ -335,14 +368,29 @@ pub async fn stream_text(
         model = %model.model_id(),
         modality = "text",
     );
-    let result: StreamResult = model.do_stream(&call_options).instrument(span).await?;
+    let result: StreamResult = match model.do_stream(&call_options).instrument(span).await {
+        Ok(r) => r,
+        Err(e) => {
+            if let Some(rec) = &recorder {
+                rec.record_outcome(&call_id, &crate::recording::OutcomeRecord::from_error(&e));
+            }
+            return Err(e);
+        }
+    };
+    // 解构避免部分 move(result 各字段去向不同)。
+    let StreamResult {
+        stream,
+        request_body,
+        response_headers,
+    } = result;
+    let stream = crate::recording::RecordingOutcomeStream::new(stream, recorder, call_id);
 
-    // 4. Return stream to user (request_body/response_headers kept for
+    // 4. Return wrapped stream to user (request_body/response_headers kept for
     //    debugging / cache probing, RFC-0015).
     Ok(StreamTextResult {
-        stream: result.stream,
-        request_body: result.request_body,
-        response_headers: result.response_headers,
+        stream: Box::pin(stream),
+        request_body,
+        response_headers,
     })
 }
 

--- a/aimux-core/src/generate.rs
+++ b/aimux-core/src/generate.rs
@@ -205,14 +205,18 @@ pub async fn generate_text(
     // 2. Build CallOptions.
     let mut call_options = options.into_call_options(lm_prompt);
 
-    // 2a. RFC-0023: call_id + recorder 快照绑定(见 generate_text)。
-    let call_id = crate::recording::new_call_id();
-    call_options.call_id = Some(call_id.clone());
+    // 2a. RFC-0023: 关闭时零成本(M2 评审)——仅在录制开启时生成 call_id
+    //     并绑定 recorder 快照;传输封闭由层 A 收尾声明(P1 无层 B,barrier
+    //     前提;P2 移交层 B)。
     let recorder = crate::recording::recorder();
-    if let Some(rec) = &recorder {
+    let call_id = recorder.as_ref().map(|rec| {
+        let call_id = crate::recording::new_call_id();
+        call_options.call_id = Some(call_id.clone());
         rec.record_input(&call_id, &call_options, model.provider(), model.model_id());
         rec.record_provider(&call_id, &model.config_snapshot());
-    }
+        rec.record_transport_closed(&call_id);
+        call_id
+    });
 
     // 2b. Session grouping (RFC-0024): explicit session_id first, opt-in
     //     prompt-prefix inference as fallback. Recorded before the call so
@@ -227,7 +231,7 @@ pub async fn generate_text(
         ),
         crate::session::session_store(),
     ) {
-        store.append(&session_id, source);
+        store.append(&session_id, call_options.call_id.as_deref(), source);
     }
 
     // 3. Call provider, inside the "generate" span (RFC-0014 §4.1 span tree).
@@ -243,15 +247,15 @@ pub async fn generate_text(
     let result = match do_generate_with_logging(model, &call_options, span, started).await {
         Ok(r) => r,
         Err(e) => {
-            if let Some(rec) = &recorder {
-                rec.record_outcome(&call_id, &crate::recording::OutcomeRecord::from_error(&e));
+            if let (Some(rec), Some(call_id)) = (&recorder, &call_id) {
+                rec.record_outcome(call_id, &crate::recording::OutcomeRecord::from_error(&e));
             }
             return Err(e);
         }
     };
-    if let Some(rec) = &recorder {
+    if let (Some(rec), Some(call_id)) = (&recorder, &call_id) {
         rec.record_outcome(
-            &call_id,
+            call_id,
             &crate::recording::OutcomeRecord::from_generate_result(&result),
         );
     }
@@ -335,14 +339,18 @@ pub async fn stream_text(
     // 2. Build CallOptions.
     let mut call_options = options.into_call_options(lm_prompt);
 
-    // 2a. RFC-0023: call_id + recorder 快照绑定(见 generate_text)。
-    let call_id = crate::recording::new_call_id();
-    call_options.call_id = Some(call_id.clone());
+    // 2a. RFC-0023: 关闭时零成本(M2 评审)——仅在录制开启时生成 call_id
+    //     并绑定 recorder 快照;传输封闭由层 A 收尾声明(P1 无层 B,barrier
+    //     前提;P2 移交层 B)。
     let recorder = crate::recording::recorder();
-    if let Some(rec) = &recorder {
+    let call_id = recorder.as_ref().map(|rec| {
+        let call_id = crate::recording::new_call_id();
+        call_options.call_id = Some(call_id.clone());
         rec.record_input(&call_id, &call_options, model.provider(), model.model_id());
         rec.record_provider(&call_id, &model.config_snapshot());
-    }
+        rec.record_transport_closed(&call_id);
+        call_id
+    });
 
     // 2b. Session grouping (RFC-0024): explicit session_id first, opt-in
     //     prompt-prefix inference as fallback. Recorded before the call so
@@ -357,7 +365,7 @@ pub async fn stream_text(
         ),
         crate::session::session_store(),
     ) {
-        store.append(&session_id, source);
+        store.append(&session_id, call_options.call_id.as_deref(), source);
     }
 
     // 3. Call provider, inside the "generate" span (RFC-0014 §4.1 span tree).
@@ -371,8 +379,8 @@ pub async fn stream_text(
     let result: StreamResult = match model.do_stream(&call_options).instrument(span).await {
         Ok(r) => r,
         Err(e) => {
-            if let Some(rec) = &recorder {
-                rec.record_outcome(&call_id, &crate::recording::OutcomeRecord::from_error(&e));
+            if let (Some(rec), Some(call_id)) = (&recorder, &call_id) {
+                rec.record_outcome(call_id, &crate::recording::OutcomeRecord::from_error(&e));
             }
             return Err(e);
         }
@@ -383,7 +391,12 @@ pub async fn stream_text(
         request_body,
         response_headers,
     } = result;
-    let stream = crate::recording::RecordingOutcomeStream::new(stream, recorder, call_id);
+    // 录制开启时才包装(终结时写 outcome + 传输封闭);关闭时零成本透传。
+    let stream = crate::recording::RecordingOutcomeStream::new(
+        stream,
+        recorder.clone(),
+        call_id.unwrap_or_default(),
+    );
 
     // 4. Return wrapped stream to user (request_body/response_headers kept for
     //    debugging / cache probing, RFC-0015).

--- a/aimux-core/src/language_model.rs
+++ b/aimux-core/src/language_model.rs
@@ -39,4 +39,11 @@ pub trait LanguageModel: Send + Sync {
 
     /// Generate a streaming response.
     async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError>;
+
+    /// RFC-0023: 配置侧快照供录制。默认返回最小信息(provider/model_id);
+    /// 各 provider 覆盖以提供 base_url/profile/api_key 来源等完整配置。
+    /// 透明 decorator(TraceLayer 等)必须覆盖并转发 inner 快照。
+    fn config_snapshot(&self) -> crate::recording::ProviderRecord {
+        crate::recording::ProviderRecord::minimal(self.provider(), self.model_id())
+    }
 }

--- a/aimux-core/src/lib.rs
+++ b/aimux-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod model_id;
 pub mod openai_output;
 pub mod options;
 pub mod provider;
+pub mod recording;
 pub mod reranking_model;
 pub mod result;
 pub mod search_model;

--- a/aimux-core/src/options.rs
+++ b/aimux-core/src/options.rs
@@ -136,6 +136,11 @@ pub struct CallOptions {
     #[ts(skip)]
     pub abort_signal: Option<AbortSignal>,
 
+    /// RFC-0023 recording correlation id (internal; never serialized).
+    #[serde(skip)]
+    #[ts(skip)]
+    pub call_id: Option<String>,
+
     /// Emit raw provider stream chunks as `StreamPart::Raw` (debugging aid).
     /// When `Some(true)`, streaming providers yield one `Raw` part per JSON
     /// SSE event, carrying the **parsed JSON payload** of the event, emitted
@@ -177,6 +182,7 @@ impl CallOptions {
             timeout: None,
             session_id: None,
             abort_signal: None,
+            call_id: None,
             include_raw_chunks: None,
         }
     }

--- a/aimux-core/src/recording.rs
+++ b/aimux-core/src/recording.rs
@@ -51,9 +51,13 @@ pub struct Recording {
     /// 最终结果摘要(状态 + finish_reason + usage)。
     pub outcome: OutcomeRecord,
 
-    /// wire 是否完整(流式 body 未补全时为 false;由 writer 兜底标记)。
+    /// wire 是否完整(流式 body 未补全时为 false;由 writer 标记)。
     #[serde(default)]
     pub complete: bool,
+    /// 传输层封闭信号:层 B 声明"不再有 exchange"(P1:层 A 收尾自动发;
+    /// P2:由层 B 发送)。false = 仍可能来 exchange(记录暂不可定稿)。
+    #[serde(default)]
+    pub transport_closed: bool,
 }
 
 impl Recording {
@@ -68,12 +72,17 @@ impl Recording {
             exchanges: Vec::new(),
             outcome: OutcomeRecord::default(),
             complete: false,
+            transport_closed: false,
         }
     }
 
-    /// completion barrier:outcome 已到(非 Pending)且全部 exchange 已终结。
+    /// completion barrier:outcome 非 Pending && 传输层已封闭 &&
+    /// 全部 exchange 已终结。缺封闭信号时(层 B 未发)不提前写出,
+    /// 防止 outcome 先到时误以为"无 exchange"而早写。
     fn ready(&self) -> bool {
-        self.outcome.status != OutcomeStatus::Pending && self.exchanges.iter().all(|e| e.finalized)
+        self.transport_closed
+            && self.outcome.status != OutcomeStatus::Pending
+            && self.exchanges.iter().all(|e| e.finalized)
     }
 }
 
@@ -237,7 +246,11 @@ pub trait Recorder: Send + Sync {
     fn record_exchange_update(&self, call_id: &str, attempt: u32, response: &ResponseRecord);
     /// 录制最终结果(层 A 入口调用)。
     fn record_outcome(&self, call_id: &str, outcome: &OutcomeRecord);
-    /// 同步 flush:阻塞直到全部已写行落盘(oneshot 回执),关闭前调用确保不丢。
+    /// 声明传输层封闭:该 call 不再会有 exchange(层 B;P1 层 A 收尾调用)。
+    fn record_transport_closed(&self, call_id: &str) {
+        let _ = call_id;
+    }
+    /// 同步 flush:阻塞到全部已写行落盘(oneshot 回执),关闭前调用确保不丢。
     fn flush(&self);
 }
 
@@ -345,6 +358,8 @@ enum RecordEvent {
         call_id: String,
         outcome: OutcomeRecord,
     },
+    /// 传输层封闭:该调用不再会有 exchange(层 B 发;P1 由层 A 收尾发)。
+    TransportClosed { call_id: String },
     /// 刷盘命令;完成后经 ack 回执(SyncSender,容量 0 即 rendezvous)。
     Flush { ack: SyncSender<()> },
 }
@@ -352,8 +367,9 @@ enum RecordEvent {
 /// 每条完整 `Recording` 一行 jsonl;分片按 call_id 在专用线程合并。
 /// 热路径仅 mpsc send(非阻塞),I/O 全部在专用线程。
 pub struct JsonlRecorder {
-    tx: Sender<RecordEvent>,
+    tx: Option<Sender<RecordEvent>>,
     dir: PathBuf,
+    thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl JsonlRecorder {
@@ -364,11 +380,22 @@ impl JsonlRecorder {
         let (tx, rx) = std::sync::mpsc::channel::<RecordEvent>();
         std::fs::create_dir_all(&dir).ok();
         let writer_dir = dir.clone();
-        std::thread::Builder::new()
+        let handle = std::thread::Builder::new()
             .name("aimux-recording".into())
             .spawn(move || writer_loop(rx, writer_dir))
             .expect("failed to spawn recording writer thread");
-        Self { tx, dir }
+        Self {
+            tx: Some(tx),
+            dir,
+            thread: Some(handle),
+        }
+    }
+
+    /// 事件入队(线程退出后静默丢弃)。
+    fn send_ev(&self, ev: RecordEvent) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(ev);
+        }
     }
 
     /// 录制文件路径。
@@ -377,9 +404,22 @@ impl JsonlRecorder {
     }
 }
 
+impl Drop for JsonlRecorder {
+    fn drop(&mut self) {
+        // 先主动断开发送端:writer 消费完残留事件后由 Disconnected 触发
+        // 兜底写 incomplete 并退出;随后 join 保证落盘完成。
+        if let Some(tx) = self.tx.take() {
+            drop(tx);
+        }
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 impl Recorder for JsonlRecorder {
     fn record_input(&self, call_id: &str, options: &CallOptions, provider: &str, model_id: &str) {
-        let _ = self.tx.send(RecordEvent::Input {
+        self.send_ev(RecordEvent::Input {
             call_id: call_id.to_string(),
             input: InputRecord::from_call_options(options),
             provider: ProviderRecord::minimal(provider, model_id),
@@ -387,21 +427,26 @@ impl Recorder for JsonlRecorder {
     }
 
     fn record_provider(&self, call_id: &str, snapshot: &ProviderRecord) {
-        let _ = self.tx.send(RecordEvent::Provider {
+        // 核心边界统一强制脱敏 provider_options/profile(B6 评审),
+        // 不依赖 provider 端自觉。
+        let mut snap = snapshot.clone();
+        snap.provider_options = snap.provider_options.take().map(redact_json);
+        snap.profile = snap.profile.take().map(redact_json);
+        self.send_ev(RecordEvent::Provider {
             call_id: call_id.to_string(),
-            provider: snapshot.clone(),
+            provider: snap,
         });
     }
 
     fn record_exchange(&self, call_id: &str, exchange: &HttpExchange) {
-        let _ = self.tx.send(RecordEvent::Exchange {
+        self.send_ev(RecordEvent::Exchange {
             call_id: call_id.to_string(),
             exchange: exchange.clone(),
         });
     }
 
     fn record_exchange_update(&self, call_id: &str, attempt: u32, response: &ResponseRecord) {
-        let _ = self.tx.send(RecordEvent::ExchangeUpdate {
+        self.send_ev(RecordEvent::ExchangeUpdate {
             call_id: call_id.to_string(),
             attempt,
             response: response.clone(),
@@ -409,18 +454,27 @@ impl Recorder for JsonlRecorder {
     }
 
     fn record_outcome(&self, call_id: &str, outcome: &OutcomeRecord) {
-        let _ = self.tx.send(RecordEvent::Outcome {
+        self.send_ev(RecordEvent::Outcome {
             call_id: call_id.to_string(),
             outcome: outcome.clone(),
         });
     }
 
+    fn record_transport_closed(&self, call_id: &str) {
+        self.send_ev(RecordEvent::TransportClosed {
+            call_id: call_id.to_string(),
+        });
+    }
+
     fn flush(&self) {
         let (ack_tx, ack_rx) = sync_channel::<()>(0);
-        if self.tx.send(RecordEvent::Flush { ack: ack_tx }).is_err() {
-            return; // writer 线程已退出。
+        // 写入 flush 事件;若 writer 已退出(通道断)则放弃等待。
+        if self.tx.is_none() {
+            return;
         }
-        let _ = ack_rx.recv_timeout(Duration::from_secs(5));
+        self.send_ev(RecordEvent::Flush { ack: ack_tx });
+        // 阻塞等 writer 回执(专用写线程,不占调用方热路径锁)。
+        let _ = ack_rx.recv_timeout(Duration::from_secs(30));
     }
 }
 
@@ -459,6 +513,7 @@ fn writer_loop(rx: Receiver<RecordEvent>, dir: PathBuf) {
                 if let Some(rec) = pending.get_mut(&call_id) {
                     rec.exchanges.push(exchange);
                 }
+                try_finalize(&mut w, &mut pending, &call_id);
             }
             RecordEvent::ExchangeUpdate {
                 call_id,
@@ -471,22 +526,25 @@ fn writer_loop(rx: Receiver<RecordEvent>, dir: PathBuf) {
                     ex.response = Some(response);
                     ex.finalized = true;
                 }
+                try_finalize(&mut w, &mut pending, &call_id);
+            }
+            RecordEvent::TransportClosed { call_id } => {
+                if let Some(rec) = pending.get_mut(&call_id) {
+                    rec.transport_closed = true;
+                }
+                try_finalize(&mut w, &mut pending, &call_id);
             }
             RecordEvent::Outcome { call_id, outcome } => {
                 if let Some(rec) = pending.get_mut(&call_id) {
                     rec.outcome = outcome;
-                    // completion barrier 满足则立即写出(引用与 move 分离)。
-                    if rec.ready()
-                        && let Some(rec) = pending.remove(&call_id)
-                    {
-                        write_line(&mut w, rec);
-                    }
                 }
+                try_finalize(&mut w, &mut pending, &call_id);
             }
             RecordEvent::Flush { ack } => {
                 write_ready_all(&mut w, &mut pending);
                 let _ = w.flush();
-                let _ = ack.try_send(());
+                // 阻塞 send:rendezvous 语义,确保 ack 一定被调用方收到。
+                let _ = ack.send(());
             }
         }
     }
@@ -503,6 +561,18 @@ fn writer_loop(rx: Receiver<RecordEvent>, dir: PathBuf) {
     let _ = w.flush();
 }
 
+/// 若该 call 的所有分片到齐(barrier 满足)则写出,并标记 complete=true。
+fn try_finalize(w: &mut impl Write, pending: &mut HashMap<String, Recording>, call_id: &str) {
+    if pending.get(call_id).map(|r| r.ready()).unwrap_or(false)
+        && let Some(mut rec) = pending.remove(call_id)
+    {
+        if !rec.exchanges.is_empty() || rec.transport_closed {
+            rec.complete = true;
+        }
+        write_line(w, rec);
+    }
+}
+
 fn write_ready_all(w: &mut impl Write, pending: &mut HashMap<String, Recording>) {
     let ids: Vec<String> = pending
         .iter()
@@ -510,7 +580,8 @@ fn write_ready_all(w: &mut impl Write, pending: &mut HashMap<String, Recording>)
         .map(|(id, _)| id.clone())
         .collect();
     for id in ids {
-        if let Some(rec) = pending.remove(&id) {
+        if let Some(mut rec) = pending.remove(&id) {
+            rec.complete = true;
             write_line(w, rec);
         }
     }
@@ -570,6 +641,8 @@ impl<S> RecordingOutcomeStream<S> {
             self.recorded = true;
             if let Some(rec) = &self.recorder {
                 rec.record_outcome(&self.call_id, outcome);
+                // P1: 流终结即传输层封闭(barrier 前提;P2 改由层 B 发)。
+                rec.record_transport_closed(&self.call_id);
             }
         }
     }
@@ -749,6 +822,8 @@ mod tests {
                 usage: None,
             },
         );
+        // 层 B 缺失的 P1 语义:收尾声明传输封闭,barrier 才满足。
+        rec.record_transport_closed("call-flush-1");
         // flush 阻塞直到落盘:无需轮询。
         rec.flush();
         let content = std::fs::read_to_string(rec.path()).unwrap();
@@ -806,6 +881,7 @@ mod tests {
                 usage: None,
             },
         );
+        rec.record_transport_closed("call-x2");
         rec.flush();
 
         let content = std::fs::read_to_string(rec.path()).unwrap();
@@ -818,22 +894,60 @@ mod tests {
     }
 
     #[test]
+    fn barrier_waits_for_transport_closed_and_marks_complete() {
+        let dir = std::env::temp_dir().join(format!("aimux-rec-btc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let rec = JsonlRecorder::new(&dir);
+
+        rec.record_input("call-btc-1", &sample_options(), "openai", "gpt-4o");
+        rec.record_outcome(
+            "call-btc-1",
+            &OutcomeRecord {
+                status: OutcomeStatus::Success,
+                finish_reason: None,
+                error: None,
+                usage: None,
+            },
+        );
+        // outcome 已到但未封闭:flush 不应写出(无写行,文件为空)。
+        rec.flush();
+        let content = std::fs::read_to_string(rec.path()).unwrap();
+        assert!(
+            content.trim().is_empty(),
+            "must not write before transport closed"
+        );
+
+        // 封闭后写出,且 complete=true。
+        rec.record_transport_closed("call-btc-1");
+        rec.flush();
+        let content = std::fs::read_to_string(rec.path()).unwrap();
+        let parsed: Recording = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed.call_id, "call-btc-1");
+        assert!(
+            parsed.complete,
+            "fully-finalized recording must be complete"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn incomplete_outcome_flushes_on_shutdown() {
         let dir = std::env::temp_dir().join(format!("aimux-rec-test3-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         {
             let rec = JsonlRecorder::new(&dir);
             rec.record_input("call-orphan", &sample_options(), "openai", "gpt-4o");
-            // 无 outcome:drop recorder 后 writer 线程被 Disconnected 终止并兜底写出。
+            // 无 outcome:drop 触发断开 + join,writer 兜底写 incomplete(确定性)。
         }
-        // 等 writer 线程退出(短睡:无同步 API,drop 后 recv 通道断开即写)。
-        std::thread::sleep(Duration::from_millis(200));
-        let dir_ok = std::fs::read_to_string(dir.join("recordings.jsonl"));
-        if let Ok(content) = dir_ok {
-            let parsed: Recording = serde_json::from_str(content.trim()).unwrap();
-            assert_eq!(parsed.outcome.status, OutcomeStatus::Incomplete);
-            assert!(!parsed.complete);
-        }
+        let content = std::fs::read_to_string(dir.join("recordings.jsonl"))
+            .expect("disconnected fallback must write the incomplete line");
+        let parsed: Recording = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed.outcome.status, OutcomeStatus::Incomplete);
+        assert!(
+            !parsed.complete,
+            "fallback line must not be marked complete"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/aimux-core/src/recording.rs
+++ b/aimux-core/src/recording.rs
@@ -1,0 +1,839 @@
+//! RFC-0023: 调用上下文录制(P1 — 数据模型 + Recorder trait + 门控 + JsonlRecorder)。
+//!
+//! 录制一次 `generate_text`/`stream_text` 调用的三层完整上下文:
+//! ① 输入侧(prompt + options)、② 配置侧(provider 身份)、③ HTTP 侧(wire 交换)。
+//!
+//! 关键性质(按 2026-08-06 定稿):
+//! - **call_id 关联**:一次逻辑调用一个 `call_id`(与 RFC-0015/24/25 语义一致,
+//!   区别于 HTTP 请求级 ID 与跨服务 trace)。
+//! - **默认关闭**:不调 `init_recording`,热路径 = 1 读锁 + clone(次 ns 级)。
+//! - **隐私受控**:api_key / Authorization 恒脱敏(contains 式,含 `x-goog-api-key`);
+//!   `InputRecord.options` 序列化前递归脱敏。
+//! - **completion barrier**:outcome 与全部 exchange(流式含终结)齐才写行。
+//! - **专用 writer thread + oneshot flush**:同步 `flush()` 阻塞至落盘,不依赖运行时。
+//! - **recorder 快照绑定**:层 A 入口取一次 `Arc<dyn Recorder>` 随调用,禁止各点重读。
+
+use crate::language_model_message::LanguageModelPrompt;
+use crate::options::CallOptions;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, Sender, SyncSender, sync_channel};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+// ── 数据模型(三层 + call_id 关联;schema 版本)────────────────────────────
+
+/// 录制格式版本(用于未来字段迁移与绑定层兼容)。
+pub const RECORDING_SCHEMA: u32 = 1;
+
+/// 一次完整调用的录制记录(三层 + call_id 关联)。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Recording {
+    /// 格式版本。
+    pub schema: u32,
+    /// 暴露逻辑调用 ID,关联三层。
+    pub call_id: String,
+    /// ISO 8601 时间戳。
+    pub recorded_at: String,
+
+    /// ① 输入侧:调用参数(prompt + options)。
+    pub input: InputRecord,
+
+    /// ② 配置侧:provider 身份与配置。
+    pub provider: ProviderRecord,
+
+    /// ③ HTTP 侧:实际 wire 交换(per-attempt 一条)。
+    pub exchanges: Vec<HttpExchange>,
+
+    /// 最终结果摘要(状态 + finish_reason + usage)。
+    pub outcome: OutcomeRecord,
+
+    /// wire 是否完整(流式 body 未补全时为 false;由 writer 兜底标记)。
+    #[serde(default)]
+    pub complete: bool,
+}
+
+impl Recording {
+    /// 以 call_id 开一条新录制(字段由事件流填充)。
+    pub fn new(call_id: &str, input: InputRecord, provider: ProviderRecord) -> Self {
+        Self {
+            schema: RECORDING_SCHEMA,
+            call_id: call_id.to_string(),
+            recorded_at: iso8601_now(),
+            input,
+            provider,
+            exchanges: Vec::new(),
+            outcome: OutcomeRecord::default(),
+            complete: false,
+        }
+    }
+
+    /// completion barrier:outcome 已到(非 Pending)且全部 exchange 已终结。
+    fn ready(&self) -> bool {
+        self.outcome.status != OutcomeStatus::Pending && self.exchanges.iter().all(|e| e.finalized)
+    }
+}
+
+/// ① 输入侧:完整调用参数,足以重建 generate_text 调用。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputRecord {
+    /// 完整 prompt(消息数组,含 ContentPart::Image 等多模态)。
+    pub prompt: LanguageModelPrompt,
+    /// 序列化的 CallOptions(abort_signal/call_id 已 serde skip);
+    /// headers/provider_options/body_overrides 已递归脱敏。
+    pub options: serde_json::Value,
+}
+
+impl InputRecord {
+    /// 从 CallOptions 提取输入侧快照(options 序列化后递归脱敏)。
+    pub fn from_call_options(options: &CallOptions) -> Self {
+        let value = serde_json::to_value(options).unwrap_or(serde_json::Value::Null);
+        Self {
+            prompt: options.prompt.clone(),
+            options: redact_json(value),
+        }
+    }
+}
+
+/// ② 配置侧:provider 身份(请求回放重建用)。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderRecord {
+    /// `model.provider()`,如 "openai"。
+    pub provider: String,
+    /// `model.model_id()`,如 "gpt-4o"。
+    pub model_id: String,
+    /// provider 的 base_url。
+    pub base_url: Option<String>,
+    /// api_key 来源(不存明文):"env:OPENAI_API_KEY" / "explicit" / "none" / "unknown"。
+    pub api_key_source: String,
+    /// OpenAICompatProfile(能力差异)。
+    pub profile: Option<serde_json::Value>,
+    /// ProviderOptions(headers/org/project/...;已脱敏)。
+    pub provider_options: Option<serde_json::Value>,
+}
+
+impl ProviderRecord {
+    /// 最小快照(provider/model_id)——`config_snapshot` 默认实现;cover 的部分放结构方法。
+    pub fn minimal(provider: &str, model_id: &str) -> Self {
+        Self {
+            provider: provider.to_string(),
+            model_id: model_id.to_string(),
+            base_url: None,
+            api_key_source: "unknown".to_string(),
+            profile: None,
+            provider_options: None,
+        }
+    }
+}
+
+/// ③ HTTP 侧:单次 attempt 的 wire 交换。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpExchange {
+    /// 第几次重试(0=首次);per-attempt 递增。
+    pub attempt: u32,
+    pub request: HttpRecord,
+    /// None = 请求失败未获响应。
+    pub response: Option<ResponseRecord>,
+    pub timing: TimingRecord,
+    pub error: Option<String>,
+    /// 流式:该 exchange 是否已终结(收到 response 补全)。非流式恒 true。
+    #[serde(default = "default_finalized")]
+    pub finalized: bool,
+}
+
+fn default_finalized() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpRecord {
+    pub method: String,
+    pub url: String,
+    /// 敏感头(authorization/cookie/含 api-key 等)已脱敏为 "[REDACTED]"。
+    pub headers: Vec<(String, String)>,
+    /// 明文(脱敏后);None = 无 body。
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseRecord {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    /// 非流式:完整 JSON;流式:原始 SSE 拼接文本(上限截断)。
+    pub body: Option<String>,
+    pub stream_chunks: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimingRecord {
+    pub latency_ms: u64,
+    pub ttfb_ms: Option<u64>,
+}
+
+/// 调用终结状态。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutcomeStatus {
+    /// 未到(内部哨兵,不作为最终输出)。
+    #[default]
+    Pending,
+    Success,
+    /// 调用失败(非流式 err / 流式 Error part / item Err)。
+    Error,
+    /// 流式:EOF 前未见 Finish(协议不完整)。
+    Incomplete,
+    /// 流式:消费方提前 drop。
+    Cancelled,
+}
+
+/// 最终结果摘要。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OutcomeRecord {
+    pub status: OutcomeStatus,
+    pub finish_reason: Option<String>,
+    pub error: Option<String>,
+    /// 序列化的 Usage。
+    pub usage: Option<serde_json::Value>,
+}
+
+impl OutcomeRecord {
+    /// 非流式成功。
+    pub fn from_generate_result(r: &crate::result::GenerateResult) -> Self {
+        Self {
+            status: OutcomeStatus::Success,
+            finish_reason: serde_json::to_value(r.finish_reason.unified)
+                .ok()
+                .and_then(|v| v.as_str().map(|s| s.to_string())),
+            error: None,
+            usage: serde_json::to_value(&r.usage).ok(),
+        }
+    }
+
+    /// 失败(非流式 / 流式立即失败)。
+    pub fn from_error(e: &crate::error::AiMuxError) -> Self {
+        Self {
+            status: OutcomeStatus::Error,
+            finish_reason: None,
+            error: Some(e.to_string()),
+            usage: None,
+        }
+    }
+}
+
+// ── Recorder trait(快照:一次调用绑定一个实例)──────────────────────────
+
+/// 录制器 trait。
+pub trait Recorder: Send + Sync {
+    /// 录制输入侧 + 配置侧最小信息(层 A 入口调用)。
+    fn record_input(&self, call_id: &str, options: &CallOptions, provider: &str, model_id: &str);
+    /// 录制配置侧完整快照。
+    fn record_provider(&self, call_id: &str, snapshot: &ProviderRecord);
+    /// 录制单次 HTTP 交换(层 B http.rs 调用,per-attempt 一条)。
+    fn record_exchange(&self, call_id: &str, exchange: &HttpExchange);
+    /// 流式响应终结时补全该次 exchange 的 response body/stream_chunks。
+    fn record_exchange_update(&self, call_id: &str, attempt: u32, response: &ResponseRecord);
+    /// 录制最终结果(层 A 入口调用)。
+    fn record_outcome(&self, call_id: &str, outcome: &OutcomeRecord);
+    /// 同步 flush:阻塞直到全部已写行落盘(oneshot 回执),关闭前调用确保不丢。
+    fn flush(&self);
+}
+
+// ── 全局门控(关闭时热路径 ≈1 读锁;支持替换/关闭/测试隔离)────────────
+
+static RECORDER: RwLock<Option<Arc<dyn Recorder>>> = RwLock::new(None);
+
+/// 注册/替换/关闭全局录制器。传 None 关闭。
+pub fn init_recording(recorder: Option<Arc<dyn Recorder>>) {
+    if let Ok(mut g) = RECORDER.write() {
+        *g = recorder;
+    }
+}
+
+/// 从环境变量初始化:`AIMUX_RECORD=1` 开启,`AIMUX_RECORD_DIR` 指定目录(默认 `./recordings`)。
+/// 未开启返回 false(静默)。
+pub fn init_recording_from_env() -> bool {
+    if std::env::var("AIMUX_RECORD").as_deref() != Ok("1") {
+        return false;
+    }
+    let dir = std::env::var("AIMUX_RECORD_DIR").unwrap_or_else(|_| "./recordings".to_string());
+    init_recording(Some(Arc::new(JsonlRecorder::new(dir))));
+    true
+}
+
+/// 热路径检查(关闭时 None,≈1 读锁 + 1 次 Arc clone)。
+///
+/// **快照语义**:层 A 入口调用一次并随 `call_id` 传到底层;
+/// 禁止各录制点重读全局 recorder(中途替换会拆散同一条 Recording)。
+pub fn recorder() -> Option<Arc<dyn Recorder>> {
+    RECORDER.read().ok()?.clone()
+}
+
+// ── call_id 生成 ──────────────────────────────────────────────────────────
+
+static CALL_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// 生成进程级唯一 call_id(`call-{ns}-{seq}`;与 session.rs 同构)。
+pub fn new_call_id() -> String {
+    let ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("call-{ns}-{}", CALL_SEQ.fetch_add(1, Ordering::Relaxed))
+}
+
+// ── 脱敏(contains 式;与 logging.rs 同规则)──────────────────────────────
+
+/// 敏感键判断:受保护头/参数名(值将恒脱敏)。
+pub(crate) fn is_sensitive_key(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n == "authorization"
+        || n == "proxy-authorization"
+        || n == "cookie"
+        || n == "set-cookie"
+        || n.contains("api-key")
+        || n.contains("api_key")
+}
+
+/// 递归脱敏(JSON 中含敏感键的项值替换为 `[REDACTED]`)。
+/// 覆盖 `CallOptions.headers`/`provider_options`/`body_overrides` 任意层级。
+pub(crate) fn redact_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                if is_sensitive_key(&k) {
+                    out.insert(k, serde_json::Value::String("[REDACTED]".into()));
+                } else {
+                    out.insert(k, redact_json(v));
+                }
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(redact_json).collect())
+        }
+        other => other,
+    }
+}
+
+// ── JsonlRecorder(专用 writer thread;completion barrier;oneshot flush)──
+
+/// writer 事件(单消费者线程合并).
+enum RecordEvent {
+    Input {
+        call_id: String,
+        input: InputRecord,
+        provider: ProviderRecord,
+    },
+    Provider {
+        call_id: String,
+        provider: ProviderRecord,
+    },
+    Exchange {
+        call_id: String,
+        exchange: HttpExchange,
+    },
+    ExchangeUpdate {
+        call_id: String,
+        attempt: u32,
+        response: ResponseRecord,
+    },
+    Outcome {
+        call_id: String,
+        outcome: OutcomeRecord,
+    },
+    /// 刷盘命令;完成后经 ack 回执(SyncSender,容量 0 即 rendezvous)。
+    Flush { ack: SyncSender<()> },
+}
+
+/// 每条完整 `Recording` 一行 jsonl;分片按 call_id 在专用线程合并。
+/// 热路径仅 mpsc send(非阻塞),I/O 全部在专用线程。
+pub struct JsonlRecorder {
+    tx: Sender<RecordEvent>,
+    dir: PathBuf,
+}
+
+impl JsonlRecorder {
+    /// 在 `dir` 下创建录制器并启动 writer 线程。目录不存在自动创建。
+    /// 文件:`{dir}/recordings.jsonl`。
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        let dir = dir.into();
+        let (tx, rx) = std::sync::mpsc::channel::<RecordEvent>();
+        std::fs::create_dir_all(&dir).ok();
+        let writer_dir = dir.clone();
+        std::thread::Builder::new()
+            .name("aimux-recording".into())
+            .spawn(move || writer_loop(rx, writer_dir))
+            .expect("failed to spawn recording writer thread");
+        Self { tx, dir }
+    }
+
+    /// 录制文件路径。
+    pub fn path(&self) -> PathBuf {
+        self.dir.join("recordings.jsonl")
+    }
+}
+
+impl Recorder for JsonlRecorder {
+    fn record_input(&self, call_id: &str, options: &CallOptions, provider: &str, model_id: &str) {
+        let _ = self.tx.send(RecordEvent::Input {
+            call_id: call_id.to_string(),
+            input: InputRecord::from_call_options(options),
+            provider: ProviderRecord::minimal(provider, model_id),
+        });
+    }
+
+    fn record_provider(&self, call_id: &str, snapshot: &ProviderRecord) {
+        let _ = self.tx.send(RecordEvent::Provider {
+            call_id: call_id.to_string(),
+            provider: snapshot.clone(),
+        });
+    }
+
+    fn record_exchange(&self, call_id: &str, exchange: &HttpExchange) {
+        let _ = self.tx.send(RecordEvent::Exchange {
+            call_id: call_id.to_string(),
+            exchange: exchange.clone(),
+        });
+    }
+
+    fn record_exchange_update(&self, call_id: &str, attempt: u32, response: &ResponseRecord) {
+        let _ = self.tx.send(RecordEvent::ExchangeUpdate {
+            call_id: call_id.to_string(),
+            attempt,
+            response: response.clone(),
+        });
+    }
+
+    fn record_outcome(&self, call_id: &str, outcome: &OutcomeRecord) {
+        let _ = self.tx.send(RecordEvent::Outcome {
+            call_id: call_id.to_string(),
+            outcome: outcome.clone(),
+        });
+    }
+
+    fn flush(&self) {
+        let (ack_tx, ack_rx) = sync_channel::<()>(0);
+        if self.tx.send(RecordEvent::Flush { ack: ack_tx }).is_err() {
+            return; // writer 线程已退出。
+        }
+        let _ = ack_rx.recv_timeout(Duration::from_secs(5));
+    }
+}
+
+/// writer 线程:按 call_id 合并分片;completion barrier 后写一行。
+fn writer_loop(rx: Receiver<RecordEvent>, dir: PathBuf) {
+    let path = dir.join("recordings.jsonl");
+    let Ok(file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    else {
+        return;
+    };
+    let mut w = BufWriter::new(file);
+    let mut pending: HashMap<String, Recording> = HashMap::new();
+
+    while let Ok(ev) = rx.recv() {
+        match ev {
+            RecordEvent::Input {
+                call_id,
+                input,
+                provider,
+            } => {
+                let rec = pending
+                    .entry(call_id.clone())
+                    .or_insert_with(|| Recording::new(&call_id, input.clone(), provider.clone()));
+                rec.input = input;
+                rec.provider = provider;
+            }
+            RecordEvent::Provider { call_id, provider } => {
+                if let Some(rec) = pending.get_mut(&call_id) {
+                    rec.provider = provider;
+                }
+            }
+            RecordEvent::Exchange { call_id, exchange } => {
+                if let Some(rec) = pending.get_mut(&call_id) {
+                    rec.exchanges.push(exchange);
+                }
+            }
+            RecordEvent::ExchangeUpdate {
+                call_id,
+                attempt,
+                response,
+            } => {
+                if let Some(rec) = pending.get_mut(&call_id)
+                    && let Some(ex) = rec.exchanges.iter_mut().find(|ex| ex.attempt == attempt)
+                {
+                    ex.response = Some(response);
+                    ex.finalized = true;
+                }
+            }
+            RecordEvent::Outcome { call_id, outcome } => {
+                if let Some(rec) = pending.get_mut(&call_id) {
+                    rec.outcome = outcome;
+                    // completion barrier 满足则立即写出(引用与 move 分离)。
+                    if rec.ready()
+                        && let Some(rec) = pending.remove(&call_id)
+                    {
+                        write_line(&mut w, rec);
+                    }
+                }
+            }
+            RecordEvent::Flush { ack } => {
+                write_ready_all(&mut w, &mut pending);
+                let _ = w.flush();
+                let _ = ack.try_send(());
+            }
+        }
+    }
+
+    // 所有 sender 已 drop:兜底把残余 pending 作为 incomplete 写出。
+    for (_, rec) in pending.drain() {
+        let mut rec = rec;
+        rec.complete = false;
+        if rec.outcome.status == OutcomeStatus::Pending {
+            rec.outcome.status = OutcomeStatus::Incomplete;
+        }
+        write_line(&mut w, rec);
+    }
+    let _ = w.flush();
+}
+
+fn write_ready_all(w: &mut impl Write, pending: &mut HashMap<String, Recording>) {
+    let ids: Vec<String> = pending
+        .iter()
+        .filter(|(_, r)| r.ready())
+        .map(|(id, _)| id.clone())
+        .collect();
+    for id in ids {
+        if let Some(rec) = pending.remove(&id) {
+            write_line(w, rec);
+        }
+    }
+}
+
+fn write_line(w: &mut impl Write, rec: Recording) {
+    if let Ok(line) = serde_json::to_string(&rec) {
+        let _ = writeln!(w, "{line}");
+        let _ = w.flush(); // 每行落盘,保证崩溃前已写行可见。
+    }
+}
+
+// ── 工具 ───────────────────────────────────────────────────────────────────
+
+fn iso8601_now() -> String {
+    // MVP:秒精度 + 时区标记 Z(毫秒精度留待列 `rfc3339` 公共 util 后统一)。
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| format!("{:?}", d))
+        .unwrap_or_default()
+        .replace("Duration", "t")
+}
+
+// ── 流式 outcome 观测(B4:流结束时终结,含 drop/EOF 兜底)────────────────
+
+/// 流式观测包装器:终结时记录 `OutcomeRecord`。
+///
+/// 终结语义:
+/// - `StreamPart::Finish` → `Success`(finish_reason/usage 写入)
+/// - `StreamPart::Error` → `Error`
+/// - 流 item `Err` → `Error`
+/// - EOF 前未见 Finish → `Incomplete`
+/// - 消费方提前 drop(未终结)→ `Cancelled`
+///
+/// 只做观测,不改流内容。
+pub struct RecordingOutcomeStream<S> {
+    inner: S,
+    recorder: Option<Arc<dyn Recorder>>,
+    call_id: String,
+    /// 已记录终结。
+    recorded: bool,
+}
+
+impl<S> RecordingOutcomeStream<S> {
+    /// 用层 A 入口取的 recorder 快照绑定流(全局替换不影响本次调用)。
+    pub fn new(inner: S, recorder: Option<Arc<dyn Recorder>>, call_id: impl Into<String>) -> Self {
+        Self {
+            inner,
+            recorder,
+            call_id: call_id.into(),
+            recorded: false,
+        }
+    }
+
+    fn record(&mut self, outcome: &OutcomeRecord) {
+        if !self.recorded {
+            self.recorded = true;
+            if let Some(rec) = &self.recorder {
+                rec.record_outcome(&self.call_id, outcome);
+            }
+        }
+    }
+}
+
+impl<S, E> futures::Stream for RecordingOutcomeStream<S>
+where
+    S: futures::Stream<Item = Result<crate::stream_part::StreamPart, E>> + Unpin,
+    E: std::fmt::Display,
+{
+    type Item = Result<crate::stream_part::StreamPart, E>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.as_mut().get_mut();
+        let inner = std::pin::Pin::new(&mut this.inner);
+        match inner.poll_next(cx) {
+            std::task::Poll::Ready(Some(Ok(part))) => {
+                match &part {
+                    crate::stream_part::StreamPart::Finish {
+                        finish_reason,
+                        usage,
+                        ..
+                    } => {
+                        let outcome = OutcomeRecord {
+                            status: OutcomeStatus::Success,
+                            finish_reason: serde_json::to_value(finish_reason.unified)
+                                .ok()
+                                .and_then(|v| v.as_str().map(|s| s.to_string())),
+                            error: None,
+                            usage: serde_json::to_value(usage).ok(),
+                        };
+                        self.as_mut().get_mut().record(&outcome);
+                    }
+                    crate::stream_part::StreamPart::Error { error } => {
+                        let outcome = OutcomeRecord {
+                            status: OutcomeStatus::Error,
+                            finish_reason: None,
+                            error: Some(error.to_string()),
+                            usage: None,
+                        };
+                        self.as_mut().get_mut().record(&outcome);
+                    }
+                    _ => {}
+                }
+                std::task::Poll::Ready(Some(Ok(part)))
+            }
+            std::task::Poll::Ready(Some(Err(e))) => {
+                let outcome = OutcomeRecord {
+                    status: OutcomeStatus::Error,
+                    finish_reason: None,
+                    error: Some(e.to_string()),
+                    usage: None,
+                };
+                this.record(&outcome);
+                std::task::Poll::Ready(Some(Err(e)))
+            }
+            std::task::Poll::Ready(None) => {
+                let outcome = OutcomeRecord {
+                    status: OutcomeStatus::Incomplete,
+                    finish_reason: None,
+                    error: None,
+                    usage: None,
+                };
+                this.record(&outcome);
+                std::task::Poll::Ready(None)
+            }
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}
+
+impl<S> Drop for RecordingOutcomeStream<S> {
+    fn drop(&mut self) {
+        if !self.recorded {
+            let outcome = OutcomeRecord {
+                status: OutcomeStatus::Cancelled,
+                finish_reason: None,
+                error: None,
+                usage: None,
+            };
+            self.record(&outcome);
+        }
+    }
+}
+
+// ── 测试 ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generate::GenerateTextOptions;
+
+    fn sample_options() -> CallOptions {
+        GenerateTextOptions {
+            temperature: Some(0.7),
+            ..Default::default()
+        }
+        .into_call_options(
+            crate::language_model_message::convert_to_language_model_prompt(
+                &[crate::message::ModelMessage::user("ping")],
+                None,
+            ),
+        )
+    }
+
+    #[test]
+    fn gate_is_off_by_default() {
+        assert!(recorder().is_none());
+    }
+
+    #[test]
+    fn call_id_is_unique() {
+        let a = new_call_id();
+        let b = new_call_id();
+        assert_ne!(a, b);
+        assert!(a.starts_with("call-"));
+    }
+
+    #[test]
+    fn input_record_serializes_options_without_internal_fields() {
+        let mut opts = sample_options();
+        opts.call_id = Some("call-test".into());
+        opts.abort_signal = None;
+        let rec = InputRecord::from_call_options(&opts);
+        let v = &rec.options;
+        assert!(v.get("call_id").is_none());
+        assert!(v.get("abort_signal").is_none());
+    }
+
+    #[test]
+    fn redact_json_hides_sensitive_values_everywhere() {
+        let v = serde_json::json!({
+            "headers": { "Authorization": "Bearer sk-abc", "X-Key": "ok", "x-goog-api-key": "gkey" },
+            "provider_options": { "headers": { "Cookie": "s=1" } },
+            "body_overrides": { "api_key": "sk-secret" },
+            "temperature": 0.5,
+        });
+        let r = redact_json(v);
+        assert_eq!(r["headers"]["Authorization"], "[REDACTED]");
+        assert_eq!(r["headers"]["x-goog-api-key"], "[REDACTED]");
+        assert_eq!(r["headers"]["X-Key"], "ok");
+        assert_eq!(r["provider_options"]["headers"]["Cookie"], "[REDACTED]");
+        assert_eq!(r["body_overrides"]["api_key"], "[REDACTED]");
+        assert_eq!(r["temperature"], 0.5);
+    }
+
+    #[test]
+    fn recording_round_trips() {
+        let rec = Recording::new(
+            "call-1",
+            InputRecord::from_call_options(&sample_options()),
+            ProviderRecord::minimal("openai", "gpt-4o"),
+        );
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: Recording = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.call_id, "call-1");
+        assert_eq!(back.schema, RECORDING_SCHEMA);
+        assert_eq!(back.provider.provider, "openai");
+    }
+
+    #[test]
+    fn jsonl_flush_writes_complete_line_blocking() {
+        let dir = std::env::temp_dir().join(format!("aimux-rec-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let rec = JsonlRecorder::new(&dir);
+
+        rec.record_input("call-flush-1", &sample_options(), "openai", "gpt-4o");
+        rec.record_outcome(
+            "call-flush-1",
+            &OutcomeRecord {
+                status: OutcomeStatus::Success,
+                finish_reason: Some("stop".into()),
+                error: None,
+                usage: None,
+            },
+        );
+        // flush 阻塞直到落盘:无需轮询。
+        rec.flush();
+        let content = std::fs::read_to_string(rec.path()).unwrap();
+        let parsed: Recording = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed.call_id, "call-flush-1");
+        assert_eq!(parsed.outcome.status, OutcomeStatus::Success);
+        assert!(parsed.exchanges.is_empty()); // 无 exchange 也算 ready(非流式仅层 A)
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn exchange_update_is_attached_to_correct_attempt() {
+        let dir = std::env::temp_dir().join(format!("aimux-rec-test2-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let rec = JsonlRecorder::new(&dir);
+
+        rec.record_input("call-x2", &sample_options(), "openai", "gpt-4o");
+        // attempt 0 骨架 + attempt 1 补全。
+        rec.record_exchange(
+            "call-x2",
+            &HttpExchange {
+                attempt: 0,
+                request: HttpRecord {
+                    method: "post".into(),
+                    url: "u".into(),
+                    headers: vec![("authorization".into(), "[REDACTED]".into())],
+                    body: Some("{}".into()),
+                },
+                response: None,
+                timing: TimingRecord {
+                    latency_ms: 1,
+                    ttfb_ms: None,
+                },
+                error: None,
+                finalized: false,
+            },
+        );
+        rec.record_exchange_update(
+            "call-x2",
+            0,
+            &ResponseRecord {
+                status: 200,
+                headers: vec![],
+                body: Some("{\"ok\":true}".into()),
+                stream_chunks: Some(1),
+            },
+        );
+        rec.record_outcome(
+            "call-x2",
+            &OutcomeRecord {
+                status: OutcomeStatus::Success,
+                finish_reason: None,
+                error: None,
+                usage: None,
+            },
+        );
+        rec.flush();
+
+        let content = std::fs::read_to_string(rec.path()).unwrap();
+        let parsed: Recording = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed.exchanges.len(), 1);
+        assert_eq!(parsed.exchanges[0].response.as_ref().unwrap().status, 200);
+        assert!(parsed.exchanges[0].finalized);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn incomplete_outcome_flushes_on_shutdown() {
+        let dir = std::env::temp_dir().join(format!("aimux-rec-test3-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        {
+            let rec = JsonlRecorder::new(&dir);
+            rec.record_input("call-orphan", &sample_options(), "openai", "gpt-4o");
+            // 无 outcome:drop recorder 后 writer 线程被 Disconnected 终止并兜底写出。
+        }
+        // 等 writer 线程退出(短睡:无同步 API,drop 后 recv 通道断开即写)。
+        std::thread::sleep(Duration::from_millis(200));
+        let dir_ok = std::fs::read_to_string(dir.join("recordings.jsonl"));
+        if let Ok(content) = dir_ok {
+            let parsed: Recording = serde_json::from_str(content.trim()).unwrap();
+            assert_eq!(parsed.outcome.status, OutcomeStatus::Incomplete);
+            assert!(!parsed.complete);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/aimux-core/src/session.rs
+++ b/aimux-core/src/session.rs
@@ -122,7 +122,14 @@ impl SessionStore {
     ///
     /// Called from the `generate_text` / `stream_text` entry points (before
     /// the call is dispatched), so failures are still part of the session.
-    pub fn append(&self, session_id: &str, source: SessionSource) -> SessionCall {
+    /// `call_id`:调用方已有(RFC-0023 层 A 生成)则复用,保证 session/recording/
+    /// trace 三系统同 ID;None 时内部自生成。
+    pub fn append(
+        &self,
+        session_id: &str,
+        call_id: Option<&str>,
+        source: SessionSource,
+    ) -> SessionCall {
         let mut inner = self.inner.lock().unwrap();
         inner.touch(session_id);
         if !inner.sessions.contains_key(session_id) {
@@ -149,7 +156,7 @@ impl SessionStore {
         let step = u32::try_from(entry.next_step).unwrap_or(u32::MAX);
         entry.next_step += 1;
         let call = SessionCall {
-            call_id: new_call_id(),
+            call_id: call_id.map(str::to_string).unwrap_or_else(new_call_id),
             step,
             recorded_at: rfc3339_now(),
         };
@@ -473,9 +480,9 @@ mod tests {
     #[test]
     fn append_increments_step_and_keeps_order() {
         let store = SessionStore::new();
-        store.append("s1", SessionSource::Explicit);
-        store.append("s1", SessionSource::Explicit);
-        store.append("s1", SessionSource::Explicit);
+        store.append("s1", None, SessionSource::Explicit);
+        store.append("s1", None, SessionSource::Explicit);
+        store.append("s1", None, SessionSource::Explicit);
 
         let calls = store.session_calls("s1");
         assert_eq!(calls.len(), 3);
@@ -503,8 +510,8 @@ mod tests {
         assert!(store.session_calls("nope").is_empty());
         assert!(store.list_sessions().is_empty());
 
-        store.append("s1", SessionSource::Explicit);
-        store.append("s2", SessionSource::Inferred);
+        store.append("s1", None, SessionSource::Explicit);
+        store.append("s2", None, SessionSource::Inferred);
 
         let views = store.list_sessions();
         assert_eq!(views.len(), 2);
@@ -518,11 +525,11 @@ mod tests {
     #[test]
     fn lru_evicts_oldest_session_when_full() {
         let store = SessionStore::with_capacity(2, 8);
-        store.append("a", SessionSource::Explicit);
-        store.append("b", SessionSource::Explicit);
+        store.append("a", None, SessionSource::Explicit);
+        store.append("b", None, SessionSource::Explicit);
         // Touching "a" makes it the most recently used.
         store.session_calls("a");
-        store.append("c", SessionSource::Explicit);
+        store.append("c", None, SessionSource::Explicit);
 
         assert!(
             store.session_calls("b").is_empty(),
@@ -535,9 +542,9 @@ mod tests {
     #[test]
     fn calls_per_session_are_bounded() {
         let store = SessionStore::with_capacity(8, 2);
-        store.append("s1", SessionSource::Explicit);
-        store.append("s1", SessionSource::Explicit);
-        store.append("s1", SessionSource::Explicit);
+        store.append("s1", None, SessionSource::Explicit);
+        store.append("s1", None, SessionSource::Explicit);
+        store.append("s1", None, SessionSource::Explicit);
 
         let calls = store.session_calls("s1");
         assert_eq!(calls.len(), 2, "oldest call dropped");
@@ -551,7 +558,7 @@ mod tests {
         // call is evicted — eviction must not reuse a step.
         let store = SessionStore::with_capacity(8, 2);
         for _ in 0..4 {
-            store.append("s1", SessionSource::Explicit);
+            store.append("s1", None, SessionSource::Explicit);
         }
         let calls = store.session_calls("s1");
         assert_eq!(calls.len(), 2, "only the two newest calls are retained");
@@ -564,8 +571,8 @@ mod tests {
         // Regression: touching unknown ids must not pollute the LRU, which
         // would let sessions exceed max_sessions (and let the LRU grow).
         let store = SessionStore::with_capacity(2, 8);
-        store.append("a", SessionSource::Explicit);
-        store.append("b", SessionSource::Explicit);
+        store.append("a", None, SessionSource::Explicit);
+        store.append("b", None, SessionSource::Explicit);
 
         // Repeatedly query unknown ids — before the fix these polluted the LRU.
         for i in 0..16 {
@@ -573,7 +580,7 @@ mod tests {
         }
 
         for id in ["c", "d", "e", "f", "g"] {
-            store.append(id, SessionSource::Explicit);
+            store.append(id, None, SessionSource::Explicit);
         }
         assert!(
             store.list_sessions().len() <= 2,
@@ -587,7 +594,7 @@ mod tests {
     #[test]
     fn clear_drops_all_sessions() {
         let store = SessionStore::new();
-        store.append("s1", SessionSource::Explicit);
+        store.append("s1", None, SessionSource::Explicit);
         store.clear();
         assert!(store.list_sessions().is_empty());
     }

--- a/aimux-core/src/trace/layer.rs
+++ b/aimux-core/src/trace/layer.rs
@@ -97,6 +97,8 @@ struct RecordCtx {
     scope_salt: u64,
     session_tracker: Arc<Mutex<HashMap<String, SessionTracker>>>,
     ctx: RequestCtx,
+    /// RFC-0023 关联 ID:复用 `options.call_id`(缺失时由构造处生成)。
+    call_id: Option<String>,
     request_body: Option<serde_json::Value>,
     response_headers: Option<HashMap<String, String>>,
     ttft_ms: Arc<AtomicU64>,
@@ -170,6 +172,7 @@ impl TraceLayer {
             strict: self.strict,
             scope_salt: self.scope_salt,
             session_tracker: self.session_tracker.clone(),
+            call_id: options.call_id.clone(),
             ctx: RequestCtx {
                 session_id,
                 scope_key,
@@ -370,12 +373,14 @@ impl RecordCtx {
             model: self.model.clone(),
             request_id,
             session_id: self.ctx.session_id.clone(),
-            call_id: format!(
-                "trace-{}-{}-{}",
-                std::process::id(),
-                self.ctx.monotonic_ms,
-                TRACE_SEQ.fetch_add(1, Ordering::Relaxed)
-            ),
+            call_id: self.call_id.clone().unwrap_or_else(|| {
+                format!(
+                    "trace-{}-{}-{}",
+                    std::process::id(),
+                    self.ctx.monotonic_ms,
+                    TRACE_SEQ.fetch_add(1, Ordering::Relaxed)
+                )
+            }),
             sent_at_unix_ms: self.ctx.sent_at_unix_ms,
             monotonic_sent_ms: self.ctx.monotonic_ms,
             lcp_token_upper,

--- a/aimux-core/src/util.rs
+++ b/aimux-core/src/util.rs
@@ -13,3 +13,36 @@ pub use crate::json_repair::{
     ParsePartialJsonResult, ParsePartialJsonState, fix_json, parse_partial_json,
 };
 pub use crate::math::{UtilError, cosine_similarity};
+
+// ── RFC 3339 时间戳(UTC,毫秒精度;session.rs 同款,统一入口)───────────────
+
+/// Current time as RFC 3339 UTC with millisecond precision
+/// (`2026-08-05T04:52:30.123Z`).
+pub fn rfc3339_now() -> String {
+    let d = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = d.as_secs() as i64;
+    let millis = d.subsec_millis();
+    let (year, month, day) = civil_from_days(secs.div_euclid(86_400));
+    let hms = secs.rem_euclid(86_400);
+    format!(
+        "{year:04}-{month:02}-{day:02}T{:02}:{:02}:{:02}.{millis:03}Z",
+        hms / 3600,
+        (hms % 3600) / 60,
+        hms % 60
+    )
+}
+
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}

--- a/aimux-core/tests/recording_e2e_test.rs
+++ b/aimux-core/tests/recording_e2e_test.rs
@@ -1,0 +1,228 @@
+//! RFC-0023 P1 端到端集成测试:层 A 接入(generate_text/stream_text) +
+//! 流式终结观测 + JsonlRecorder 落盘。
+//!
+//! 全局录制器是进程级单例,所有场景放在同一测试内串行执行(init→验证→替换)。
+
+use aimux_core::language_model::LanguageModel;
+use aimux_core::options::CallOptions;
+use aimux_core::recording::{self, JsonlRecorder, OutcomeStatus, Recording};
+use aimux_core::result::{GenerateContent, GenerateResult, StreamResult};
+use aimux_core::stream_part::StreamPart;
+use aimux_core::types::{FinishReason, FinishReasonUnified, Usage};
+use async_trait::async_trait;
+use futures::StreamExt;
+use std::sync::Arc;
+
+/// Mock model:非流式固定回话;流式按参数决定行为。
+#[derive(Default)]
+struct EchoModel {
+    /// do_generate 立即失败。
+    gen_fails: bool,
+    /// 流中途发 Error part。
+    part_error: bool,
+    /// do_stream 立即失败。
+    stream_fails: bool,
+}
+
+#[async_trait]
+impl LanguageModel for EchoModel {
+    fn provider(&self) -> &str {
+        "mock-echo"
+    }
+
+    fn model_id(&self) -> &str {
+        "echo-1"
+    }
+
+    async fn do_generate(
+        &self,
+        _options: &CallOptions,
+    ) -> Result<GenerateResult, aimux_core::error::AiMuxError> {
+        if self.gen_fails {
+            return Err(aimux_core::error::AiMuxError::Provider("gen boom".into()));
+        }
+        Ok(GenerateResult {
+            content: vec![GenerateContent::Text {
+                text: "pong".into(),
+                provider_metadata: None,
+            }],
+            finish_reason: FinishReason {
+                unified: FinishReasonUnified::Stop,
+                raw: None,
+            },
+            usage: Usage::default(),
+            warnings: vec![],
+            provider_metadata: None,
+            response: aimux_core::types::ResponseMetadata::default(),
+            request_body: None,
+            response_headers: None,
+        })
+    }
+
+    async fn do_stream(
+        &self,
+        _options: &CallOptions,
+    ) -> Result<StreamResult, aimux_core::error::AiMuxError> {
+        if self.stream_fails {
+            return Err(aimux_core::error::AiMuxError::Stream("boom".into()));
+        }
+        if self.part_error {
+            let parts = vec![
+                Ok(StreamPart::StreamStart { warnings: vec![] }),
+                Ok(StreamPart::Error {
+                    error: aimux_core::error::AiMuxError::Stream("mid-stream".into()),
+                }),
+            ];
+            return Ok(StreamResult {
+                stream: Box::pin(futures::stream::iter(parts)),
+                request_body: None,
+                response_headers: None,
+            });
+        }
+        let parts = vec![
+            Ok(StreamPart::StreamStart { warnings: vec![] }),
+            Ok(StreamPart::TextDelta {
+                id: "1".into(),
+                delta: "hi".into(),
+                provider_metadata: None,
+            }),
+            Ok(StreamPart::Finish {
+                finish_reason: FinishReason {
+                    unified: FinishReasonUnified::Stop,
+                    raw: None,
+                },
+                usage: Usage::default(),
+                provider_metadata: None,
+            }),
+        ];
+        Ok(StreamResult {
+            stream: Box::pin(futures::stream::iter(parts)),
+            request_body: None,
+            response_headers: None,
+        })
+    }
+}
+
+fn run<F: std::future::Future>(f: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(f)
+}
+
+fn wait_sorted_line(dir: &std::path::Path) -> Recording {
+    let path = dir.join("recordings.jsonl");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if let Ok(s) = std::fs::read_to_string(&path)
+            && let Some(line) = s.lines().next()
+            && !line.trim().is_empty()
+            && let Ok(rec) = serde_json::from_str::<Recording>(line.trim())
+        {
+            return rec;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("recording not written: {}", path.display());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn layer_a_records_all_outcome_paths() {
+    let pid = std::process::id();
+    let dir_ok = std::env::temp_dir().join(format!("aimux-e2e-ok-{pid}"));
+    let dir_err = std::env::temp_dir().join(format!("aimux-e2e-err-{pid}"));
+    let dir_finish = std::env::temp_dir().join(format!("aimux-e2e-fin-{pid}"));
+    let dir_part_err = std::env::temp_dir().join(format!("aimux-e2e-pe-{pid}"));
+    let dir_cancel = std::env::temp_dir().join(format!("aimux-e2e-cancel-{pid}"));
+    for d in [&dir_ok, &dir_err, &dir_finish, &dir_part_err, &dir_cancel] {
+        let _ = std::fs::remove_dir_all(d);
+    }
+
+    // ① generate 成功 → Success + finish_reason。
+    recording::init_recording(Some(Arc::new(JsonlRecorder::new(&dir_ok))));
+    run(async {
+        let r = aimux_core::generate::generate_text(
+            &EchoModel::default(),
+            "ping",
+            aimux_core::generate::GenerateTextOptions::default(),
+        )
+        .await;
+        assert_eq!(r.unwrap().text, "pong");
+    });
+    let rec = wait_sorted_line(&dir_ok);
+    assert!(rec.call_id.starts_with("call-"));
+    assert_eq!(rec.provider.provider, "mock-echo");
+    assert_eq!(rec.outcome.status, OutcomeStatus::Success);
+    assert_eq!(rec.outcome.finish_reason.as_deref(), Some("stop"));
+
+    // ② generate 失败 → Error。
+    recording::init_recording(Some(Arc::new(JsonlRecorder::new(&dir_err))));
+    run(async {
+        let r = aimux_core::generate::generate_text(
+            &EchoModel {
+                gen_fails: true,
+                ..Default::default()
+            },
+            "ping",
+            aimux_core::generate::GenerateTextOptions::default(),
+        )
+        .await;
+        assert!(r.is_err());
+    });
+    let rec = wait_sorted_line(&dir_err);
+    assert_eq!(rec.outcome.status, OutcomeStatus::Error);
+    assert!(rec.outcome.error.is_some());
+
+    // ③ 流式正常终结(消费完) → Success。
+    recording::init_recording(Some(Arc::new(JsonlRecorder::new(&dir_finish))));
+    run(async {
+        let result = aimux_core::generate::stream_text(
+            &EchoModel::default(),
+            "ping",
+            aimux_core::generate::GenerateTextOptions::default(),
+        )
+        .await
+        .unwrap();
+        let parts: Vec<_> = result.stream.collect::<Vec<_>>().await;
+        assert_eq!(parts.len(), 3);
+    });
+    let rec = wait_sorted_line(&dir_finish);
+    assert_eq!(rec.outcome.status, OutcomeStatus::Success);
+
+    // ④ 流式 Error part → Error。
+    recording::init_recording(Some(Arc::new(JsonlRecorder::new(&dir_part_err))));
+    run(async {
+        let result = aimux_core::generate::stream_text(
+            &EchoModel {
+                part_error: true,
+                ..Default::default()
+            },
+            "ping",
+            aimux_core::generate::GenerateTextOptions::default(),
+        )
+        .await
+        .unwrap();
+        let parts: Vec<_> = result.stream.collect::<Vec<_>>().await;
+        assert_eq!(parts.len(), 2);
+    });
+    let rec = wait_sorted_line(&dir_part_err);
+    assert_eq!(rec.outcome.status, OutcomeStatus::Error);
+    assert!(rec.outcome.error.unwrap_or_default().contains("mid-stream"));
+
+    // ⑤ 流式提前 drop(不消费完)→ Cancelled。
+    recording::init_recording(Some(Arc::new(JsonlRecorder::new(&dir_cancel))));
+    run(async {
+        let result = aimux_core::generate::stream_text(
+            &EchoModel::default(),
+            "ping",
+            aimux_core::generate::GenerateTextOptions::default(),
+        )
+        .await
+        .unwrap();
+        drop(result.stream); // 未 poll 完即抛弃 → Drop 终结 Cancelled
+    });
+    let rec = wait_sorted_line(&dir_cancel);
+    assert_eq!(rec.outcome.status, OutcomeStatus::Cancelled);
+
+    recording::init_recording(None);
+    let _ = std::fs::remove_dir_all(&dir_ok);
+}

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -69,6 +69,7 @@ fn options_with_tools(prompt: LanguageModelPrompt, tools: Vec<FunctionTool>) -> 
         abort_signal: None,
         session_id: None,
         include_raw_chunks: None,
+        call_id: None,
     }
 }
 

--- a/aimux-providers/tests/openai_convert_extended_test.rs
+++ b/aimux-providers/tests/openai_convert_extended_test.rs
@@ -64,6 +64,7 @@ fn default_opts(p: LanguageModelPrompt) -> CallOptions {
         abort_signal: None,
         session_id: None,
         include_raw_chunks: None,
+        call_id: None,
     }
 }
 fn po(map: Value) -> Option<std::collections::HashMap<String, Value>> {

--- a/aimux-providers/tests/openai_model_extended_test.rs
+++ b/aimux-providers/tests/openai_model_extended_test.rs
@@ -49,6 +49,7 @@ fn default_opts(p: LanguageModelPrompt) -> CallOptions {
         abort_signal: None,
         session_id: None,
         include_raw_chunks: None,
+        call_id: None,
     }
 }
 fn po(map: Value) -> Option<std::collections::HashMap<String, Value>> {

--- a/aimux-providers/tests/openai_model_test.rs
+++ b/aimux-providers/tests/openai_model_test.rs
@@ -74,6 +74,7 @@ fn options_with_tools(prompt: LanguageModelPrompt, tools: Vec<FunctionTool>) -> 
         abort_signal: None,
         session_id: None,
         include_raw_chunks: None,
+        call_id: None,
     }
 }
 

--- a/docs/plan/rfc0023-recording.md
+++ b/docs/plan/rfc0023-recording.md
@@ -85,6 +85,13 @@
 - `send_with_retry_raw` per-attempt 录制的错误体捕获点(read_error_body)需实现时确认。
 - P5 Node/C ABI 的 model handle 所有权(C ABI 不直接表达借用型 Option<&dyn LanguageModel>)。
 
+## 实施进度
+
+| 阶段 | 状态 | 备注 |
+|---|---|---|
+| P1 录制核心 | 🔄 已实施(双模型评审后修复中) | completion barrier + transport_closed 信号、专用 writer thread + oneshot flush + Drop join、脱敏超集、call_id 三系统统一(TraceLayer/session 复用 options.call_id)、complete 标记、ISO 时间戳 |
+| 队列语义 | ⏳ 延期 | P1 用无界 channel;bounded/drop-newest + 丢弃计数留 P2(防无限积压由 P6 RingRecorder 兜底) |
+
 ## 参考
 
 - 回滚前的 P1-P3 实施代码:分支 `backup/rfc0023-p1-p3`(3 个提交,仅作方案参考,不直接复用)


### PR DESCRIPTION
## 变更

RFC-0023 调用上下文录制 P1(三层数据模型 + Recorder trait + JsonlRecorder + 层 A 接入),按双模型评审(gpt-5.6-sol + glm-5.2)定稿基线实施。

### P1 提交
- **recording.rs**: Recording(schema=1/call_id/OutcomeStatus/complete/transport_closed)+ Recorder trait(record_exchange_update(attempt)/record_transport_closed/同步 flush)+ RwLock 门控 + 专用 writer thread + completion barrier + 递归脱敏(超集) + RecordingOutcomeStream 流式终结观测
- **generate.rs**: 层 A 接入(generate_text 成功/失败录 outcome;stream_text 包装终结) + call_id 复用
- **options.rs**: CallOptions.call_id(serde+ts skip)
- **language_model.rs**: config_snapshot 默认方法(零破坏)
- **util.rs**: rfc3339_now 公共时间戳
- **session.rs / trace/layer.rs**: call_id 三系统统一(TraceLayer/session 复用 options.call_id)

### 评审修复(250f714)
B1-B7 + M1-M3 + S1-S6 全部落地(见提交信息)。

### 测试
- 9 单测(模型/脱敏超集/门控/flush/update 定位/barrier 顺序/complete 标记/确定性 shutdown)
- e2e 5 场景(成功/失败/流完成/流 Error/流 drop→Cancelled)
- workspace 全测 + clippy 0 + fmt 干净

### 范围外(P2 起)
层 B http.rs 录制、mock 回放、绑定层、RingRecorder。