### PR TITLE
fix(providers): registry base_url hygiene + panic convert API hidden (#90)

### DIFF
--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -235,6 +235,18 @@ pub fn convert_prompt_to_anthropic_full_fallible(
 }
 
 /// Convert a prompt into the full Anthropic shape.
+///
+/// Panics on conversion failure. Production paths use the fallible variant
+/// [`convert_prompt_to_anthropic_full_fallible`]; this panic wrapper exists
+/// only for integration tests under `tests/`. It is `#[doc(hidden)]` and
+/// `#[deprecated]` so it neither appears on the public API surface nor can be
+/// pulled in by accident (release uses `panic = "abort"`, so reaching a panic
+/// here via FFI would kill the host process).
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.1",
+    note = "panics on failure; use convert_prompt_to_anthropic_full_fallible instead (issue #90 R1)"
+)]
 pub fn convert_prompt_to_anthropic_full(
     prompt: &LanguageModelPrompt,
     send_reasoning: bool,
@@ -251,6 +263,11 @@ pub fn convert_prompt_to_anthropic_full(
 /// messages that map to the same effective Anthropic role (`user`/`tool` →
 /// `user`, `assistant` → `assistant`) are merged into a single message, matching
 /// the SDK behaviour.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.1",
+    note = "panics on failure; use convert_prompt_to_anthropic_full_fallible instead (issue #90 R1)"
+)]
 pub fn convert_prompt_to_anthropic(
     prompt: &LanguageModelPrompt,
 ) -> (Option<Vec<Value>>, Vec<Value>) {

--- a/aimux-providers/src/openai/convert.rs
+++ b/aimux-providers/src/openai/convert.rs
@@ -198,6 +198,19 @@ fn prepare_tools_groq(
 // ── Message conversion ──────────────────────────────────────────────────────
 
 /// Convert a `LanguageModelPrompt` to OpenAI `messages` array.
+///
+/// Panics on conversion failure. Production paths use the fallible variant
+/// [`convert_prompt_to_openai_messages_with_mode_fallible`]; this panic
+/// wrapper exists only for integration tests under `tests/`. It is
+/// `#[doc(hidden)]` and `#[deprecated]` so it neither appears on the public
+/// API surface nor can be pulled in by accident (release uses
+/// `panic = "abort"`, so reaching a panic here via FFI would kill the host
+/// process).
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.1",
+    note = "panics on failure; use convert_prompt_to_openai_messages_with_mode_fallible instead (issue #90 R1)"
+)]
 pub fn convert_prompt_to_openai_messages(prompt: &LanguageModelPrompt) -> Vec<Value> {
     convert_prompt_to_openai_messages_with_mode_fallible(prompt, SystemMessageMode::System)
         .expect("convert_prompt_to_openai_messages: conversion failed")
@@ -214,6 +227,19 @@ pub fn convert_prompt_to_openai_messages_with_mode_fallible(
 
 /// Convert a `LanguageModelPrompt` to OpenAI `messages` array with a system
 /// message mode.
+///
+/// Panics on conversion failure. Production paths use the fallible variant
+/// [`convert_prompt_to_openai_messages_with_mode_fallible`]; this panic
+/// wrapper exists only for integration tests under `tests/`. It is
+/// `#[doc(hidden)]` and `#[deprecated]` so it neither appears on the public
+/// API surface nor can be pulled in by accident (release uses
+/// `panic = "abort"`, so reaching a panic here via FFI would kill the host
+/// process).
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.1",
+    note = "panics on failure; use convert_prompt_to_openai_messages_with_mode_fallible instead (issue #90 R1)"
+)]
 pub fn convert_prompt_to_openai_messages_with_mode(
     prompt: &LanguageModelPrompt,
     system_message_mode: SystemMessageMode,

--- a/aimux-providers/src/provider.rs
+++ b/aimux-providers/src/provider.rs
@@ -92,6 +92,17 @@ fn registry() -> &'static [RegistryEntry] {
     })
 }
 
+/// Detect unexpanded placeholder syntax in a registry `base_url`.
+///
+/// Templated entries (cloudflare, neon, snowflake, oci, ...) carry account- or
+/// region-scoped placeholders that the caller must fill in via
+/// [`ProviderOptions::base_url`]. Recognized forms: `{VAR}` (covers `${var}`
+/// too) and `<host>`. If a new placeholder form is introduced in the
+/// registry, extend this function.
+fn base_url_has_placeholder(base_url: &str) -> bool {
+    base_url.contains('{') || base_url.contains('<')
+}
+
 /// Per-call construction options for [`provider`] (overrides the registry entry).
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ProviderOptions {
@@ -146,6 +157,19 @@ pub fn provider_handle(
             ProviderName::all_names()
         ))
     })?;
+
+    // Reject registry base_urls that still carry unexpanded placeholders
+    // (e.g. cloudflare's `{CLOUDFLARE_ACCOUNT_ID}`, snowflake's
+    // `<account-identifier>`). These entries are intentionally templated —
+    // the caller MUST supply a concrete base_url via ProviderOptions.
+    let base_url_overridden = options.as_ref().is_some_and(|o| o.base_url.is_some());
+    if !base_url_overridden && base_url_has_placeholder(&entry.base_url) {
+        return Err(AiMuxError::InvalidArgument(format!(
+            "provider '{name}' has a templated base_url {:?} with an unexpanded \
+             placeholder; pass a concrete `base_url` via ProviderOptions to use it",
+            entry.base_url
+        )));
+    }
 
     // api_key 来源标注(回放重建用):显式传 key → explicit;否则 env。
     let source: Option<String> = if api_key.is_some() {
@@ -330,6 +354,92 @@ mod tests {
             assert!(!e.base_url.is_empty());
             assert!(!e.env_var.is_empty());
         }
+    }
+
+    #[test]
+    fn registry_no_corrupt_base_urls() {
+        // Issue #90 R2: no registry base_url may carry non-ASCII pollution
+        // or be a non-URL fragment. Templated placeholders (cloudflare/neon/
+        // snowflake/oci) are allowed but rejected at construct time — see
+        // provider_handle's base_url_has_placeholder check.
+        for e in registry() {
+            assert!(
+                e.base_url.starts_with("https://") || e.base_url.starts_with("http://"),
+                "registry entry '{}' has a non-URL base_url: {:?}",
+                e.name,
+                e.base_url
+            );
+            assert!(
+                e.base_url.is_ascii(),
+                "registry entry '{}' base_url has non-ASCII chars: {:?}",
+                e.name,
+                e.base_url
+            );
+        }
+    }
+
+    #[test]
+    fn registry_fixed_base_urls_are_correct() {
+        // Issue #90 R2: pin the corrected base_urls for entries that were
+        // broken (regression guard against reverting to the old bad values).
+        let by_name: std::collections::HashMap<&str, &str> = registry()
+            .iter()
+            .map(|e| (e.name.as_str(), e.base_url.as_str()))
+            .collect();
+        assert_eq!(
+            by_name.get("xpersona").copied(),
+            Some("https://www.xpersona.co/v1"),
+            "xpersona base_url was '/v1' (truncated); must be the full URL"
+        );
+        assert_eq!(
+            by_name.get("moonshotai_cn").copied(),
+            Some("https://api.moonshot.cn/anthropic/v1"),
+            "moonshotai_cn base_url had a leaked '（Anthropic' annotation suffix"
+        );
+        assert_eq!(
+            by_name.get("zhipuai_coding_plan").copied(),
+            Some("https://open.bigmodel.cn/api/coding/paas/v4"),
+            "zhipuai_coding_plan base_url was a docs page, not the API endpoint"
+        );
+        assert_eq!(
+            by_name.get("the_grid_ai").copied(),
+            Some("https://api.thegrid.ai/v1"),
+            "the_grid_ai base_url was a docs page, not the API endpoint"
+        );
+    }
+
+    #[test]
+    fn provider_rejects_templated_base_url_without_override() {
+        // Both placeholder forms must be rejected without an override:
+        // cloudflare uses `{CLOUDFLARE_ACCOUNT_ID}`, snowflake uses
+        // `<account-identifier>` — exercise both so `base_url_has_placeholder`
+        // can't silently lose one form.
+        for name in ["cloudflare", "snowflake"] {
+            let err = match provider(name, Some("dummy".into()), "m", None) {
+                Ok(_) => panic!("templated base_url for '{name}' without override must fail"),
+                Err(e) => e,
+            };
+            assert!(
+                matches!(err, AiMuxError::InvalidArgument(_)),
+                "expected InvalidArgument for '{name}' templated base_url, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_accepts_templated_base_url_with_override() {
+        // With a concrete base_url override, the templated entry must construct
+        // fine (key is dummy; we only assert it gets past validation).
+        let res = provider(
+            "cloudflare",
+            Some("dummy".into()),
+            "m",
+            Some(ProviderOptions {
+                base_url: Some("https://example.com/v1".into()),
+                ..Default::default()
+            }),
+        );
+        assert!(res.is_ok(), "override should bypass placeholder check");
     }
 
     #[test]

--- a/aimux-providers/src/provider_registry.json
+++ b/aimux-providers/src/provider_registry.json
@@ -1051,7 +1051,7 @@
   {
     "name": "moonshotai_cn",
     "display": "Moonshot AI (China)",
-    "base_url": "https://api.moonshot.cn/anthropic/v1（Anthropic",
+    "base_url": "https://api.moonshot.cn/anthropic/v1",
     "env_var": "MOONSHOT_API_KEY",
     "profile": {}
   },
@@ -1560,7 +1560,7 @@
   {
     "name": "the_grid_ai",
     "display": "The Grid AI",
-    "base_url": "https://thegrid.ai/docs",
+    "base_url": "https://api.thegrid.ai/v1",
     "env_var": "THEGRIDAI_API_KEY",
     "profile": {}
   },
@@ -1721,7 +1721,7 @@
   {
     "name": "xpersona",
     "display": "Xpersona",
-    "base_url": "/v1",
+    "base_url": "https://www.xpersona.co/v1",
     "env_var": "XPERSONA_API_KEY",
     "profile": {}
   },
@@ -1770,7 +1770,7 @@
   {
     "name": "zhipuai_coding_plan",
     "display": "Zhipu AI Coding Plan",
-    "base_url": "https://docs.bigmodel.cn/cn/coding-plan/quick-start",
+    "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
     "env_var": "ZHIPU_API_KEY",
     "profile": {}
   }

--- a/aimux-providers/tests/anthropic_cache_control_test.rs
+++ b/aimux-providers/tests/anthropic_cache_control_test.rs
@@ -1,4 +1,6 @@
-﻿//! Rust port of the Anthropic `cache_control` tests.
+﻿// Panic convert wrappers are #[deprecated]; these tests still use them.
+#![allow(deprecated)]
+//! Rust port of the Anthropic `cache_control` tests.
 //!
 //! Translated from the Vercel AI SDK TypeScript test suites:
 //! - `packages/anthropic/src/convert-to-anthropic-prompt.test.ts`

--- a/aimux-providers/tests/anthropic_convert_full_test.rs
+++ b/aimux-providers/tests/anthropic_convert_full_test.rs
@@ -1,4 +1,6 @@
-﻿//! Rust port of the remaining `convert-to-anthropic-prompt.test.ts` cases that
+﻿// Panic convert wrappers are #[deprecated]; these tests still use them.
+#![allow(deprecated)]
+//! Rust port of the remaining `convert-to-anthropic-prompt.test.ts` cases that
 //! exercise features now supported by the Rust data model: mid-conversation
 //! system messages, trailing-whitespace trimming, reasoning/thinking parts, URL
 //! & base64 file parts, PDF beta, top-level media-type detection, and

--- a/aimux-providers/tests/anthropic_convert_test.rs
+++ b/aimux-providers/tests/anthropic_convert_test.rs
@@ -1,4 +1,6 @@
-﻿//! Rust port of the Anthropic provider pure-function tests.
+﻿// Panic convert wrappers are #[deprecated]; these tests still use them.
+#![allow(deprecated)]
+//! Rust port of the Anthropic provider pure-function tests.
 //!
 //! Translated from the Vercel AI SDK TypeScript tests:
 //! - `packages/anthropic/src/convert-anthropic-usage.test.ts` (15 cases)

--- a/aimux-providers/tests/openai_convert_extended_test.rs
+++ b/aimux-providers/tests/openai_convert_extended_test.rs
@@ -1,4 +1,6 @@
-//! Extended OpenAI convert tests ??covers the previously-missing TS cases.
+// Panic convert wrappers are #[deprecated]; these tests still use them.
+#![allow(deprecated)]
+//! Extended OpenAI convert tests — covers the previously-missing TS cases.
 //!
 //! Sources:
 //! - `convert-to-openai-chat-messages.test.ts` (25 previously missing cases)

--- a/aimux-providers/tests/openai_convert_test.rs
+++ b/aimux-providers/tests/openai_convert_test.rs
@@ -1,4 +1,6 @@
-﻿//! Rust translations of the AI SDK OpenAI provider pure-function tests.
+﻿// Panic convert wrappers are #[deprecated]; these tests still use them.
+#![allow(deprecated)]
+//! Rust translations of the AI SDK OpenAI provider pure-function tests.
 //!
 //! Sources (TS → Rust):
 //! - `packages/openai/src/chat/convert-to-openai-chat-messages.test.ts`

--- a/aimux-providers/tests/tool_result_and_reasoning_fix_test.rs
+++ b/aimux-providers/tests/tool_result_and_reasoning_fix_test.rs
@@ -1,3 +1,5 @@
+// Panic convert wrappers are #[deprecated]; these tests still use them.
+#![allow(deprecated)]
 //! Regression tests for two issues reported against aimux 0.1.1 when driving
 //! OpenAI-compatible thinking models (e.g. DeepSeek `deepseek-v4-flash`) in
 //! multi-turn tool-call conversations:

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -3,7 +3,7 @@
 > **GENERATED** by `scripts/gen_providers_doc.py` — do not edit by hand.
 > Regenerate with: `python scripts/gen_providers_doc.py`
 
-**251 registry-backed OpenAI-compatible providers** (construct via `provider(name, ...)` / `ProviderName`) + **76 non-registry providers** (construct via the typed factories listed below).
+**251 registry-backed OpenAI-compatible providers** (construct via `provider(name, ...)` / `ProviderName`) + **78 non-registry providers** (construct via the typed factories listed below).
 
 ## Registry-backed (OpenAI-compatible) — 251
 
@@ -158,7 +158,7 @@
 | `model_oracle_ai` | Model Oracle AI | `MODEL_ORACLE_API_KEY` | `https://api.modeloracle.com/api/v1` |
 | `modelscope` | ModelScope | `MODELSCOPE_API_KEY` | `https://api-inference.modelscope.cn/v1` |
 | `moonshotai` | Moonshot AI | `MOONSHOT_API_KEY` | `https://api.moonshot.cn/v1` |
-| `moonshotai_cn` | Moonshot AI (China) | `MOONSHOT_API_KEY` | `https://api.moonshot.cn/anthropic/v1（Anthropic` |
+| `moonshotai_cn` | Moonshot AI (China) | `MOONSHOT_API_KEY` | `https://api.moonshot.cn/anthropic/v1` |
 | `morph` | Morph LLM | `MORPH_API_KEY` | `https://api.morphllm.com/v1` |
 | `nanogpt` | NanoGPT | `NANOGPT_API_KEY` | `https://api.nanogpt.com/v1` |
 | `ncompass` | Ncompass | `NCOMPASS_API_KEY` | `https://api.ncompass.tech/v1` |
@@ -229,7 +229,7 @@
 | `tencent_token_plan_hy_personal` | 腾讯云 Token Plan / Hy Token Plan（个人版） | `TENCENT_TOKEN_PLAN_API_KEY` | `https://api.lkeap.cloud.tencent.com/plan/v3` |
 | `tencent_tokenhub` | Tencent TokenHub | `TENCENT_TOKENHUB_API_KEY` | `https://tokenhub.tencentmaas.com/v1` |
 | `tensormesh` | Tensormesh | `YOUR_API_KEY` | `https://serverless.tensormesh.ai` |
-| `the_grid_ai` | The Grid AI | `THEGRIDAI_API_KEY` | `https://thegrid.ai/docs` |
+| `the_grid_ai` | The Grid AI | `THEGRIDAI_API_KEY` | `https://api.thegrid.ai/v1` |
 | `thinkingmachines` | Thinking Machines | `TINKER_API_KEY` | `https://tinker.thinkingmachines.dev/services/tinker-prod/oai/api/v1` |
 | `tinfoil` | Tinfoil | `TINFOIL_API_KEY` | `https://inference.tinfoil.sh/v1` |
 | `togetherai` | Together AI | `TOGETHER_API_KEY` | `https://api.together.xyz/v1` |
@@ -252,14 +252,14 @@
 | `xiaomi_token_plan_cn` | Xiaomi Token Plan (China) | `MIMO_API_KEY` | `https://token-plan-cn.xiaomimimo.com/v1` |
 | `xiaomi_token_plan_sgp` | Xiaomi Token Plan (Singapore) | `MIMO_API_KEY` | `https://token-plan-sgp.xiaomimimo.com/v1` |
 | `xiaomimimo` | Xiaomi MiMo | `XIAOMI_API_KEY` | `https://mimo.xiaomi.com/v1` |
-| `xpersona` | Xpersona | `XPERSONA_API_KEY` | `/v1` |
+| `xpersona` | Xpersona | `XPERSONA_API_KEY` | `https://www.xpersona.co/v1` |
 | `xunfei` | Xunfei | `XUNFEI_API_PASSWORD` | `https://spark-api-open.xf-yun.com/v1` |
 | `zai` | Zai | `ZAI_API_KEY` | `https://api.z.ai/api/paas/v4` |
 | `zai_coding_plan` | Z.AI Coding Plan | `ZHIPU_API_KEY` | `https://api.z.ai/api/anthropic` |
 | `zeldoc` | Zeldoc | `ZELDOC_API_KEY` | `https://api.zeldoc.ai/v1` |
 | `zenmux` | ZenMux | `ZENMUX_API_KEY` | `https://zenmux.ai/api/v1` |
 | `zhipu_v4` | ZhipuV4 | `ZHIPU_API_KEY` | `https://open.bigmodel.cn/api/paas/v4` |
-| `zhipuai_coding_plan` | Zhipu AI Coding Plan | `ZHIPU_API_KEY` | `https://docs.bigmodel.cn/cn/coding-plan/quick-start` |
+| `zhipuai_coding_plan` | Zhipu AI Coding Plan | `ZHIPU_API_KEY` | `https://open.bigmodel.cn/api/coding/paas/v4` |
 
 ## Typed factories (non-registry)
 
@@ -269,6 +269,8 @@ These providers are **not** name-addressable: `provider("anthropic", ...)` fails
 
 | module | typed entry points |
 |--------|--------------------|
+| `replay` | — |
+| `catalogue` | `Catalogue` |
 | `anthropic` | `AnthropicConfig` / `AnthropicProvider` |
 | `anthropic_aws` | `AnthropicAwsConfig` / `AnthropicAwsProvider` |
 | `azure` | `AzureConfig` / `AzureProvider` |


### PR DESCRIPTION
## Summary

Addresses **R1 + R2** of the 2026-08-07 architecture audit (#90). R3 (structured `AiMuxError`) is deferred to a future RFC — not in scope here.

**Non-breaking:** R1 deprecates+hides existing functions (still callable, but with compile-time warning); R2 fixes values that were already broken (unusable as-is). The one behavior change: templated registry entries (cloudflare/snowflake/neon/oci) now reject `provider()` with `InvalidArgument` unless a `base_url` override is passed — but such calls were already broken (would fail at the HTTP layer), so this is a bug fix, not a regression.

## R1 — panic convert wrappers deprecated + hidden from public API

The 4 panic/`.expect()` convert wrappers in anthropic/openai were still `pub fn`. Production paths (`model.rs`, `aimux-ffi`) already use the `*_fallible` variants — these wrappers were only referenced by integration tests under `tests/`. However, release builds use `panic = "abort"`, so any future misuse via FFI would kill the host process.

**Fix:** marked all 4 `#[doc(hidden)]` **+** `#[deprecated]` — hidden from docs/auto-complete AND any external call site gets a compile-time warning directing them to the fallible variant. Integration tests under `tests/` (the only callers) opt out with `#![allow(deprecated)]`.

| file | function |
|---|---|
| `anthropic/convert.rs` | `convert_prompt_to_anthropic_full`, `convert_prompt_to_anthropic` |
| `openai/convert.rs` | `convert_prompt_to_openai_messages`, `convert_prompt_to_openai_messages_with_mode` |

## R2 — registry base_url data quality

### Data fixes (4 entries)
| provider | was | now | cause |
|---|---|---|---|
| `xpersona` | `/v1` | `https://www.xpersona.co/v1` | truncated (missing scheme+host); confirmed via provider-inventory + xpersona.co/docs |
| `moonshotai_cn` | `https://api.moonshot.cn/anthropic/v1（Anthropic` | `https://api.moonshot.cn/anthropic/v1` | leaked annotation suffix "（Anthropic" |
| `zhipuai_coding_plan` | `https://docs.bigmodel.cn/cn/coding-plan/quick-start` | `https://open.bigmodel.cn/api/coding/paas/v4` | doc page used as API base |
| `the_grid_ai` | `https://thegrid.ai/docs` | `https://api.thegrid.ai/v1` | doc page used as API base (same class as zhipuai_coding_plan; not in audit's original list, found by independent review) |

Evidence: `provider-inventory/providers.json` + internal research batches + official docs. The `zhipuai_coding_plan` endpoint differs from sibling `zhipu_v4` (`/paas/v4`) by an extra `/coding` segment — using the wrong one silently fails to consume plan quota.

### Construct-time validation (templated entries kept)
6 entries with intentional placeholders are **kept** (cloudflare, cloudflare_workers_ai, neon, snowflake, snowflake_cortex, oci) — they require a user-supplied account ID. But `provider_handle()` now rejects them with `InvalidArgument` unless a concrete `base_url` is passed via `ProviderOptions`:

```rust
provider("cloudflare", None, "m", None)
// → Err(InvalidArgument("...templated base_url ... pass a concrete base_url via ProviderOptions"))
```

### Data-integrity tests (replace the audit's "optional CI check")
Two lib tests guard registry hygiene (run on every `cargo test`, no CI config needed):
- `registry_no_corrupt_base_urls` — every base_url must be `http(s)://` + ASCII
- `registry_fixed_base_urls_are_correct` — pins the 4 corrected values (regression guard)

## Derived files regenerated
- `scripts/gen_provider_names.py` → `provider_name.rs` + 8 language bindings (no change — only base_url values were wrong)
- `scripts/gen_providers_doc.py` → `docs/api/providers.md`

## Tests
- `registry_no_corrupt_base_urls` — data-integrity guard (all 251 entries)
- `registry_fixed_base_urls_are_correct` — pins the 4 corrected base_urls
- `provider_rejects_templated_base_url_without_override` — covers **both** placeholder forms (`{` via cloudflare, `<` via snowflake)
- `provider_accepts_templated_base_url_with_override`

## Verification
- ✅ `cargo build -p aimux-providers` (no warnings)
- ✅ `cargo test -p aimux-providers --lib` (12 pass in `provider::tests::*`; 63 total)
- ✅ `cargo fmt -p aimux-providers --check`
- ✅ `cargo clippy` clean on touched files

## Pre-existing failures (unrelated)
- `anthropic_aws_sigv4_auth` — network test (HTTP 502), fails on `master` too
- `black_forest_labs.rs:319` clippy lint (`search_is_some`) — clippy version drift, fails on `master` too

## Review history
Two independent architecture reviews shaped this PR:
1. **First review** caught that the initial version deleted `xpersona` (based on the assumption that `/v1` meant "no public API"). It pointed to `provider-inventory/providers.json` which records `https://www.xpersona.co/v1` — the registry value was a truncation. Corrected to fix the base_url instead. It also pushed R1 from `#[doc(hidden)]` alone to `#[doc(hidden)]` + `#[deprecated]`.
2. **Second review (fresh eyes)** independently scanned all 251 entries and found `the_grid_ai` (`https://thegrid.ai/docs`) — the same docs-page-as-base class as `zhipuai_coding_plan`, missed by the audit and the first review. Added to this PR. It also noted the `<` placeholder form wasn't covered by tests — fixed.

Follow-up items noted by reviewers (not in scope here): migrate integration tests off the deprecated wrappers and delete them entirely (audit's "keep fallible-only" ideal); optional runtime scheme validation for defense-in-depth.

Connected to #90 (R1 + R2 only; R3 deferred to a future RFC).
