### PR TITLE
fix(error)!: carry the retry verdict across the ABI and scope payload fields to their error class

### DIFF
--- a/aimux-core/src/error.rs
+++ b/aimux-core/src/error.rs
@@ -38,7 +38,10 @@ pub struct ApiCallError {
     /// status. Our normalized take on `APICallError.data`.
     #[serde(default)]
     pub provider_code: Option<String>,
-    /// The provider's message, verbatim. No status prefix.
+    /// The failure's own text, without a status prefix — `Display` adds
+    /// that. Usually the provider's words as extracted from the body; on a
+    /// transport failure, or a body the extractor could not read, it is
+    /// ours. `response_body` is the lossless evidence either way.
     pub message: String,
     /// The raw response body, verbatim (`APICallError.responseBody`) — the
     /// lossless evidence when `message`/`provider_code` are extractions.
@@ -49,9 +52,13 @@ pub struct ApiCallError {
     /// response header when one was sent. Filled by the shared HTTP layer.
     #[serde(default)]
     pub request_id: Option<String>,
-    /// Retry hint in milliseconds, distilled from the `retry-after-ms` /
-    /// `retry-after` response headers on a 429. The classification lives in
-    /// `status_code`; this is the matching action input.
+    /// Retry hint in milliseconds, when the provider advertised one. Two
+    /// sources: the `retry-after-ms` / `retry-after` response headers on any
+    /// retryable status (RFC 7231 defines `Retry-After` for 503 as well as
+    /// 429), and the `retry_after_ms` / `retry_after` members of a JSON error
+    /// payload, which arrive on whatever status that payload came with. The
+    /// classification lives in `status_code`; this is the matching action
+    /// input, and it is never fabricated locally.
     #[serde(default)]
     #[ts(type = "number | null")]
     pub retry_after_ms: Option<u64>,
@@ -125,6 +132,14 @@ pub enum AiMuxError {
     /// Registry-level "model id does not resolve" (the AI SDK's
     /// `NoSuchModelError { modelId, modelType }`). Pre-HTTP: the upstream API
     /// was never called, so there is no status.
+    ///
+    /// **Reserved — nothing constructs this yet.** `provider(name, key,
+    /// model_id)` does not validate the model id against the catalogue, so an
+    /// unknown model reaches the wire and comes back as an `ApiCall` 404. The
+    /// variant and its bindings exist so that resolution, when it lands, has a
+    /// shape to report; until then, do not branch on it expecting coverage of
+    /// mistyped model ids. Contrast [`AiMuxError::NoSuchProvider`], which
+    /// `provider()` does raise.
     #[error("no such model: {model_id}")]
     NoSuchModel {
         model_id: String,
@@ -180,10 +195,10 @@ impl AiMuxError {
     }
 
     /// Returns the retry-after delay hint (in milliseconds) carried by this
-    /// error, if any — distilled from the `retry-after-ms` / `retry-after`
-    /// response headers into [`ApiCallError::retry_after_ms`]. Returns `None`
-    /// for errors that don't advertise a delay, in which case the retry
-    /// strategy falls back to exponential backoff.
+    /// error, if any — whatever reached [`ApiCallError::retry_after_ms`],
+    /// from either the response headers or a JSON error payload. Returns
+    /// `None` for errors that don't advertise a delay, in which case the
+    /// retry strategy falls back to exponential backoff.
     ///
     /// Mirrors the header-consulting behaviour of
     /// `retryWithExponentialBackoffRespectingRetryHeaders` in the TS SDK.

--- a/aimux-ffi/aimux-error.h
+++ b/aimux-ffi/aimux-error.h
@@ -66,11 +66,19 @@ typedef struct AimuxError {
     char *message;
     char *error_value;
     /**
+     * 1 when retrying may help, 0 when it will not — the core's retry
+     * verdict, stored at construction. Do NOT infer it from `status`: a
+     * statusless AIMUX_E_API_CALL is a transport failure (retryable) when the
+     * request went out, and a missing API key (not retryable) when it never
+     * did. The callee always writes this field.
+     */
+    int retryable;
+    /**
      * Reserved for future ABI extension. Must be zero; the callee zeroes it
      * on failure. The struct size is part of the caller-allocated ABI and
-     * can never change — this slot is the only room left to grow.
+     * can never change — this is the room left to grow.
      */
-    void *reserved[1];
+    int reserved;
 } AimuxError;
 
 /**
@@ -87,7 +95,8 @@ static inline void aimux_error_clear(AimuxError *e) {
     e->retry_ms = -1;
     e->message = 0;
     e->error_value = 0;
-    e->reserved[0] = 0;
+    e->retryable = 0;
+    e->reserved = 0;
 }
 
 #ifdef __cplusplus

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -332,7 +332,11 @@ pub struct CAimuxError {
     pub retry_ms: i64,
     pub message: *mut c_char,
     pub error_value: *mut c_char,
-    pub reserved: [*mut c_void; 1],
+    /// `1` when retrying may help, `0` when it will not — the core's
+    /// `AiMuxError::is_retryable()`. Do not infer this from `status`: a
+    /// statusless `ApiCall` may be either.
+    pub retryable: i32,
+    pub reserved: i32,
 }
 
 fn aimux_error_code(err: &AiMuxError) -> i32 {
@@ -354,7 +358,14 @@ fn aimux_error_code(err: &AiMuxError) -> i32 {
 }
 
 /// # Safety: `err` null or writable `CAimuxError`.
-unsafe fn fill_error(err: *mut CAimuxError, code: i32, status: i32, retry_ms: i64, msg: &str) {
+unsafe fn fill_error(
+    err: *mut CAimuxError,
+    code: i32,
+    status: i32,
+    retry_ms: i64,
+    retryable: bool,
+    msg: &str,
+) {
     if err.is_null() {
         return;
     }
@@ -364,7 +375,8 @@ unsafe fn fill_error(err: *mut CAimuxError, code: i32, status: i32, retry_ms: i6
     e.retry_ms = retry_ms;
     e.message = into_cstring_raw(msg.to_string());
     e.error_value = std::ptr::null_mut();
-    e.reserved = [std::ptr::null_mut(); 1];
+    e.retryable = i32::from(retryable);
+    e.reserved = 0;
 }
 
 /// # Safety: `err` null or writable `CAimuxError`.
@@ -373,7 +385,7 @@ unsafe fn fill_from_aimux(err: *mut CAimuxError, ae: &AiMuxError) {
     let status = ae.status_code().map(|s| s as i32).unwrap_or(-1);
     let retry_ms = ae.retry_after_hint().unwrap_or(-1);
     let msg = ae.to_string();
-    unsafe { fill_error(err, code, status, retry_ms, &msg) };
+    unsafe { fill_error(err, code, status, retry_ms, ae.is_retryable(), &msg) };
     if err.is_null() {
         return;
     }
@@ -414,7 +426,9 @@ unsafe fn fail<T: Sentinel>(
     retry_ms: i64,
     msg: &str,
 ) -> T {
-    unsafe { fill_error(err, code, status, retry_ms, msg) };
+    // Boundary-synthesized failures (bad argument, unparseable JSON) are
+    // never retryable — same verdict the core gives every non-ApiCall variant.
+    unsafe { fill_error(err, code, status, retry_ms, false, msg) };
     T::sentinel()
 }
 
@@ -581,7 +595,7 @@ fn normalize_config_json(config_json: *const c_char, err: *mut CAimuxError) -> O
     }
     match cstr_to_string(config_json) {
         None => unsafe {
-            fill_error(err, AIMUX_E_INVALID_ARGUMENT, -1, -1, INVALID_ARGS);
+            fill_error(err, AIMUX_E_INVALID_ARGUMENT, -1, -1, false, INVALID_ARGS);
             None
         },
         Some(s) if s.trim().is_empty() || s.trim() == "null" => Some(String::from("{}")),
@@ -2914,6 +2928,43 @@ mod tests {
         assert_eq!(std::mem::size_of::<CAimuxError>(), 40);
     }
 
+    /// The retry verdict crosses the ABI as a field. It is not derivable from
+    /// `status`: both cases below report -1, and they disagree.
+    #[test]
+    fn retryable_crosses_the_abi_and_status_cannot_stand_in() {
+        let mut c = CAimuxError {
+            code: AIMUX_OK,
+            status: 0,
+            retry_ms: 0,
+            message: std::ptr::null_mut(),
+            error_value: std::ptr::null_mut(),
+            retryable: 0,
+            reserved: 0,
+        };
+
+        let transport = AiMuxError::ApiCall(ApiCallError {
+            message: "connection reset".into(),
+            is_retryable: true,
+            ..Default::default()
+        });
+        unsafe { fill_from_aimux(&mut c, &transport) };
+        assert_eq!(c.status, -1);
+        assert_eq!(c.retryable, 1);
+        assert_eq!(c.reserved, 0);
+
+        let no_key = AiMuxError::ApiCall(ApiCallError {
+            message: "no api key".into(),
+            ..Default::default()
+        });
+        unsafe { fill_from_aimux(&mut c, &no_key) };
+        assert_eq!(c.status, -1, "same sentinel as the transport failure");
+        assert_eq!(c.retryable, 0, "but the opposite verdict");
+
+        // Non-ApiCall variants are never retryable.
+        unsafe { fill_from_aimux(&mut c, &AiMuxError::InvalidArgument("bad".into())) };
+        assert_eq!(c.retryable, 0);
+    }
+
     /// Pin the full 13-variant → code mapping and the status/retry derivation.
     #[test]
     fn error_code_mapping_covers_all_variants() {
@@ -2970,7 +3021,8 @@ mod tests {
             retry_ms: 0,
             message: std::ptr::null_mut(),
             error_value: std::ptr::null_mut(),
-            reserved: [std::ptr::null_mut(); 1],
+            retryable: 0,
+            reserved: 0,
         };
         // A 429 is an ApiCall error; code is AIMUX_E_API_CALL and the
         // classification/hint cross the ABI as status/retry_ms.
@@ -3004,9 +3056,10 @@ mod tests {
             retry_ms: -1,
             message: std::ptr::null_mut(),
             error_value: std::ptr::null_mut(),
-            reserved: [std::ptr::null_mut(); 1],
+            retryable: 0,
+            reserved: 0,
         };
-        unsafe { fill_error(&mut c, AIMUX_E_OTHER, -1, -1, "a\0b") };
+        unsafe { fill_error(&mut c, AIMUX_E_OTHER, -1, -1, false, "a\0b") };
         let m = unsafe { CStr::from_ptr(c.message) }.to_str().unwrap();
         assert_eq!(m, "a\u{FFFD}b");
         unsafe { aimux_free_string(c.message) };
@@ -3197,7 +3250,8 @@ mod tests {
             retry_ms: 0,
             message: std::ptr::null_mut(),
             error_value: std::ptr::null_mut(),
-            reserved: [std::ptr::null_mut(); 1],
+            retryable: 0,
+            reserved: 0,
         }
     }
 

--- a/aimux-ffi/tests/error_detail_test.rs
+++ b/aimux-ffi/tests/error_detail_test.rs
@@ -30,7 +30,8 @@ fn clear_err() -> CAimuxError {
         retry_ms: -1,
         message: ptr::null_mut(),
         error_value: std::ptr::null_mut(),
-        reserved: [std::ptr::null_mut(); 1],
+        retryable: 0,
+        reserved: 0,
     }
 }
 
@@ -208,13 +209,15 @@ fn success_leaves_err_untouched() {
         retry_ms: 7,
         message: ptr::null_mut(),
         error_value: std::ptr::null_mut(),
-        reserved: [std::ptr::null_mut(); 1],
+        retryable: 1,
+        reserved: 0,
     };
     let h = aimux_openai_new(c("sk-test").as_ptr(), c("gpt-4o-mini").as_ptr(), &mut err);
     assert_ne!(h, 0);
     assert_eq!(err.code, AIMUX_E_OTHER, "success must not write err.code");
     assert_eq!(err.status, 42);
     assert_eq!(err.retry_ms, 7);
+    assert_eq!(err.retryable, 1, "success must not write err.retryable");
     assert!(err.message.is_null());
     aimux_drop_handle(h);
 }

--- a/aimux-ffi/tests/native_constructors_test.rs
+++ b/aimux-ffi/tests/native_constructors_test.rs
@@ -27,7 +27,8 @@ fn clear_err() -> CAimuxError {
         retry_ms: -1,
         message: std::ptr::null_mut(),
         error_value: std::ptr::null_mut(),
-        reserved: [std::ptr::null_mut(); 1],
+        retryable: 0,
+        reserved: 0,
     }
 }
 

--- a/aimux-ffi/tests/provider_handle_test.rs
+++ b/aimux-ffi/tests/provider_handle_test.rs
@@ -25,7 +25,8 @@ fn clear_err() -> CAimuxError {
         retry_ms: -1,
         message: std::ptr::null_mut(),
         error_value: std::ptr::null_mut(),
-        reserved: [std::ptr::null_mut(); 1],
+        retryable: 0,
+        reserved: 0,
     }
 }
 

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -1304,10 +1304,12 @@ async fn send_with_retry_raw(
                     .find_map(|k| resp.headers().get(*k))
                     .and_then(|v| v.to_str().ok())
                     .map(str::to_owned);
-                // Retry hint: stored only for 429 (current core contract).
-                // Missing/invalid/negative header → None; never fabricate a
-                // local fallback as provider data (RFC-0009 §4.2).
-                let retry_after_ms = (status_code == 429)
+                // Retry hint: read for every retryable status, not 429
+                // alone — RFC 7231 defines Retry-After for 503 too, and the
+                // AI SDK's backoff consults the header on any retryable
+                // failure. Missing/invalid/negative header → None; never
+                // fabricate a local fallback as provider data (RFC-0009 §4.2).
+                let retry_after_ms = (matches!(status_code, 408 | 409 | 429) || status_code >= 500)
                     .then(|| {
                         parse_retry_after(
                             resp.headers()

--- a/aimux-provider-utils/tests/structured_error_fields.rs
+++ b/aimux-provider-utils/tests/structured_error_fields.rs
@@ -234,6 +234,52 @@ fn retry_policy_includes_408_and_409() {
     assert!(!parse_provider_error(400, "", &DEFAULT_ERROR_STRUCTURE).is_retryable());
 }
 
+/// A `Retry-After` header is honoured on every retryable status, not on 429
+/// alone — RFC 7231 defines it for 503 too, and the AI SDK's backoff reads it
+/// for any retryable failure. A non-retryable status still takes no hint.
+#[tokio::test]
+async fn retry_after_is_read_on_every_retryable_status() {
+    use aimux_provider_utils::{HttpBody, HttpMethod, HttpRequest, RetryConfig, send};
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn hint_for(status: u16) -> Option<i64> {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(status).insert_header("retry-after-ms", "1500"))
+            .mount(&server)
+            .await;
+
+        let request = HttpRequest {
+            method: HttpMethod::Post,
+            url: server.uri(),
+            headers: vec![],
+            body: HttpBody::Json(serde_json::json!({})),
+            abort_signal: None,
+            call_id: None,
+            recording_context: None,
+        };
+        let no_retry = RetryConfig {
+            max_retries: 0,
+            ..RetryConfig::default()
+        };
+        send(request, no_retry, &DEFAULT_ERROR_STRUCTURE)
+            .await
+            .unwrap_err()
+            .retry_after_hint()
+    }
+
+    for status in [503u16, 408, 429] {
+        assert_eq!(
+            hint_for(status).await,
+            Some(1500),
+            "status {status} advertised a retry hint and it must survive"
+        );
+    }
+    // 400 is not retryable, so the header is not taken as provider data.
+    assert_eq!(hint_for(400).await, None);
+}
+
 /// §9.1 shared non-2xx regression, through the real HTTP loop: every non-2xx
 /// goes through the provider error parser (extracted message/code + raw body
 /// survive), the observed request id is attached to the same detail, and a

--- a/aimux-providers/src/catalogue.rs
+++ b/aimux-providers/src/catalogue.rs
@@ -412,7 +412,7 @@ async fn fetch_text(url: &str) -> Result<String, AiMuxError> {
             status_code: Some(status),
             message: format!("get_model_specs: fetch {url}"),
             response_body: resp.text().await.ok().filter(|b| !b.is_empty()),
-            is_retryable: status == 429 || status >= 500,
+            is_retryable: matches!(status, 408 | 409 | 429) || status >= 500,
             ..Default::default()
         }));
     }

--- a/bindings/c/example.c
+++ b/bindings/c/example.c
@@ -12,11 +12,12 @@
 #include "aimux-error.h"
 #include "aimux-ffi.h"
 
-// Print the failure, then release e->message (owned by the caller).
-static void report(const char *what, AimuxError *e) {
+// Print the failure, release e->message (owned by the caller), and hand back
+// the callee's retry verdict: 1 when retrying may help, 0 when it will not.
+static int report(const char *what, AimuxError *e) {
     if (!e || e->code == AIMUX_OK) {
         fprintf(stderr, "%s: failed\n", what);
-        return;
+        return 0;
     }
     switch (e->code) {
     // Every HTTP-shaped failure arrives as AIMUX_E_API_CALL; classify on status.
@@ -41,8 +42,10 @@ static void report(const char *what, AimuxError *e) {
         } else {
             // status == -1: no HTTP response was ever observed — a missing API
             // key, an error built without a request, or a transport failure.
-            // Says nothing about whether a retry would help.
-            fprintf(stderr, "%s: no HTTP response: %s\n", what, e->message);
+            // Which one it was is e->retryable, never the status: those shapes
+            // both report -1 and disagree about whether a retry helps.
+            fprintf(stderr, "%s: no HTTP response (%s): %s\n", what,
+                    e->retryable ? "retryable" : "not retryable", e->message);
         }
         break;
     case AIMUX_E_TOKEN_EXPIRED:
@@ -56,6 +59,7 @@ static void report(const char *what, AimuxError *e) {
     aimux_free_string(e->error_value);
     e->message = NULL;
     e->error_value = NULL;
+    return e->retryable;
 }
 
 static void on_part(const char *json, void *stream_ctx) {
@@ -89,9 +93,14 @@ int main(void) {
     // 2. Generate text (non-streaming) — failure: result == NULL
     const char *prompt = "\"Explain Rust ownership in one sentence.\"";
     char *result = aimux_generate_text(handle, prompt, NULL, &err);
-    if (!result) {
-        report("generate_text", &err);
-    } else {
+    if (!result && report("generate_text", &err)) {
+        // Retry on the callee's verdict, not on the status sentinel.
+        result = aimux_generate_text(handle, prompt, NULL, &err);
+        if (!result) {
+            report("generate_text (retry)", &err);
+        }
+    }
+    if (result) {
         printf("Result: %s\n", result);
         aimux_free_string(result);
     }

--- a/bindings/c/example.c
+++ b/bindings/c/example.c
@@ -22,8 +22,16 @@ static void report(const char *what, AimuxError *e) {
     // Every HTTP-shaped failure arrives as AIMUX_E_API_CALL; classify on status.
     case AIMUX_E_API_CALL:
         if (e->status == 429) {
-            fprintf(stderr, "%s: rate limited, retry in %lldms: %s\n", what,
-                    (long long)e->retry_ms, e->message);
+            // retry_ms is -1 when the 429 carried no retry-after header —
+            // fall back to your own exponential backoff.
+            if (e->retry_ms >= 0) {
+                fprintf(stderr, "%s: rate limited, retry in %lldms: %s\n", what,
+                        (long long)e->retry_ms, e->message);
+            } else {
+                fprintf(stderr, "%s: rate limited, no retry-after hint, back off "
+                                "exponentially: %s\n",
+                        what, e->message);
+            }
         } else if (e->status == 401) {
             fprintf(stderr, "%s: auth (HTTP 401): %s\n", what, e->message);
         } else if (e->status == 404) {
@@ -31,8 +39,10 @@ static void report(const char *what, AimuxError *e) {
         } else if (e->status >= 0) {
             fprintf(stderr, "%s: HTTP %d: %s\n", what, e->status, e->message);
         } else {
-            // No status: transport failure, retryable.
-            fprintf(stderr, "%s: transport: %s\n", what, e->message);
+            // status == -1: no HTTP response was ever observed — a missing API
+            // key, an error built without a request, or a transport failure.
+            // Says nothing about whether a retry would help.
+            fprintf(stderr, "%s: no HTTP response: %s\n", what, e->message);
         }
         break;
     case AIMUX_E_TOKEN_EXPIRED:

--- a/bindings/c/example.cpp
+++ b/bindings/c/example.cpp
@@ -166,7 +166,13 @@ int main() {
         std::cerr << "Error: " << e.what() << "\n";
         // HTTP-shaped failures are all AIMUX_E_API_CALL; status is the classification.
         if (e.code() == AIMUX_E_API_CALL && e.status() == 429) {
-            std::cerr << "rate limited, retry_ms=" << e.retryMs() << "\n";
+            // retryMs() is -1 when the 429 carried no retry-after header —
+            // fall back to your own exponential backoff.
+            if (e.retryMs() >= 0) {
+                std::cerr << "rate limited, retry_ms=" << e.retryMs() << "\n";
+            } else {
+                std::cerr << "rate limited, no retry-after hint, back off exponentially\n";
+            }
         }
         return 1;
     } catch (const std::exception &e) {

--- a/bindings/c/example.cpp
+++ b/bindings/c/example.cpp
@@ -20,6 +20,7 @@ public:
     AimuxException(const std::string &context, AimuxError &e)
         : std::runtime_error(context + ": " + (e.message ? e.message : "failed")),
           code_(e.code), status_(e.status), retry_ms_(e.retry_ms),
+          retryable_(e.retryable != 0),
           error_value_(e.error_value ? e.error_value : "") {
         aimux_free_string(e.message);
         aimux_free_string(e.error_value);
@@ -34,6 +35,10 @@ public:
     AimuxErrorCode code() const { return code_; }
     int status() const { return status_; }
     int64_t retryMs() const { return retry_ms_; }
+    /** The callee's verdict: true when retrying may help. Not derivable from
+     *  status() — a transport failure and a missing API key both report -1
+     *  and disagree here. */
+    bool retryable() const { return retryable_; }
     /** Lossless AiMuxError JSON, or "" for FFI-synthesized failures. */
     const std::string &errorValue() const { return error_value_; }
 
@@ -41,6 +46,7 @@ private:
     AimuxErrorCode code_ = AIMUX_E_UNKNOWN;
     int status_ = -1;
     int64_t retry_ms_ = -1;
+    bool retryable_ = false;
     std::string error_value_;
 };
 
@@ -164,14 +170,16 @@ int main() {
 
     } catch (const AimuxException &e) {
         std::cerr << "Error: " << e.what() << "\n";
-        // HTTP-shaped failures are all AIMUX_E_API_CALL; status is the classification.
-        if (e.code() == AIMUX_E_API_CALL && e.status() == 429) {
-            // retryMs() is -1 when the 429 carried no retry-after header —
-            // fall back to your own exponential backoff.
+        // Whether to retry is the callee's verdict, not a guess from status:
+        // a statusless failure is a transport blip (retryable) or a missing
+        // API key (not), and both report status() == -1.
+        if (e.retryable()) {
+            // retryMs() is -1 when no retry-after hint arrived — fall back to
+            // your own exponential backoff.
             if (e.retryMs() >= 0) {
-                std::cerr << "rate limited, retry_ms=" << e.retryMs() << "\n";
+                std::cerr << "retryable, retry_ms=" << e.retryMs() << "\n";
             } else {
-                std::cerr << "rate limited, no retry-after hint, back off exponentially\n";
+                std::cerr << "retryable, no retry-after hint, back off exponentially\n";
             }
         }
         return 1;

--- a/bindings/flutter/lib/errors.dart
+++ b/bindings/flutter/lib/errors.dart
@@ -24,7 +24,8 @@ import 'package:ffi/ffi.dart';
 /// 14 variant codes, numbered consecutively 1–14. Every HTTP-shaped failure
 /// arrives as [apiCall], classified
 /// by [AimuxException.status] (401 auth, 404 model, 429 rate limit;
-/// no status = transport failure).
+/// -1 = no HTTP response was ever observed — a missing API key, an error
+/// built without a request, or a transport failure).
 abstract final class AimuxErrorCode {
   static const int ok = 0;
   static const int unknown = 1;
@@ -407,7 +408,9 @@ class NoSuchProviderError extends AimuxException {
 
 /// Provider API call failed (AI SDK `APICallError` analogue) — every
 /// HTTP-shaped failure. [status] is the classification (401 auth, 404 model,
-/// 429 rate limit + [retryMs]); `-1` means no response arrived (transport).
+/// 429 rate limit + [retryMs]); `-1` means no HTTP response was ever observed
+/// — a missing API key, an error built without a request, or a transport
+/// failure — and says nothing about whether a retry would help.
 class APICallError extends AimuxException {
   APICallError(super.message, {super.status, super.retryMs, super.errorValue})
       : super(code: AimuxErrorCode.apiCall);

--- a/bindings/flutter/lib/errors.dart
+++ b/bindings/flutter/lib/errors.dart
@@ -73,8 +73,8 @@ abstract final class AimuxErrorCode {
 ///
 /// Layout must match `aimux-error.h` / Rust `CAimuxError` (`#[repr(C)]`):
 /// `code:i32`, `status:i32`, `retry_ms:i64`, `message:char*`,
-/// `error_value:char*`, plus one reserved pointer slot for future ABI
-/// extension (always zero).
+/// `error_value:char*`, `retryable:i32`, plus an `i32` reserved slot for
+/// future ABI extension (always zero).
 ///
 /// On failure the callee allocates [message] and optionally [errorValue]
 /// (lossless externally-tagged core `AiMuxError` JSON; NULL for
@@ -95,7 +95,11 @@ final class AimuxCError extends Struct {
 
   external Pointer<Utf8> errorValue;
 
-  external Pointer<Void> reserved0;
+  @Int32()
+  external int retryable;
+
+  @Int32()
+  external int reserved;
 }
 
 /// Reset [err] to OK / no hint / no message (mirrors `aimux_error_clear`).
@@ -105,7 +109,8 @@ void clearAimuxCError(Pointer<AimuxCError> err) {
   err.ref.retryMs = -1;
   err.ref.message = nullptr;
   err.ref.errorValue = nullptr;
-  err.ref.reserved0 = nullptr;
+  err.ref.retryable = 0;
+  err.ref.reserved = 0;
 }
 
 /// Allocate a cleared [AimuxCError], run [fn], free the engine-allocated
@@ -227,6 +232,7 @@ int construct2(
 /// - [code]: kind ([AimuxErrorCode])
 /// - [status]: HTTP status, or `-1`
 /// - [retryMs]: rate-limit hint, or `-1` (`0` = retry now)
+/// - [retryable]: whether retrying may help
 /// - [message]: human-readable text
 /// - [errorValue]: raw lossless core-error JSON, or `null`
 class AimuxException implements Exception {
@@ -242,6 +248,12 @@ class AimuxException implements Exception {
   /// Rate-limit hint in ms; `-1` if none; `0` means retry immediately.
   final int retryMs;
 
+  /// Whether retrying may help — the engine's verdict, carried across the C
+  /// ABI. Not derivable from [status]: a transport failure (request went out,
+  /// connection reset) and a missing API key (request never went out) both
+  /// report `status == -1` and disagree here.
+  final bool retryable;
+
   /// Raw lossless core-error JSON (externally-tagged `AiMuxError`), or `null`
   /// when absent (e.g. FFI-synthesized failures). No parsing is done.
   final String? errorValue;
@@ -251,6 +263,7 @@ class AimuxException implements Exception {
     this.code = AimuxErrorCode.other,
     this.status = -1,
     this.retryMs = -1,
+    this.retryable = false,
     this.errorValue,
   });
 
@@ -276,6 +289,7 @@ class AimuxException implements Exception {
       message,
       status: e.status,
       retryMs: e.retryMs,
+      retryable: e.retryable != 0,
       errorValue:
           e.errorValue == nullptr ? null : e.errorValue.toDartString(),
     );
@@ -287,48 +301,51 @@ class AimuxException implements Exception {
     String message, {
     int status = -1,
     int retryMs = -1,
+    bool retryable = false,
     String? errorValue,
   }) {
     switch (code) {
       case AimuxErrorCode.jsonParse:
-        return JSONParseError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return JSONParseError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.invalidResponseData:
-        return InvalidResponseDataError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return InvalidResponseDataError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.tool:
-        return ToolError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return ToolError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.invalidArgument:
-        return InvalidArgumentError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return InvalidArgumentError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.invalidPrompt:
-        return InvalidPromptError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return InvalidPromptError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.tokenExpired:
         return TokenExpiredError(
           message,
           status: status == -1 ? 401 : status,
           retryMs: retryMs,
+          retryable: retryable,
           errorValue: errorValue,
         );
       case AimuxErrorCode.unsupportedFunctionality:
-        return UnsupportedFunctionalityError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return UnsupportedFunctionalityError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.noSuchModel:
-        return NoSuchModelError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return NoSuchModelError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.noSuchProvider:
-        return NoSuchProviderError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return NoSuchProviderError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.apiCall:
-        return APICallError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return APICallError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.timeout:
-        return AimuxTimeoutError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return AimuxTimeoutError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.aborted:
-        return RequestAbortedError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return RequestAbortedError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.other:
-        return OtherError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return OtherError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       case AimuxErrorCode.unknown:
-        return UnknownError(message, status: status, retryMs: retryMs, errorValue: errorValue);
+        return UnknownError(message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue);
       default:
         return AimuxException(
           message,
           code: code,
           status: status,
           retryMs: retryMs,
+          retryable: retryable,
           errorValue: errorValue,
         );
     }
@@ -345,64 +362,64 @@ class AimuxException implements Exception {
 
 /// Unclassified / unknown failure (C `AIMUX_E_UNKNOWN`).
 class UnknownError extends AimuxException {
-  UnknownError(super.message, {super.status, super.retryMs, super.errorValue})
+  UnknownError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.unknown);
 }
 
 /// JSON parse / serialize failure.
 class JSONParseError extends AimuxException {
-  JSONParseError(super.message, {super.status, super.retryMs, super.errorValue})
+  JSONParseError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.jsonParse);
 }
 
 /// Invalid / malformed response data (streaming or decode failure).
 class InvalidResponseDataError extends AimuxException {
   InvalidResponseDataError(super.message,
-      {super.status, super.retryMs, super.errorValue})
+      {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.invalidResponseData);
 }
 
 /// Tool-related failure.
 class ToolError extends AimuxException {
-  ToolError(super.message, {super.status, super.retryMs, super.errorValue})
+  ToolError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.tool);
 }
 
 /// Invalid argument (null args, invalid or expired handles, …).
 class InvalidArgumentError extends AimuxException {
-  InvalidArgumentError(super.message, {super.status, super.retryMs, super.errorValue})
+  InvalidArgumentError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.invalidArgument);
 }
 
 /// Invalid prompt.
 class InvalidPromptError extends AimuxException {
-  InvalidPromptError(super.message, {super.status, super.retryMs, super.errorValue})
+  InvalidPromptError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.invalidPrompt);
 }
 
 /// Access token expired.
 class TokenExpiredError extends AimuxException {
-  TokenExpiredError(super.message, {super.status = 401, super.retryMs, super.errorValue})
+  TokenExpiredError(super.message, {super.status = 401, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.tokenExpired);
 }
 
 /// Unsupported functionality.
 class UnsupportedFunctionalityError extends AimuxException {
   UnsupportedFunctionalityError(super.message,
-      {super.status, super.retryMs, super.errorValue})
+      {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.unsupportedFunctionality);
 }
 
 /// No such model in registry / catalogue.
 class NoSuchModelError extends AimuxException {
-  NoSuchModelError(super.message, {super.status, super.retryMs, super.errorValue})
+  NoSuchModelError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.noSuchModel);
 }
 
 /// No such provider name.
 class NoSuchProviderError extends AimuxException {
   NoSuchProviderError(super.message,
-      {super.status, super.retryMs, super.errorValue})
+      {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.noSuchProvider);
 }
 
@@ -410,27 +427,28 @@ class NoSuchProviderError extends AimuxException {
 /// HTTP-shaped failure. [status] is the classification (401 auth, 404 model,
 /// 429 rate limit + [retryMs]); `-1` means no HTTP response was ever observed
 /// — a missing API key, an error built without a request, or a transport
-/// failure — and says nothing about whether a retry would help.
+/// failure. Read [retryable] to decide on a retry; [status] cannot tell those
+/// two apart.
 class APICallError extends AimuxException {
-  APICallError(super.message, {super.status, super.retryMs, super.errorValue})
+  APICallError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.apiCall);
 }
 
 /// Request timed out. (Prefixed to avoid shadowing dart:async
 /// `TimeoutError`.)
 class AimuxTimeoutError extends AimuxException {
-  AimuxTimeoutError(super.message, {super.status, super.retryMs, super.errorValue})
+  AimuxTimeoutError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.timeout);
 }
 
 /// Request aborted (not DOM `AbortError`).
 class RequestAbortedError extends AimuxException {
-  RequestAbortedError(super.message, {super.status, super.retryMs, super.errorValue})
+  RequestAbortedError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.aborted);
 }
 
 /// Unclassified failure (`AIMUX_E_OTHER`).
 class OtherError extends AimuxException {
-  OtherError(super.message, {super.status, super.retryMs, super.errorValue})
+  OtherError(super.message, {super.status, super.retryMs, super.retryable, super.errorValue})
       : super(code: AimuxErrorCode.other);
 }

--- a/bindings/flutter/test/errors_test.dart
+++ b/bindings/flutter/test/errors_test.dart
@@ -143,12 +143,14 @@ void main() {
         err.ref.code = AimuxErrorCode.apiCall;
         err.ref.status = 429;
         err.ref.retryMs = 1500;
+        err.ref.retryable = 1;
         err.ref.message = 'API call error: HTTP 429: slow down'.toNativeUtf8();
         err.ref.errorValue = json.toNativeUtf8();
       });
       expect(e, isA<APICallError>());
       expect(e.status, 429);
       expect(e.retryMs, 1500);
+      expect(e.retryable, isTrue);
       expect(e.errorValue, json);
     });
 
@@ -161,6 +163,7 @@ void main() {
       });
       expect(e, isA<APICallError>());
       expect(e.status, 401);
+      expect(e.retryable, isFalse);
       expect(e.message, contains('HTTP 401'));
     });
 
@@ -175,6 +178,24 @@ void main() {
       expect(e, isA<NoSuchModelError>());
       expect(e.status, -1);
       expect(e.errorValue, json);
+    });
+
+    test('retryable crosses the ABI and status cannot stand in', () {
+      // Both report status == -1 and disagree — never infer one from the other.
+      final transport = fromFilled((err) {
+        err.ref.code = AimuxErrorCode.apiCall;
+        err.ref.message = 'API call error: connection reset'.toNativeUtf8();
+        err.ref.retryable = 1;
+      });
+      expect(transport.status, -1);
+      expect(transport.retryable, isTrue);
+
+      final noKey = fromFilled((err) {
+        err.ref.code = AimuxErrorCode.apiCall;
+        err.ref.message = 'API call error: missing api key'.toNativeUtf8();
+      });
+      expect(noKey.status, -1);
+      expect(noKey.retryable, isFalse);
     });
 
     test('OK code becomes UnknownError with fallback message', () {
@@ -229,6 +250,8 @@ void main() {
       expect(err.ref.retryMs, -1);
       expect(err.ref.message, nullptr);
       expect(err.ref.errorValue, nullptr);
+      expect(err.ref.retryable, 0);
+      expect(err.ref.reserved, 0);
       return 42;
     });
     expect(result, 42);

--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -1162,8 +1162,8 @@ func errorFromC(e *C.AimuxError) error {
 		e.error_value = nil
 	}
 	// TokenExpired carries a 401 by contract even if C reports -1; every
-	// other status is the observed one (ApiCall without a status = transport
-	// failure, no response). See bindings/node src/error.ts.
+	// other status is the observed one (ApiCall without a status = no HTTP
+	// response was observed). See bindings/node src/error.ts.
 	status := defaultStatus(Code(e.code), int(e.status))
 	return &Error{
 		Code:       Code(e.code),
@@ -1176,7 +1176,7 @@ func errorFromC(e *C.AimuxError) error {
 
 // ffiString runs an FFI call returning an aimux-allocated C string, mapping
 // the NULL-sentinel failure path through errorFromC. It clears *cerr up front
-// (cheap at 24 bytes) as defense against callees that fail without writing it.
+// (cheap at 40 bytes) as defense against callees that fail without writing it.
 func ffiString(call func(cerr *C.AimuxError) *C.char) (string, error) {
 	var cerr C.AimuxError
 	C.aimux_error_clear(&cerr)

--- a/bindings/go/aimux.go
+++ b/bindings/go/aimux.go
@@ -1170,6 +1170,7 @@ func errorFromC(e *C.AimuxError) error {
 		Message:    msg,
 		Status:     status,
 		RetryMs:    int64(e.retry_ms),
+		Retryable:  e.retryable != 0,
 		ErrorValue: errValue,
 	}
 }

--- a/bindings/go/error.go
+++ b/bindings/go/error.go
@@ -78,7 +78,7 @@ func (c Code) String() string {
 //
 //	var e *aimux.Error
 //	if errors.As(err, &e) {
-//	    // e.Code, e.Status, e.RetryMs, e.Message
+//	    // e.Code, e.Status, e.RetryMs, e.Retryable, e.Message
 //	    // e.Code == aimux.CodeAPICall && e.Status == 429 → rate limited
 //	}
 //
@@ -87,12 +87,20 @@ func (c Code) String() string {
 //   - Status: HTTP status, or -1 — the classification for CodeAPICall
 //     (401 auth, 404 model, 429 rate limit)
 //   - RetryMs: rate-limit hint, or -1 (0 = retry now)
+//   - Retryable: the core's retry verdict, carried across the ABI
 //   - Message: human-readable text
 type Error struct {
 	Code    Code
 	Message string
 	Status  int   // HTTP status or -1
 	RetryMs int64 // retry hint or -1; 0 = retry immediately
+	// Retryable is the core's verdict on whether retrying may help. It
+	// rides the ABI as its own field and is never derived from Status: a
+	// transport failure (request went out, connection reset) is retryable
+	// and a missing API key (request never went out) is not, yet both
+	// report Status -1. False for failures synthesized at the FFI
+	// boundary (bad argument, unparseable JSON).
+	Retryable bool
 	// ErrorValue is the lossless machine-readable source error:
 	// externally-tagged aimux-core AiMuxError JSON; empty for failures
 	// synthesized at the FFI boundary.

--- a/bindings/go/error.go
+++ b/bindings/go/error.go
@@ -8,7 +8,9 @@ import (
 // aimux-ffi AimuxErrorCode (1..14 = core AiMuxError variants).
 //
 // Every HTTP-shaped failure arrives as CodeAPICall, classified by Status
-// (401 auth, 404 model, 429 rate limit; no status = transport failure).
+// (401 auth, 404 model, 429 rate limit; Status -1 = no HTTP response was ever
+// observed — a missing API key, an error built without a request, or a
+// transport failure — which says nothing about whether a retry would help).
 type Code int
 
 const (
@@ -115,8 +117,9 @@ func newError(code Code, message string) *Error {
 
 // defaultStatus fills the status TokenExpired carries by contract (401) when
 // the C ABI reports -1. CodeAPICall statuses are observed, never invented: a
-// missing status there means no response arrived (transport failure), so it
-// stays -1.
+// missing status there means no HTTP response was ever observed (a missing API
+// key, an error built without a request, or a transport failure), so it stays
+// -1.
 func defaultStatus(code Code, status int) int {
 	if status == -1 && code == CodeTokenExpired {
 		return 401

--- a/bindings/go/error_test.go
+++ b/bindings/go/error_test.go
@@ -136,3 +136,29 @@ func TestDefaultStatus(t *testing.T) {
 		}
 	}
 }
+
+// Retryable crosses the ABI as its own field. Two ApiCall failures both report
+// Status -1 and disagree about retrying, so Status cannot stand in for it.
+func TestRetryableIsNotDerivedFromStatus(t *testing.T) {
+	transport := &Error{
+		Code:      CodeAPICall,
+		Message:   "API call error: connection reset",
+		Status:    -1,
+		RetryMs:   -1,
+		Retryable: true, // request went out
+	}
+	missingKey := &Error{
+		Code:    CodeAPICall,
+		Message: "API call error: missing api key",
+		Status:  -1,
+		RetryMs: -1,
+	} // request never went out; Retryable stays false
+
+	if transport.Status != -1 || missingKey.Status != -1 {
+		t.Fatalf("both must carry Status -1: got %d / %d", transport.Status, missingKey.Status)
+	}
+	if !transport.Retryable || missingKey.Retryable {
+		t.Fatalf("Retryable: transport=%v missingKey=%v; want true / false",
+			transport.Retryable, missingKey.Retryable)
+	}
+}

--- a/bindings/java/src/main/java/ai/arcships/aimux/AimuxCError.java
+++ b/bindings/java/src/main/java/ai/arcships/aimux/AimuxCError.java
@@ -12,10 +12,11 @@ import com.sun.jna.Structure;
  * with {@code aimux_free_string}). On success {@code *err} is left untouched.
  *
  * <p>Field layout matches the 40-byte C struct: {@code code}, {@code status},
- * {@code retry_ms}, {@code message}, {@code error_value}, {@code reserved0}
- * (one reserved pointer slot for future ABI extension; always zero).
+ * {@code retry_ms}, {@code message}, {@code error_value}, {@code retryable},
+ * {@code reserved} (the last two 32-bit ints split what was one reserved
+ * pointer slot; {@code reserved} is always zero).
  */
-@Structure.FieldOrder({"code", "status", "retry_ms", "message", "error_value", "reserved0"})
+@Structure.FieldOrder({"code", "status", "retry_ms", "message", "error_value", "retryable", "reserved"})
 public class AimuxCError extends Structure {
 
     /** {@link AimuxException} code constant (0 = OK). */
@@ -37,8 +38,17 @@ public class AimuxCError extends Structure {
      */
     public Pointer error_value;
 
+    /**
+     * The engine's retry verdict: {@code 1} when retrying may help, {@code 0}
+     * when it will not. Written by the callee on every failure, and <em>not</em>
+     * derivable from {@link #status}: a statusless API-call failure is a
+     * retryable transport error when the request went out, and a non-retryable
+     * missing API key when it never did.
+     */
+    public int retryable;
+
     /** Reserved for future ABI extension; always zero. */
-    public Pointer reserved0;
+    public int reserved;
 
     public AimuxCError() {
         super();
@@ -54,7 +64,8 @@ public class AimuxCError extends Structure {
         retry_ms = -1L;
         message = null;
         error_value = null;
-        reserved0 = null;
+        retryable = 0;
+        reserved = 0;
     }
 
     /**

--- a/bindings/java/src/main/java/ai/arcships/aimux/AimuxException.java
+++ b/bindings/java/src/main/java/ai/arcships/aimux/AimuxException.java
@@ -19,8 +19,9 @@ package ai.arcships.aimux;
  * }</pre>
  *
  * <p>Every instance carries {@link #getCode()} (C {@code AimuxErrorCode} 0–14),
- * {@link #getStatusCode()} (HTTP or {@code -1}), and {@link #getRetryMs()} (hint
- * or {@code -1}; {@code 0} = retry now). Message text comes from the C layer.
+ * {@link #getStatusCode()} (HTTP or {@code -1}), {@link #getRetryMs()} (hint
+ * or {@code -1}; {@code 0} = retry now) and {@link #isRetryable()}. Message
+ * text comes from the C layer.
  *
  * <p>Message-only constructors default {@code status=-1}, {@code retryMs=-1} for
  * backward compatibility with typed-layer decode failures.
@@ -56,6 +57,9 @@ public class AimuxException extends RuntimeException {
     // failures. Not a constructor param so the 13 subclass constructors keep
     // their public signatures.
     private String errorValue;
+
+    // Same deal: set once by fromC, false for local / synthesized failures.
+    private boolean retryable;
 
     // ── Constructors ────────────────────────────────────────────────────────
 
@@ -110,6 +114,19 @@ public class AimuxException extends RuntimeException {
         return errorValue;
     }
 
+    /**
+     * The engine's retry verdict: {@code true} when retrying may help.
+     *
+     * <p>Not derivable from {@link #getStatusCode()} — two failures can both
+     * report {@code -1} and disagree: a transport failure (the request went out,
+     * the connection was reset) is retryable, a missing API key (the request
+     * never went out) is not. {@code false} for local (non-FFI) failures and
+     * for failures synthesized at the FFI boundary.
+     */
+    public boolean isRetryable() {
+        return retryable;
+    }
+
     // ── Factories ───────────────────────────────────────────────────────────
 
     /**
@@ -131,6 +148,7 @@ public class AimuxException extends RuntimeException {
         long retryMs;
         String msg;
         String errorValue = null;
+        boolean retryable = false;
         if (e == null) {
             code = AIMUX_E_OTHER;
             status = -1;
@@ -145,6 +163,7 @@ public class AimuxException extends RuntimeException {
             retryMs = e.retry_ms;
             msg = e.takeMessage();
             errorValue = e.takeErrorValue();
+            retryable = e.retryable != 0;
             if (msg.isEmpty()) {
                 msg = "aimux: " + codeName(e.code);
             }
@@ -154,6 +173,7 @@ public class AimuxException extends RuntimeException {
         }
         AimuxException ex = createByCode(code, msg, status, retryMs);
         ex.errorValue = errorValue;
+        ex.retryable = retryable;
         return ex;
     }
 
@@ -306,7 +326,8 @@ public class AimuxException extends RuntimeException {
      * errors, transport failures, 401 auth, 404 model, 429 rate limit. Classify
      * with {@link #getStatusCode()}; {@code -1} means no HTTP response was ever
      * observed — a missing API key, an error built without a request, or a
-     * transport failure — and says nothing about whether a retry would help.
+     * transport failure — and says nothing about whether a retry would help:
+     * read {@link #isRetryable()} for that, never the status sentinel.
      */
     public static class APICallError extends AimuxException {
         public APICallError(String message, int status, long retryMs) {

--- a/bindings/java/src/main/java/ai/arcships/aimux/AimuxException.java
+++ b/bindings/java/src/main/java/ai/arcships/aimux/AimuxException.java
@@ -304,7 +304,9 @@ public class AimuxException extends RuntimeException {
     /**
      * Every HTTP-shaped failure (AI SDK {@code APICallError} analogue): provider
      * errors, transport failures, 401 auth, 404 model, 429 rate limit. Classify
-     * with {@link #getStatusCode()}; a transport failure reports {@code -1}.
+     * with {@link #getStatusCode()}; {@code -1} means no HTTP response was ever
+     * observed — a missing API key, an error built without a request, or a
+     * transport failure — and says nothing about whether a retry would help.
      */
     public static class APICallError extends AimuxException {
         public APICallError(String message, int status, long retryMs) {

--- a/bindings/java/src/test/java/ai/arcships/aimux/AimuxExceptionTest.java
+++ b/bindings/java/src/test/java/ai/arcships/aimux/AimuxExceptionTest.java
@@ -14,7 +14,7 @@ class AimuxExceptionTest {
     @Test
     void cErrorStructIs40Bytes() {
         // Mirrors the C AimuxError layout:
-        // int32 + int32 + int64 + char* + char* + void*[1].
+        // int32 + int32 + int64 + char* + char* + int32 + int32.
         assertThat(new AimuxCError().size()).isEqualTo(40);
     }
 
@@ -153,6 +153,31 @@ class AimuxExceptionTest {
         AimuxCError err = filled(AimuxException.AIMUX_E_API_CALL, 429, 1500L, "slow down", json);
         AimuxException e = AimuxException.fromC(err);
         assertThat(e.getErrorValue()).isEqualTo(json);
+    }
+
+    @Test
+    void retryableCrossesTheAbiAndStatusCannotStandIn() {
+        // Same status (-1), opposite verdicts: the request went out and the
+        // connection dropped vs. it never went out at all.
+        AimuxCError transport = filled(
+            AimuxException.AIMUX_E_API_CALL, -1, -1L, "connection reset");
+        transport.retryable = 1;
+        AimuxException retryable = AimuxException.fromC(transport);
+
+        AimuxCError noKey = filled(
+            AimuxException.AIMUX_E_API_CALL, -1, -1L, "missing api key");
+        AimuxException fatal = AimuxException.fromC(noKey);
+
+        assertThat(retryable.getStatusCode()).isEqualTo(fatal.getStatusCode());
+        assertThat(retryable.isRetryable()).isTrue();
+        assertThat(fatal.isRetryable()).isFalse();
+    }
+
+    @Test
+    void retryableIsFalseForLocalFailures() {
+        assertThat(AimuxException.of(AimuxException.AIMUX_E_INVALID_ARGUMENT, "bad arg")
+            .isRetryable()).isFalse();
+        assertThat(AimuxException.fromC(null).isRetryable()).isFalse();
     }
 
     @Test

--- a/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/AimuxCError.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/AimuxCError.kt
@@ -6,7 +6,8 @@ import com.sun.jna.Structure
 /**
  * JNA mirror of C `AimuxError` (aimux-error.h): 40 bytes
  * (int32 code, int32 status, int64 retry_ms, char *message, char *error_value,
- * and one reserved pointer slot for future ABI extension — always zero).
+ * int32 retryable, int32 reserved — the last two split what was one reserved
+ * pointer slot; `reserved` is always zero).
  *
  * Pass as the trailing `err` argument to fallible FFI calls. On failure the
  * callee fills every field and allocates [message] (NUL-terminated UTF-8) and,
@@ -17,12 +18,22 @@ import com.sun.jna.Structure
  * is left untouched. Check the function return first (0 / NULL), then read
  * this. Field defaults mirror `aimux_error_clear`.
  */
-@Structure.FieldOrder("code", "status", "retry_ms", "message", "error_value", "reserved0")
+@Structure.FieldOrder("code", "status", "retry_ms", "message", "error_value", "retryable", "reserved")
 open class AimuxCError : Structure() {
     @JvmField var code: Int = 0
     @JvmField var status: Int = -1
     @JvmField var retry_ms: Long = -1
     @JvmField var message: Pointer? = null
     @JvmField var error_value: Pointer? = null
-    @JvmField var reserved0: Pointer? = null
+
+    /**
+     * The core's retry verdict: 1 when retrying may help, 0 when it will not.
+     * Never infer it from [status] — a statusless API-call failure is a
+     * retryable transport error when the request went out, and a non-retryable
+     * missing API key when it never did.
+     */
+    @JvmField var retryable: Int = 0
+
+    /** Reserved for future ABI extension; always zero. */
+    @JvmField var reserved: Int = 0
 }

--- a/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Errors.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Errors.kt
@@ -55,6 +55,15 @@ sealed class AimuxException(
      * was synthesized at the FFI boundary (bad argument, invalid handle).
      */
     val errorValue: String? = null,
+    /**
+     * The engine's retry verdict: true when retrying may help.
+     *
+     * Not derivable from [status] — two failures can both report -1 and
+     * disagree: a transport failure (the request went out, the connection was
+     * reset) is retryable, a missing API key (the request never went out) is
+     * not. False for failures synthesized at the FFI boundary.
+     */
+    val retryable: Boolean = false,
 ) : RuntimeException(message, cause) {
 
     companion object {
@@ -78,7 +87,14 @@ sealed class AimuxException(
                     "aimux: ${codeName(code)}"
                 }
             }
-            return createByCode(code, msg, err.status, err.retry_ms, errorValue = err.error_value?.getString(0, "UTF-8"))
+            return createByCode(
+                code,
+                msg,
+                err.status,
+                err.retry_ms,
+                errorValue = err.error_value?.getString(0, "UTF-8"),
+                retryable = err.retryable != 0,
+            )
         }
 
         /**
@@ -95,28 +111,30 @@ sealed class AimuxException(
             retryMs: Long = -1,
             cause: Throwable? = null,
             errorValue: String? = null,
+            retryable: Boolean = false,
         ): AimuxException = when (code) {
-            AIMUX_E_JSON_PARSE -> JSONParseError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_INVALID_RESPONSE_DATA -> InvalidResponseDataError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_TOOL -> ToolError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_INVALID_ARGUMENT -> InvalidArgumentError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_INVALID_PROMPT -> InvalidPromptError(message, status, retryMs, cause, errorValue)
+            AIMUX_E_JSON_PARSE -> JSONParseError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_INVALID_RESPONSE_DATA -> InvalidResponseDataError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_TOOL -> ToolError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_INVALID_ARGUMENT -> InvalidArgumentError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_INVALID_PROMPT -> InvalidPromptError(message, status, retryMs, cause, errorValue, retryable)
             AIMUX_E_TOKEN_EXPIRED -> TokenExpiredError(
                 message,
                 status = if (status == -1) 401 else status,
                 retryMs = retryMs,
                 cause = cause,
                 errorValue = errorValue,
+                retryable = retryable,
             )
-            AIMUX_E_UNSUPPORTED_FUNCTIONALITY -> UnsupportedFunctionalityError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_NO_SUCH_MODEL -> NoSuchModelError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_NO_SUCH_PROVIDER -> NoSuchProviderError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_API_CALL -> APICallError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_TIMEOUT -> TimeoutError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_ABORTED -> RequestAbortedError(message, status, retryMs, cause, errorValue)
-            AIMUX_E_OTHER -> OtherError(message, status, retryMs, cause, errorValue)
-            AIMUX_OK -> OtherError(message.ifEmpty { "aimux: operation failed" }, status, retryMs, cause, errorValue)
-            else -> UnknownAimuxError(message, code, status, retryMs, cause, errorValue)
+            AIMUX_E_UNSUPPORTED_FUNCTIONALITY -> UnsupportedFunctionalityError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_NO_SUCH_MODEL -> NoSuchModelError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_NO_SUCH_PROVIDER -> NoSuchProviderError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_API_CALL -> APICallError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_TIMEOUT -> TimeoutError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_ABORTED -> RequestAbortedError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_E_OTHER -> OtherError(message, status, retryMs, cause, errorValue, retryable)
+            AIMUX_OK -> OtherError(message.ifEmpty { "aimux: operation failed" }, status, retryMs, cause, errorValue, retryable)
+            else -> UnknownAimuxError(message, code, status, retryMs, cause, errorValue, retryable)
         }
 
         /** Core / C code → short name. */
@@ -148,7 +166,8 @@ class JSONParseError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_JSON_PARSE, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_JSON_PARSE, status, retryMs, cause, errorValue, retryable)
 
 class InvalidResponseDataError(
     message: String,
@@ -156,7 +175,8 @@ class InvalidResponseDataError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_INVALID_RESPONSE_DATA, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_INVALID_RESPONSE_DATA, status, retryMs, cause, errorValue, retryable)
 
 class ToolError(
     message: String,
@@ -164,7 +184,8 @@ class ToolError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_TOOL, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_TOOL, status, retryMs, cause, errorValue, retryable)
 
 class InvalidArgumentError(
     message: String,
@@ -172,7 +193,8 @@ class InvalidArgumentError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_INVALID_ARGUMENT, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_INVALID_ARGUMENT, status, retryMs, cause, errorValue, retryable)
 
 class InvalidPromptError(
     message: String,
@@ -180,7 +202,8 @@ class InvalidPromptError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_INVALID_PROMPT, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_INVALID_PROMPT, status, retryMs, cause, errorValue, retryable)
 
 /** Access token expired and must be refreshed (HTTP 401, but retry-after-refresh). */
 class TokenExpiredError(
@@ -189,7 +212,8 @@ class TokenExpiredError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_TOKEN_EXPIRED, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_TOKEN_EXPIRED, status, retryMs, cause, errorValue, retryable)
 
 class UnsupportedFunctionalityError(
     message: String,
@@ -197,7 +221,8 @@ class UnsupportedFunctionalityError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_UNSUPPORTED_FUNCTIONALITY, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_UNSUPPORTED_FUNCTIONALITY, status, retryMs, cause, errorValue, retryable)
 
 class NoSuchModelError(
     message: String,
@@ -205,7 +230,8 @@ class NoSuchModelError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_NO_SUCH_MODEL, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_NO_SUCH_MODEL, status, retryMs, cause, errorValue, retryable)
 
 class NoSuchProviderError(
     message: String,
@@ -213,7 +239,8 @@ class NoSuchProviderError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_NO_SUCH_PROVIDER, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_NO_SUCH_PROVIDER, status, retryMs, cause, errorValue, retryable)
 
 /**
  * Every HTTP-shaped provider failure (AI SDK `APICallError` analogue).
@@ -221,7 +248,8 @@ class NoSuchProviderError(
  * Classification is [status], not the class: 401 auth, 404 model not found,
  * 429 rate limited (with [retryMs]); -1 means no HTTP response was ever
  * observed — a missing API key, an error built without a request, or a
- * transport failure — and says nothing about whether a retry would help.
+ * transport failure — and says nothing about whether a retry would help: read
+ * [retryable] for that, never the status sentinel.
  * The full detail — `provider_code`, `response_body`, `request_id`,
  * `is_retryable` — is in [errorValue].
  */
@@ -231,7 +259,8 @@ class APICallError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_API_CALL, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_API_CALL, status, retryMs, cause, errorValue, retryable)
 
 class TimeoutError(
     message: String,
@@ -239,7 +268,8 @@ class TimeoutError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_TIMEOUT, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_TIMEOUT, status, retryMs, cause, errorValue, retryable)
 
 /** Request aborted (not a Java interruption). */
 class RequestAbortedError(
@@ -248,7 +278,8 @@ class RequestAbortedError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_ABORTED, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_ABORTED, status, retryMs, cause, errorValue, retryable)
 
 class OtherError(
     message: String,
@@ -256,7 +287,8 @@ class OtherError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, AIMUX_E_OTHER, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, AIMUX_E_OTHER, status, retryMs, cause, errorValue, retryable)
 
 /** `AIMUX_E_UNKNOWN` or an unrecognized / future code; preserves the raw [code]. */
 class UnknownAimuxError(
@@ -266,4 +298,5 @@ class UnknownAimuxError(
     retryMs: Long = -1,
     cause: Throwable? = null,
     errorValue: String? = null,
-) : AimuxException(message, code, status, retryMs, cause, errorValue)
+    retryable: Boolean = false,
+) : AimuxException(message, code, status, retryMs, cause, errorValue, retryable)

--- a/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Errors.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Errors.kt
@@ -34,7 +34,7 @@ const val AIMUX_E_OTHER: Int = 14
  *     model.generateText("\"hi\"")
  * } catch (e: APICallError) {
  *     // Classification is the status field: 429 → rate limited (e.retryMs),
- *     // 401 → auth, 404 → model not found, -1 → transport failure
+ *     // 401 → auth, 404 → model not found, -1 → no HTTP response observed
  * } catch (e: AimuxException) {
  *     // e.code, e.status, e.retryMs
  * }
@@ -219,7 +219,9 @@ class NoSuchProviderError(
  * Every HTTP-shaped provider failure (AI SDK `APICallError` analogue).
  *
  * Classification is [status], not the class: 401 auth, 404 model not found,
- * 429 rate limited (with [retryMs]); a transport failure has no status (-1).
+ * 429 rate limited (with [retryMs]); -1 means no HTTP response was ever
+ * observed — a missing API key, an error built without a request, or a
+ * transport failure — and says nothing about whether a retry would help.
  * The full detail — `provider_code`, `response_body`, `request_id`,
  * `is_retryable` — is in [errorValue].
  */

--- a/bindings/kotlin/src/test/kotlin/ai/arcships/aimux/ErrorsTest.kt
+++ b/bindings/kotlin/src/test/kotlin/ai/arcships/aimux/ErrorsTest.kt
@@ -105,6 +105,23 @@ class ErrorsTest {
         assertThat(ex.status).isEqualTo(401)
     }
 
+    /** Same status (-1), opposite verdicts: status cannot stand in for retryable. */
+    @Test
+    fun `fromC carries the retry verdict that status cannot express`() {
+        val transport = AimuxCError()
+        transport.code = AIMUX_E_API_CALL
+        transport.retryable = 1 // request went out, connection reset
+        val retryable = AimuxException.fromC(transport)
+
+        val noKey = AimuxCError()
+        noKey.code = AIMUX_E_API_CALL // missing api key: request never went out
+        val fatal = AimuxException.fromC(noKey)
+
+        assertThat(retryable.status).isEqualTo(fatal.status)
+        assertThat(retryable.retryable).isTrue()
+        assertThat(fatal.retryable).isFalse()
+    }
+
     @Test
     fun `fromC preserves unrecognized codes`() {
         val err = AimuxCError()

--- a/bindings/node/__test__/error.test.ts
+++ b/bindings/node/__test__/error.test.ts
@@ -1,18 +1,33 @@
 // Error contract tests: every failure surfaced by the binding must be an
-// `AimuxError` subclass (instanceof works) carrying `.code` / `.status` /
-// `.retryMs`. All tests are hermetic — no network beyond 127.0.0.1.
+// `AimuxError` subclass (instanceof works) carrying `.code` / `.status`.
+// Payload fields belong to the one subclass the core fills them for.
+// All tests are hermetic — no network beyond 127.0.0.1.
 
 import test from 'ava'
+import { createServer, type Server } from 'node:http'
 import {
   openai,
   provider,
   mockReplay,
   streamText,
+  generateText,
   AimuxError,
   APICallError,
   InvalidArgumentError,
   NoSuchProviderError,
 } from '../src/index.ts'
+
+function startMockServer(
+  handler: (req: any, res: any) => void,
+): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler)
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as any
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` })
+    })
+  })
+}
 
 test('sync native failure throws a typed AimuxError subclass', (t) => {
   const err = t.throws(() => mockReplay('')) as AimuxError
@@ -21,7 +36,6 @@ test('sync native failure throws a typed AimuxError subclass', (t) => {
   t.is(err.name, 'InvalidArgumentError')
   t.is(err.code, 'InvalidArgument')
   t.is(typeof err.status, 'number')
-  t.is(typeof err.retryMs, 'number')
   // Binding-side failures also synthesize an AiMuxError, so errorValue is set.
   t.is(typeof err.errorValue, 'string')
   t.true(Object.hasOwn(JSON.parse(err.errorValue!), 'InvalidArgument'))
@@ -61,7 +75,6 @@ test('stream error path yields a typed AimuxError', async (t) => {
   t.is(typeof err.code, 'string')
   t.true(err.code.length > 0)
   t.is(typeof err.status, 'number')
-  t.is(typeof err.retryMs, 'number')
 })
 
 test('instanceof narrows to the specific subclass only', async (t) => {
@@ -77,4 +90,57 @@ test('instanceof narrows to the specific subclass only', async (t) => {
   t.is(rl.status, 429)
   t.is(rl.code, 'ApiCall')
   t.is(rl.name, 'APICallError')
+})
+
+test('payload fields live on the subclass the core fills them for', async (t) => {
+  const err = (await t.throwsAsync(() =>
+    provider('definitely-not-a-provider', null, 'some-model'),
+  )) as NoSuchProviderError
+  t.true(err instanceof NoSuchProviderError)
+
+  // The registry payload is a field, not something to dig out of errorValue.
+  t.is(err.providerId, 'definitely-not-a-provider')
+
+  // ApiCall-only fields are absent here — the core fills them for no other
+  // variant, so they must not exist as always-empty properties.
+  for (const key of ['retryMs', 'retryable', 'providerCode', 'responseBody', 'requestId']) {
+    t.false(key in err, `${key} must not exist on ${err.name}`)
+  }
+
+  // …and they do exist on an ApiCall error.
+  const call = new APICallError('slow down', 429, 1500, true)
+  t.is(call.retryMs, 1500)
+  t.true(call.retryable)
+})
+
+test('APICallError carries every field the response produced', async (t) => {
+  const body = JSON.stringify({
+    error: { message: 'slow down', type: 'rate_limit_exceeded' },
+  })
+  const { server, url } = await startMockServer((_req, res) => {
+    res.writeHead(429, {
+      'content-type': 'application/json',
+      'x-request-id': 'req_abc123',
+      'retry-after-ms': '1500',
+    })
+    res.end(body)
+  })
+  try {
+    const model = await openai('test-key', 'gpt-4o', { baseUrl: url, maxRetries: 0 })
+    const err = (await t.throwsAsync(() => generateText(model, 'hi'))) as APICallError
+    t.true(err instanceof APICallError)
+
+    t.is(err.status, 429)
+    t.is(err.retryMs, 1500)
+    t.true(err.retryable)
+    t.is(err.providerCode, 'rate_limit_exceeded')
+    t.is(err.requestId, 'req_abc123')
+    t.is(err.responseBody, body)
+    // The provider's text on its own; `message` is the composed form.
+    t.is(err.providerMessage, 'slow down')
+    t.true(err.message.includes('slow down'))
+    t.not(err.message, err.providerMessage)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
 })

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -27,10 +27,18 @@ pub struct MappedError {
     pub retryable: bool,
     /// Provider's machine-readable error code (`ApiCallError::provider_code`).
     pub provider_code: Option<String>,
+    /// The provider's message verbatim (`ApiCallError::message`). `message`
+    /// above is the composed `"API call error: HTTP 429: …"` form.
+    pub provider_message: Option<String>,
     /// Provider-assigned request id (`ApiCallError::request_id`).
     pub request_id: Option<String>,
     /// Raw response body, verbatim (`ApiCallError::response_body`).
     pub response_body: Option<String>,
+    /// Registry lookup subject: `NoSuchModel::model_id` / `model_type`.
+    pub model_id: Option<String>,
+    pub model_type: Option<String>,
+    /// Registry lookup subject: `NoSuchProvider::provider_id`.
+    pub provider_id: Option<String>,
     /// Lossless externally-tagged serde JSON of the source `AiMuxError`
     /// (e.g. `{"ApiCall":{...}}`); `None` if serialization failed.
     pub error_value: Option<String>,
@@ -63,6 +71,16 @@ impl From<&AiMuxError> for MappedError {
             AiMuxError::Aborted => "Aborted",
             AiMuxError::Other(_) => "Other",
         };
+        let (model_id, model_type) = match e {
+            AiMuxError::NoSuchModel {
+                model_id,
+                model_type,
+            } => (
+                Some(model_id.clone()),
+                (!model_type.is_empty()).then(|| model_type.clone()),
+            ),
+            _ => (None, None),
+        };
         Self {
             code: code.to_string(),
             message: e.to_string(),
@@ -70,8 +88,17 @@ impl From<&AiMuxError> for MappedError {
             retry_ms: e.retry_after_hint().unwrap_or(-1),
             retryable: e.is_retryable(),
             provider_code: detail.and_then(|d| d.provider_code.clone()),
+            provider_message: detail
+                .map(|d| d.message.clone())
+                .filter(|m| !m.is_empty()),
             request_id: detail.and_then(|d| d.request_id.clone()),
             response_body: detail.and_then(|d| d.response_body.clone()),
+            model_id,
+            model_type,
+            provider_id: match e {
+                AiMuxError::NoSuchProvider { provider_id } => Some(provider_id.clone()),
+                _ => None,
+            },
             error_value: serde_json::to_string(e).ok(),
         }
     }
@@ -141,11 +168,23 @@ pub(crate) fn create_throwable(env: &Env, m: &MappedError) -> NapiResult<Error> 
     if let Some(pc) = &m.provider_code {
         obj.set("providerCode", pc.as_str())?;
     }
+    if let Some(pm) = &m.provider_message {
+        obj.set("providerMessage", pm.as_str())?;
+    }
     if let Some(rid) = &m.request_id {
         obj.set("requestId", rid.as_str())?;
     }
     if let Some(rb) = &m.response_body {
         obj.set("responseBody", rb.as_str())?;
+    }
+    if let Some(id) = &m.model_id {
+        obj.set("modelId", id.as_str())?;
+    }
+    if let Some(t) = &m.model_type {
+        obj.set("modelType", t.as_str())?;
+    }
+    if let Some(id) = &m.provider_id {
+        obj.set("providerId", id.as_str())?;
     }
     if let Some(ev) = &m.error_value {
         obj.set("errorValue", ev.as_str())?;

--- a/bindings/node/src/error.ts
+++ b/bindings/node/src/error.ts
@@ -20,16 +20,11 @@
 export class AimuxError extends Error {
   /** Core variant name, e.g. `'InvalidArgument'`. */
   readonly code: string
+  /**
+   * HTTP status when the error carries one — the observed status on
+   * `APICallError`, `401` on `TokenExpiredError` — otherwise `-1`.
+   */
   readonly status: number
-  readonly retryMs: number
-  /** Stored retry verdict (`APICallError.isRetryable` analogue). */
-  readonly retryable: boolean
-  /** Provider's machine-readable error code (e.g. `'rate_limit_exceeded'`). */
-  readonly providerCode?: string
-  /** Raw error response body, verbatim (AI SDK `APICallError.responseBody`). */
-  readonly responseBody?: string
-  /** Provider-assigned request id (`x-request-id` / `request-id` header). */
-  readonly requestId?: string
   /**
    * Lossless externally-tagged serde JSON of the core `AiMuxError`,
    * e.g. `'{"ApiCall":{"status_code":429,"retry_after_ms":1500,...}}'`.
@@ -37,13 +32,11 @@ export class AimuxError extends Error {
    */
   readonly errorValue?: string
 
-  constructor(message: string, status: number = -1, retryMs: number = -1, retryable: boolean = false) {
+  constructor(message: string, status: number = -1) {
     super(message)
     this.name = new.target.name
     this.code = CODE_BY_NAME.get(this.name) ?? 'Other'
     this.status = status
-    this.retryMs = retryMs
-    this.retryable = retryable
     Object.setPrototypeOf(this, new.target.prototype)
     const capture = (Error as { captureStackTrace?: (t: object, ctor: unknown) => void })
       .captureStackTrace
@@ -56,58 +49,40 @@ export class AimuxError extends Error {
       return err
     }
 
+    const props = (err instanceof Error ? err : {}) as Record<string, unknown>
+    const str = (key: string): string | undefined =>
+      typeof props[key] === 'string' ? (props[key] as string) : undefined
+
     let message = String(err)
     let code = 'Other'
     let status = -1
     let retryMs = -1
     let retryable = false
-    let providerCode: string | undefined
-    let responseBody: string | undefined
-    let requestId: string | undefined
-    let errorValue: string | undefined
 
     if (err instanceof Error) {
       message = err.message
-      const any = err as Error & {
-        code?: unknown
-        status?: unknown
-        retryMs?: unknown
-        retryable?: unknown
-        providerCode?: unknown
-        responseBody?: unknown
-        requestId?: unknown
-        errorValue?: unknown
-      }
-
-      if (typeof any.status === 'number') status = any.status
-      if (typeof any.retryMs === 'number') retryMs = any.retryMs
-      if (typeof any.retryable === 'boolean') retryable = any.retryable
-      if (typeof any.providerCode === 'string') providerCode = any.providerCode
-      if (typeof any.responseBody === 'string') responseBody = any.responseBody
-      if (typeof any.requestId === 'string') requestId = any.requestId
-      if (typeof any.errorValue === 'string') errorValue = any.errorValue
-
-      if (typeof any.code === 'string' && any.code.length > 0) {
-        code = any.code
-      } else if (typeof any.name === 'string') {
-        // Native sets name to e.g. "APICallError"
-        code = CODE_BY_NAME.get(any.name) ?? 'Other'
-      }
+      if (typeof props.status === 'number') status = props.status
+      if (typeof props.retryMs === 'number') retryMs = props.retryMs
+      if (typeof props.retryable === 'boolean') retryable = props.retryable
+      // Native sets `name` to the subclass, e.g. "APICallError".
+      code = str('code') || CODE_BY_NAME.get(err.name) || 'Other'
     }
 
     const wrapped = createByCode(code, message, status, retryMs, retryable)
-    if (providerCode !== undefined) {
-      ;(wrapped as { providerCode?: string }).providerCode = providerCode
+    // Each payload belongs to the one variant the core fills it for.
+    if (wrapped instanceof APICallError) {
+      assign(wrapped, {
+        providerCode: str('providerCode'),
+        providerMessage: str('providerMessage'),
+        responseBody: str('responseBody'),
+        requestId: str('requestId'),
+      })
+    } else if (wrapped instanceof NoSuchModelError) {
+      assign(wrapped, { modelId: str('modelId'), modelType: str('modelType') })
+    } else if (wrapped instanceof NoSuchProviderError) {
+      assign(wrapped, { providerId: str('providerId') })
     }
-    if (responseBody !== undefined) {
-      ;(wrapped as { responseBody?: string }).responseBody = responseBody
-    }
-    if (requestId !== undefined) {
-      ;(wrapped as { requestId?: string }).requestId = requestId
-    }
-    if (errorValue !== undefined) {
-      ;(wrapped as { errorValue?: string }).errorValue = errorValue
-    }
+    assign(wrapped, { errorValue: str('errorValue') })
     if (err instanceof Error) {
       ;(wrapped as Error & { cause?: unknown }).cause = err
     }
@@ -115,7 +90,49 @@ export class AimuxError extends Error {
   }
 }
 
-export class APICallError extends AimuxError {}
+/** Set the fields that are present; they are `readonly` to callers only. */
+function assign(target: object, fields: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) (target as Record<string, unknown>)[key] = value
+  }
+}
+
+/**
+ * A call that reached (or tried to reach) the provider. Classification is
+ * `status`; everything below is what that exchange produced, and lives on this
+ * class alone — the core fills these for no other variant (AI SDK likewise
+ * keeps `isRetryable` / `responseBody` / `data` on `APICallError`).
+ */
+export class APICallError extends AimuxError {
+  /** Rate-limit hint in ms; `-1` if none; `0` means retry immediately. */
+  readonly retryMs: number
+  /** Stored retry verdict (AI SDK `APICallError.isRetryable`). */
+  readonly retryable: boolean
+  /** Provider's machine-readable error code (e.g. `'rate_limit_exceeded'`). */
+  readonly providerCode?: string
+  /**
+   * The failure's own text, without the composed prefix: `message` reads
+   * `'API call error: HTTP 429: slow down'`, this reads `'slow down'`.
+   * Usually the provider's words; on a transport failure or a body the
+   * extractor could not read, it is ours. `responseBody` is the evidence.
+   */
+  readonly providerMessage?: string
+  /** Raw error response body, verbatim (AI SDK `APICallError.responseBody`). */
+  readonly responseBody?: string
+  /** Provider-assigned request id (`x-request-id` / `request-id` header). */
+  readonly requestId?: string
+
+  constructor(
+    message: string,
+    status: number = -1,
+    retryMs: number = -1,
+    retryable: boolean = false,
+  ) {
+    super(message, status)
+    this.retryMs = retryMs
+    this.retryable = retryable
+  }
+}
 export class JSONParseError extends AimuxError {}
 export class InvalidResponseDataError extends AimuxError {}
 export class ToolError extends AimuxError {}
@@ -123,18 +140,23 @@ export class InvalidArgumentError extends AimuxError {}
 export class InvalidPromptError extends AimuxError {}
 export class TokenExpiredError extends AimuxError {}
 export class UnsupportedFunctionalityError extends AimuxError {}
-export class NoSuchModelError extends AimuxError {}
-export class NoSuchProviderError extends AimuxError {}
+/** Registry lookup failed for a model id (AI SDK `NoSuchModelError`). */
+export class NoSuchModelError extends AimuxError {
+  /** The model id that did not resolve. */
+  readonly modelId?: string
+  /** Kind of model requested (`'languageModel'`, `'imageModel'`, …). */
+  readonly modelType?: string
+}
+/** Registry lookup failed for a provider name (AI SDK `NoSuchProviderError`). */
+export class NoSuchProviderError extends AimuxError {
+  /** The provider name that did not resolve. */
+  readonly providerId?: string
+}
 export class TimeoutError extends AimuxError {}
 /** Request aborted (not DOM `AbortError`). */
 export class RequestAbortedError extends AimuxError {
-  constructor(
-    message: string = 'request aborted',
-    status: number = -1,
-    retryMs: number = -1,
-    retryable: boolean = false,
-  ) {
-    super(message, status, retryMs, retryable)
+  constructor(message: string = 'request aborted', status: number = -1) {
+    super(message, status)
   }
 }
 export class OtherError extends AimuxError {}

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -712,17 +712,9 @@ pub fn init_recording_ring(cap: Option<u32>) -> error::AimuxResult<()> {
             Ok(())
         }
         // 显式 cap == 0:拒绝(与 Kotlin/Java/Python 一致)。
-        Some(0) => Err(crate::error::MappedError {
-            code: "InvalidArgument".to_string(),
-            message: "initRecordingRing: cap must be > 0".to_string(),
-            status: -1,
-            retry_ms: -1,
-            retryable: false,
-            provider_code: None,
-            request_id: None,
-            response_body: None,
-            error_value: None,
-        }),
+        Some(0) => Err(MappedError::from(&AiMuxError::InvalidArgument(
+            "initRecordingRing: cap must be > 0".into(),
+        ))),
         // 显式 cap > 0:指定容量的有界 ring。
         Some(c) => {
             aimux_core::recording::init_recording(Some(std::sync::Arc::new(

--- a/bindings/node/src/types/ApiCallError.ts
+++ b/bindings/node/src/types/ApiCallError.ts
@@ -37,7 +37,10 @@ status_code: number | null,
  */
 provider_code: string | null, 
 /**
- * The provider's message, verbatim. No status prefix.
+ * The failure's own text, without a status prefix — `Display` adds
+ * that. Usually the provider's words as extracted from the body; on a
+ * transport failure, or a body the extractor could not read, it is
+ * ours. `response_body` is the lossless evidence either way.
  */
 message: string, 
 /**
@@ -52,9 +55,13 @@ response_body: string | null,
  */
 request_id: string | null, 
 /**
- * Retry hint in milliseconds, distilled from the `retry-after-ms` /
- * `retry-after` response headers on a 429. The classification lives in
- * `status_code`; this is the matching action input.
+ * Retry hint in milliseconds, when the provider advertised one. Two
+ * sources: the `retry-after-ms` / `retry-after` response headers on any
+ * retryable status (RFC 7231 defines `Retry-After` for 503 as well as
+ * 429), and the `retry_after_ms` / `retry_after` members of a JSON error
+ * payload, which arrive on whatever status that payload came with. The
+ * classification lives in `status_code`; this is the matching action
+ * input, and it is never fabricated locally.
  */
 retry_after_ms: number | null, 
 /**

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -83,28 +83,41 @@ fn raise_variant(py: Python<'_>, e: &AiMuxError) -> PyResult<PyErr> {
         AiMuxError::Aborted => py.get_type_bound::<RequestAbortedError>(),
         AiMuxError::Other(_) => py.get_type_bound::<OtherError>(),
     };
-    let detail = match e {
-        AiMuxError::ApiCall(d) => Some(d),
-        _ => None,
-    };
     let inst = typ.call1((e.to_string(),))?;
-    // None when the core has no value (openai/anthropic convention: int | None).
+    // Carried by ApiCall (observed) and TokenExpired (401 by contract); None
+    // elsewhere, per the openai/anthropic convention of `int | None`.
     inst.setattr("status", e.status_code().map(i32::from))?;
-    inst.setattr("retry_ms", e.retry_after_hint())?;
-    inst.setattr("retryable", e.is_retryable())?;
-    // Structured fields from `ApiCallError` (AI SDK `APICallError` analogues).
-    inst.setattr(
-        "provider_code",
-        detail.and_then(|d| d.provider_code.as_deref()),
-    )?;
-    inst.setattr(
-        "response_body",
-        detail.and_then(|d| d.response_body.as_deref()),
-    )?;
-    inst.setattr(
-        "request_id",
-        detail.and_then(|d| d.request_id.as_deref()),
-    )?;
+    // Everything below belongs to the one variant the core fills it for —
+    // absent, not None-valued, on the others (AI SDK likewise keeps
+    // isRetryable / responseBody on APICallError alone).
+    match e {
+        AiMuxError::ApiCall(d) => {
+            inst.setattr("retry_ms", e.retry_after_hint())?;
+            inst.setattr("retryable", d.is_retryable)?;
+            inst.setattr("provider_code", d.provider_code.as_deref())?;
+            // str(e) is the composed "API call error: HTTP 429: …"; this is
+            // the failure's own text. Usually the provider's words — ours on
+            // a transport failure or an unreadable body (response_body is
+            // the evidence either way).
+            inst.setattr(
+                "provider_message",
+                (!d.message.is_empty()).then_some(d.message.as_str()),
+            )?;
+            inst.setattr("response_body", d.response_body.as_deref())?;
+            inst.setattr("request_id", d.request_id.as_deref())?;
+        }
+        AiMuxError::NoSuchModel {
+            model_id,
+            model_type,
+        } => {
+            inst.setattr("model_id", model_id.as_str())?;
+            inst.setattr("model_type", (!model_type.is_empty()).then_some(model_type.as_str()))?;
+        }
+        AiMuxError::NoSuchProvider { provider_id } => {
+            inst.setattr("provider_id", provider_id.as_str())?;
+        }
+        _ => {}
+    }
     // Lossless externally-tagged JSON of the source error (parity with C ABI).
     inst.setattr("error_value", serde_json::to_string(e).ok())?;
     Ok(PyErr::from_value_bound(inst))

--- a/bindings/python/tests/test_aimux.py
+++ b/bindings/python/tests/test_aimux.py
@@ -31,7 +31,7 @@ def test_provider_creates_registry_model():
 
 
 def test_provider_unknown_name_raises():
-    """provider() rejects unknown names with the available list."""
+    """provider() rejects unknown names, naming the one that did not resolve."""
     from aimux import provider
 
     with pytest.raises(Exception, match="no-such-provider"):

--- a/bindings/python/tests/test_error.py
+++ b/bindings/python/tests/test_error.py
@@ -1,0 +1,119 @@
+"""Error contract tests for the Python binding.
+
+Every failure is an ``AimuxError`` subclass. ``status`` is on the base — the
+observed status on ``APICallError``, 401 on ``TokenExpiredError``, ``None``
+elsewhere. Every other payload attribute belongs to the one exception class the
+core fills it for, and is *absent* (not ``None``) on the others.
+
+No outbound network: registry lookups fail before any request, and the API-call
+case talks to a mock server on 127.0.0.1.
+"""
+
+import json
+import socket
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from multiprocessing import Process
+
+import pytest
+
+# Attributes the core only ever fills on ApiCall.
+_API_CALL_ONLY = (
+    "retry_ms",
+    "retryable",
+    "provider_code",
+    "provider_message",
+    "response_body",
+    "request_id",
+)
+
+_ERROR_BODY = json.dumps(
+    {"error": {"message": "slow down", "type": "rate_limit_exceeded"}}
+)
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _rate_limited_server(port):
+    """Always answers 429 with a provider error body plus retry/request headers."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            resp = _ERROR_BODY.encode()
+            self.send_response(429)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(resp)))
+            self.send_header("x-request-id", "req_abc123")
+            self.send_header("retry-after-ms", "1500")
+            self.end_headers()
+            self.wfile.write(resp)
+
+        def log_message(self, *args):
+            pass
+
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+
+
+def test_no_such_provider_carries_provider_id():
+    from aimux import NoSuchProviderError, provider
+
+    with pytest.raises(NoSuchProviderError) as excinfo:
+        provider("definitely-not-a-provider", "sk-test-fake-key", "some-model")
+    err = excinfo.value
+
+    # The registry payload is an attribute, not something to dig out of JSON.
+    assert err.provider_id == "definitely-not-a-provider"
+    assert err.status is None
+    for attr in _API_CALL_ONLY:
+        assert not hasattr(err, attr), f"{attr} must not exist on {type(err).__name__}"
+
+
+def test_error_value_still_carries_the_raw_core_json():
+    from aimux import NoSuchProviderError, provider
+
+    with pytest.raises(NoSuchProviderError) as excinfo:
+        provider("definitely-not-a-provider", "sk-test-fake-key", "some-model")
+
+    parsed = json.loads(excinfo.value.error_value)
+    assert list(parsed) == ["NoSuchProvider"]
+    assert parsed["NoSuchProvider"]["provider_id"] == "definitely-not-a-provider"
+
+
+def test_api_call_error_carries_every_field_the_response_produced():
+    from aimux import APICallError, generate_text, openai
+
+    port = _free_port()
+    proc = Process(target=_rate_limited_server, args=(port,))
+    proc.start()
+    try:
+        for _ in range(50):
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.connect(("127.0.0.1", port))
+                break
+            except ConnectionRefusedError:
+                time.sleep(0.05)
+
+        model = openai("test-key", "gpt-4o", f"http://127.0.0.1:{port}")
+        with pytest.raises(APICallError) as excinfo:
+            generate_text(model, "hi")
+        err = excinfo.value
+
+        assert err.status == 429
+        assert err.retry_ms == 1500
+        assert err.retryable is True
+        assert err.provider_code == "rate_limit_exceeded"
+        assert err.request_id == "req_abc123"
+        assert err.response_body == _ERROR_BODY
+        # The provider's text on its own; str(e) is the composed form.
+        assert err.provider_message == "slow down"
+        assert "slow down" in str(err)
+        assert str(err) != err.provider_message
+    finally:
+        proc.terminate()
+        proc.join(timeout=2)

--- a/bindings/swift/Sources/Aimux/Aimux.swift
+++ b/bindings/swift/Sources/Aimux/Aimux.swift
@@ -64,31 +64,34 @@ func ffiStringCall(
 ///     // Classification is the status field: 429 → rate limited (e.retryMs),
 ///     // 401 → auth, 404 → model not found.
 ///     if case .apiCall = e, e.status == 429 { /* back off */ }
+///     // Whether a retry is worth it is `e.retryable`, never the status.
+///     if e.retryable { /* retry */ }
 /// }
 /// ```
 public enum AimuxError: Error, LocalizedError, CustomStringConvertible, Equatable, Sendable {
     /// Local: model/provider handle is 0 or already released.
     case invalidHandle
 
-    case jsonParse(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case invalidResponseData(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case tool(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case invalidArgument(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case invalidPrompt(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case tokenExpired(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case unsupportedFunctionality(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case noSuchModel(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case noSuchProvider(message: String, status: Int, retryMs: Int64, errorValue: String?)
+    case jsonParse(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case invalidResponseData(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case tool(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case invalidArgument(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case invalidPrompt(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case tokenExpired(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case unsupportedFunctionality(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case noSuchModel(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case noSuchProvider(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
     /// Every HTTP-shaped failure: read `status` to classify (401 auth,
     /// 404 model, 429 rate limit). A `nil` status means no HTTP response was
     /// ever observed — a missing API key, an error built without a request, or
-    /// a transport failure — and says nothing about whether a retry would help.
-    case apiCall(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case timeout(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case aborted(message: String, status: Int, retryMs: Int64, errorValue: String?)
-    case other(message: String, status: Int, retryMs: Int64, errorValue: String?)
+    /// a transport failure; read `retryable` to tell those apart, `status`
+    /// cannot.
+    case apiCall(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case timeout(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case aborted(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
+    case other(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
     /// `AIMUX_E_UNKNOWN` or an unexpected/future code.
-    case unknown(message: String, status: Int, retryMs: Int64, errorValue: String?)
+    case unknown(message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)
 
     /// Binding-local encode/decode failure (not produced by the C ABI).
     case serializationError(String)
@@ -96,25 +99,25 @@ public enum AimuxError: Error, LocalizedError, CustomStringConvertible, Equatabl
     // MARK: Accessors
 
     /// The C-derived payload, or `nil` for the binding-local cases.
-    private var payload: (message: String, status: Int, retryMs: Int64, errorValue: String?)? {
+    private var payload: (message: String, status: Int, retryMs: Int64, retryable: Bool, errorValue: String?)? {
         switch self {
         case .invalidHandle, .serializationError:
             return nil
-        case .jsonParse(let m, let s, let r, let v),
-             .invalidResponseData(let m, let s, let r, let v),
-             .tool(let m, let s, let r, let v),
-             .invalidArgument(let m, let s, let r, let v),
-             .invalidPrompt(let m, let s, let r, let v),
-             .tokenExpired(let m, let s, let r, let v),
-             .unsupportedFunctionality(let m, let s, let r, let v),
-             .noSuchModel(let m, let s, let r, let v),
-             .noSuchProvider(let m, let s, let r, let v),
-             .apiCall(let m, let s, let r, let v),
-             .timeout(let m, let s, let r, let v),
-             .aborted(let m, let s, let r, let v),
-             .other(let m, let s, let r, let v),
-             .unknown(let m, let s, let r, let v):
-            return (m, s, r, v)
+        case .jsonParse(let m, let s, let r, let t, let v),
+             .invalidResponseData(let m, let s, let r, let t, let v),
+             .tool(let m, let s, let r, let t, let v),
+             .invalidArgument(let m, let s, let r, let t, let v),
+             .invalidPrompt(let m, let s, let r, let t, let v),
+             .tokenExpired(let m, let s, let r, let t, let v),
+             .unsupportedFunctionality(let m, let s, let r, let t, let v),
+             .noSuchModel(let m, let s, let r, let t, let v),
+             .noSuchProvider(let m, let s, let r, let t, let v),
+             .apiCall(let m, let s, let r, let t, let v),
+             .timeout(let m, let s, let r, let t, let v),
+             .aborted(let m, let s, let r, let t, let v),
+             .other(let m, let s, let r, let t, let v),
+             .unknown(let m, let s, let r, let t, let v):
+            return (m, s, r, t, v)
         }
     }
 
@@ -136,6 +139,15 @@ public enum AimuxError: Error, LocalizedError, CustomStringConvertible, Equatabl
     public var retryMs: Int64? {
         guard let payload, payload.retryMs >= 0 else { return nil }
         return payload.retryMs
+    }
+
+    /// Whether retrying may help — the engine's verdict, carried across the C
+    /// ABI. Not derivable from `status`: a transport failure (request went
+    /// out, connection reset) and a missing API key (request never went out)
+    /// both report no status and disagree here. `false` for the
+    /// binding-local cases.
+    public var retryable: Bool {
+        payload?.retryable ?? false
     }
 
     /// Raw lossless machine-readable form of the source error: the
@@ -179,38 +191,39 @@ public enum AimuxError: Error, LocalizedError, CustomStringConvertible, Equatabl
         }
         let status = Int(e.status)
         let retryMs = e.retry_ms
+        let retryable = e.retryable != 0
         let message = rawMsg.isEmpty ? "aimux: operation failed" : rawMsg
 
         switch e.code {
         case AIMUX_E_JSON_PARSE:
-            return .jsonParse(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .jsonParse(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_INVALID_RESPONSE_DATA:
-            return .invalidResponseData(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .invalidResponseData(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_TOOL:
-            return .tool(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .tool(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_INVALID_ARGUMENT:
-            return .invalidArgument(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .invalidArgument(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_INVALID_PROMPT:
-            return .invalidPrompt(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .invalidPrompt(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_TOKEN_EXPIRED:
             // TokenExpired is definitionally an observed 401 (RFC-0018).
-            return .tokenExpired(message: message, status: status == -1 ? 401 : status, retryMs: retryMs, errorValue: errorValue)
+            return .tokenExpired(message: message, status: status == -1 ? 401 : status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_UNSUPPORTED_FUNCTIONALITY:
-            return .unsupportedFunctionality(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .unsupportedFunctionality(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_NO_SUCH_MODEL:
-            return .noSuchModel(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .noSuchModel(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_NO_SUCH_PROVIDER:
-            return .noSuchProvider(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .noSuchProvider(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_API_CALL:
-            return .apiCall(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .apiCall(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_TIMEOUT:
-            return .timeout(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .timeout(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_ABORTED:
-            return .aborted(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .aborted(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         case AIMUX_E_OTHER:
-            return .other(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .other(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         default:
-            return .unknown(message: message, status: status, retryMs: retryMs, errorValue: errorValue)
+            return .unknown(message: message, status: status, retryMs: retryMs, retryable: retryable, errorValue: errorValue)
         }
     }
 }
@@ -463,6 +476,7 @@ public final class Model: @unchecked Sendable {
                 message: "aimux: initRecordingRing requires cap > 0 (got \(cap ?? 0))",
                 status: -1,
                 retryMs: -1,
+                retryable: false,
                 errorValue: nil
             )
         }
@@ -738,7 +752,8 @@ public final class Model: @unchecked Sendable {
             onError(e)
         } catch {
             // withCError only throws AimuxError.
-            onError(.unknown(message: "\(error)", status: -1, retryMs: -1, errorValue: nil))
+            onError(.unknown(message: "\(error)", status: -1, retryMs: -1, retryable: false,
+                             errorValue: nil))
         }
     }
 

--- a/bindings/swift/Sources/Aimux/Aimux.swift
+++ b/bindings/swift/Sources/Aimux/Aimux.swift
@@ -80,7 +80,9 @@ public enum AimuxError: Error, LocalizedError, CustomStringConvertible, Equatabl
     case noSuchModel(message: String, status: Int, retryMs: Int64, errorValue: String?)
     case noSuchProvider(message: String, status: Int, retryMs: Int64, errorValue: String?)
     /// Every HTTP-shaped failure: read `status` to classify (401 auth,
-    /// 404 model, 429 rate limit; `nil` status = transport failure).
+    /// 404 model, 429 rate limit). A `nil` status means no HTTP response was
+    /// ever observed — a missing API key, an error built without a request, or
+    /// a transport failure — and says nothing about whether a retry would help.
     case apiCall(message: String, status: Int, retryMs: Int64, errorValue: String?)
     case timeout(message: String, status: Int, retryMs: Int64, errorValue: String?)
     case aborted(message: String, status: Int, retryMs: Int64, errorValue: String?)

--- a/bindings/swift/Tests/AimuxTests/AimuxTests.swift
+++ b/bindings/swift/Tests/AimuxTests/AimuxTests.swift
@@ -62,24 +62,43 @@ final class AimuxTests: XCTestCase {
     func testApiCallClassifiesByStatus() {
         let rateLimited = AimuxError.apiCall(
             message: "API call error: HTTP 429: slow down",
-            status: 429, retryMs: 1500, errorValue: nil
+            status: 429, retryMs: 1500, retryable: true, errorValue: nil
         )
         XCTAssertEqual(rateLimited.status, 429)
         XCTAssertEqual(rateLimited.retryMs, 1500)
+        XCTAssertTrue(rateLimited.retryable)
 
         let auth = AimuxError.apiCall(
             message: "API call error: HTTP 401: invalid api key",
-            status: 401, retryMs: -1, errorValue: nil
+            status: 401, retryMs: -1, retryable: false, errorValue: nil
         )
         XCTAssertEqual(auth.status, 401)
         XCTAssertNil(auth.retryMs)
+        XCTAssertFalse(auth.retryable)
 
         // Transport failure: no response, so no status.
         let transport = AimuxError.apiCall(
             message: "API call error: connection reset",
-            status: -1, retryMs: -1, errorValue: nil
+            status: -1, retryMs: -1, retryable: true, errorValue: nil
         )
         XCTAssertNil(transport.status)
+    }
+
+    /// `retryable` is not derivable from `status`: both of these report no
+    /// status and disagree about whether a retry is worth attempting.
+    func testRetryableIsNotDerivableFromStatus() {
+        let transport = AimuxError.apiCall(
+            message: "API call error: connection reset",
+            status: -1, retryMs: -1, retryable: true, errorValue: nil
+        )
+        let missingKey = AimuxError.apiCall(
+            message: "API call error: missing api key",
+            status: -1, retryMs: -1, retryable: false, errorValue: nil
+        )
+        XCTAssertNil(transport.status)
+        XCTAssertNil(missingKey.status)
+        XCTAssertTrue(transport.retryable)
+        XCTAssertFalse(missingKey.retryable)
     }
 
     /// End to end: a 401 from the provider surfaces as `.apiCall` with the

--- a/docs/api/c.md
+++ b/docs/api/c.md
@@ -54,7 +54,7 @@ Every fallible call takes a trailing `AimuxError *err` (may be `NULL`).
 | Failure + `err == NULL` | Still fails; no details (caller discarded them) |
 | Success | Use the return value; `*err` is **not touched** |
 
-The struct is 40 bytes (four fields plus two reserved pointer slots for future ABI extension); on failure `message` is allocated by aimux and the
+The struct is 40 bytes (five fields plus one reserved pointer slot for future ABI extension); on failure `message` is allocated by aimux and the
 caller **must release it with `aimux_free_string`** after reading. Initialize
 with `aimux_error_clear` (or `= {0}`) before first use.
 
@@ -79,8 +79,11 @@ Internal panics abort the process (the workspace builds with `panic=abort`).
 
 Codes: `AIMUX_OK`, `AIMUX_E_UNKNOWN`, plus **13** values mirroring
 `aimux-core::AiMuxError` (`AIMUX_E_JSON_PARSE=2` … `AIMUX_E_OTHER=14`,
-numbered consecutively). The enum is
-append-only; always handle `default` / `AIMUX_E_UNKNOWN`.
+numbered consecutively). The values are **not** append-only — they were
+renumbered once already (the range used to be 2..19 with gaps and other
+names), so a consumer built against an older header misreads every code:
+recompile against the current `aimux-error.h` rather than pinning the numbers.
+Always handle `default` / `AIMUX_E_UNKNOWN`.
 
 ### Quick start
 
@@ -119,7 +122,8 @@ if (!handle) {
     case AIMUX_E_API_CALL:
         /* every HTTP-shaped failure; classify on err.status */
         if (err.status == 429) {
-            /* rate limited — use err.retry_ms */
+            /* rate limited — use err.retry_ms only if >= 0 (the
+               headers may carry no hint), else your own backoff */
         } else if (err.status == 401) {
             fprintf(stderr, "auth HTTP 401: %s\n", err.message);
         }

--- a/docs/api/c.md
+++ b/docs/api/c.md
@@ -54,7 +54,8 @@ Every fallible call takes a trailing `AimuxError *err` (may be `NULL`).
 | Failure + `err == NULL` | Still fails; no details (caller discarded them) |
 | Success | Use the return value; `*err` is **not touched** |
 
-The struct is 40 bytes (five fields plus one reserved pointer slot for future ABI extension); on failure `message` is allocated by aimux and the
+The struct is 40 bytes (six fields plus a 4-byte reserved slot for future ABI
+extension); on failure `message` is allocated by aimux and the
 caller **must release it with `aimux_free_string`** after reading. Initialize
 with `aimux_error_clear` (or `= {0}`) before first use.
 
@@ -65,9 +66,16 @@ typedef struct AimuxError {
     int64_t retry_ms;      /* ApiCall retry hint (retry_after_ms), or -1; 0 = retry now */
     char *message;         /* owned; free with aimux_free_string */
     char *error_value;     /* owned; lossless AiMuxError JSON, or NULL */
-    void *reserved[1];     /* future ABI room; always zero */
+    int retryable;         /* 1 = retrying may help, 0 = it will not */
+    int reserved;          /* future ABI room; always zero */
 } AimuxError;
 ```
+
+Branch on `retryable`, never on the `status` sentinel: a transport failure and
+a missing API key both report `status == -1` and disagree about whether a retry
+would help. `retry_ms` is a *hint* that rides along — it is `-1` whenever the
+response carried no `retry-after` header, including on a retryable status, so
+fall back to your own exponential backoff when it is negative.
 
 `error_value` carries the machine-readable source error — the
 externally-tagged JSON of aimux-core's `AiMuxError`, e.g.

--- a/docs/api/java.md
+++ b/docs/api/java.md
@@ -106,7 +106,7 @@ try (Model model = Model.openai("sk-...", "gpt-4o")) {
     // 401 — refresh the token and retry
 } catch (APICallError e) {
     // Classify on status: 429 → rate limited (e.getRetryMs()),
-    // 401 → auth, 404 → model; -1 → transport failure
+    // 401 → auth, 404 → model; -1 → no HTTP response observed
 } catch (AimuxException e) {
     // any engine / binding failure
 }

--- a/docs/api/kotlin.md
+++ b/docs/api/kotlin.md
@@ -81,7 +81,7 @@ try {
     // 401 — refresh the token and retry
 } catch (e: APICallError) {
     // Classify on status: 429 → rate limited (e.retryMs),
-    // 401 → auth, 404 → model not found, -1 → transport failure
+    // 401 → auth, 404 → model not found, -1 → no HTTP response observed
 } catch (e: AimuxException) {
     // e.code (AIMUX_E_*), e.status, e.retryMs
 }

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -98,7 +98,12 @@ Error
       └── OtherError
 ```
 
-Every instance has `message`, `status` (HTTP or `-1`), and `retryMs` (hint or `-1`).
+Every instance has `message`, `code`, `status` (HTTP or `-1`) and `errorValue`.
+Payload fields belong to the class that carries them: `APICallError` adds
+`retryMs` / `retryable` / `providerCode` / `providerMessage` /
+`responseBody` / `requestId`,
+`NoSuchModelError` adds `modelId` / `modelType`, `NoSuchProviderError` adds
+`providerId`.
 
 ```typescript
 import { generateText, AimuxError, APICallError } from 'aimux'

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -331,10 +331,15 @@ Exception
       └── OtherError
 ```
 
-Instances carry `status` (HTTP status or `None`), `retry_ms` (hint or `None`),
-and `error_value: str | None` — the raw externally-tagged AiMuxError JSON
-(e.g. `'{"ApiCall":{"status_code":429,"retry_after_ms":1500,...}}'`), the
+Instances carry `status` (HTTP status or `None`) and `error_value: str | None`
+— the raw externally-tagged AiMuxError JSON (e.g.
+`'{"ApiCall":{"status_code":429,"retry_after_ms":1500,...}}'`), the
 machine-readable companion to `str(e)`.
+
+Payload attributes belong to the class that carries them, and are absent on the
+others: `APICallError` has `retry_ms` / `retryable` / `provider_code` /
+`provider_message` / `response_body` / `request_id`, `NoSuchModelError` has `model_id` /
+`model_type`, `NoSuchProviderError` has `provider_id`.
 
 ```python
 from aimux import (


### PR DESCRIPTION
Two error-surface fixes that follow #94's structured fields through to the
bindings. The first is additive across all eight; the second is a breaking
change confined to node and python.

## The retry verdict never crossed the ABI

`is_retryable()` is one of three accessors on `AiMuxError`, and six of the
eight bindings could not read it: it had no field on the C struct, so Go, Java,
Kotlin, Swift, Flutter and C could only recover it by hand-parsing the
`error_value` JSON. The documented workaround — infer it from the status
sentinel — does not work: a transport failure and a missing API key both report
status `-1` and disagree on whether a retry is worth attempting. A pinned test
now states that pair.

`AimuxError` gains `retryable`, spending the reserved slot that existed for
exactly this. The struct is still 40 bytes, so the three layout assertions
(Rust, Java, Flutter) hold unchanged and `reserved` keeps 4 bytes of room.
`aimux_error_clear` zeroes both. Every wrapper surfaces the field, and the C
examples branch on it instead of guessing from the status.

Two adjacent contract bugs travelled with it:

- **`Retry-After` was read on 429 alone.** RFC 7231 defines the header for 503
  as well, and the AI SDK consults it for any retryable failure, so a 503 or
  408 that advertised a delay had it dropped.
- **`catalogue.rs` classified 408 and 409 as non-retryable**, disagreeing with
  the policy `response.rs` actually applies and with the field's own doc.

Three doc claims that contradicted the code are corrected: `ApiCallError.message`
is not always the provider's words (transport strings and unreadable bodies land
there too), `retry_after_ms` has a second source in the JSON error payload and is
not 429-gated, and `NoSuchModel` is marked reserved — nothing constructs it, so an
unknown model id still arrives as an `ApiCall` 404 and callers must not branch on
it expecting coverage.

## Payload fields belonged to every error, including the ones that never carry them

The native bindings flattened every `ApiCall` detail onto the base error, so
`ToolError`, `TimeoutError` and `InvalidArgumentError` all carried `retryMs`,
`retryable`, `providerCode`, `responseBody` and `requestId` as permanently empty
properties — the core fills them for no variant but `ApiCall`. The AI SDK keeps
`isRetryable` / `responseBody` on `APICallError` alone; node and python take the
native path (napi-rs / pyo3, no fixed-layout struct in the way) and can do the
same.

- `APICallError` owns `retryMs` / `retryable` / `providerCode` / `responseBody` /
  `requestId`. The base keeps `code`, `status` and `errorValue`: status is carried
  by `ApiCall` (observed) and `TokenExpired` (401 by contract), so it stays shared.
- `NoSuchModelError` exposes `modelId` / `modelType` and `NoSuchProviderError`
  exposes `providerId`. The core has carried these as struct fields all along;
  both bindings dropped them, leaving callers to parse `errorValue` JSON by hand.
- Python sets the attributes only on the owning class, so a missing field is
  absent rather than `None` — `hasattr` now answers the question honestly.

**Breaking, node and python only:** code that read `err.retryable` (or
`responseBody`, `providerCode`, `requestId`, `retryMs`) off a non-`ApiCall` error
was reading a permanently empty value; it now needs an `APICallError` check. The
C-ABI bindings are unchanged — their fixed-layout `AimuxError` struct is the
protocol, and a flat field set is correct there.

## Rebase note

Rebased onto current `master`. Two call sites added by #100 needed to follow the
signature changes here, both mechanical:

- `normalize_config_json` calls `fill_error`, which gains a `retryable` argument. It
  passes `false`: a non-UTF-8 config string is a boundary-synthesized failure, and
  retrying an unchanged argument cannot help — the same verdict the core gives every
  non-`ApiCall` variant.
- the `zero_err()` test helper constructs `CAimuxError`, which gains `retryable` and
  narrows `reserved`; it now sets both to `0`.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace` and `python3 scripts/gen_ts_types.py --check` all clean on
the rebased head.