### PR TITLE
fix(providers): use tool_name for Gemini functionResponse.name

### DIFF
--- a/aimux-providers/src/google/convert.rs
+++ b/aimux-providers/src/google/convert.rs
@@ -213,6 +213,7 @@ fn convert_tool_parts(content: &[ContentPart]) -> Vec<Value> {
     for part in content {
         if let ContentPart::ToolResult {
             tool_call_id,
+            tool_name,
             result,
             ..
         } = part
@@ -225,12 +226,16 @@ fn convert_tool_parts(content: &[ContentPart]) -> Vec<Value> {
             if !tool_call_id.is_empty() {
                 function_response.insert("id".to_string(), json!(tool_call_id));
             }
-            // `name` is required by the API; the TS SDK uses the tool name
-            // from the part. We don't have it on `ToolResult`, so we fall
-            // back to the call id. This is sufficient for round-tripping
-            // with our own test fixtures; production callers that need the
-            // real tool name should use `ContentPart::ToolCall` first.
-            let name = tool_call_id.clone();
+            // `name` is required by the API and must be the name of the tool
+            // that was called (Gemini pairs functionResponse with the prior
+            // functionCall by name; an empty or mismatched name is rejected
+            // with HTTP 400 on multi-turn tool calls). Prefer the framework
+            // provided `tool_name`, falling back to the call id for callers
+            // that never set one.
+            let name = tool_name
+                .clone()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| tool_call_id.clone());
             function_response.insert("name".to_string(), json!(name));
             function_response.insert(
                 "response".to_string(),

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -1885,9 +1885,38 @@ mod request_body {
         assert_eq!(tool_msg["role"], "user");
         let fr = &tool_msg["parts"][0]["functionResponse"];
         assert_eq!(fr["id"], "call-1");
+        // Without a tool_name the call id is used as the required `name`
+        // (fallback path).
+        assert_eq!(fr["name"], "call-1");
+        assert_eq!(fr["response"]["name"], "call-1");
         // The serialized JSON output is a string under response.content.
         let content_str = fr["response"]["content"].as_str().unwrap();
         assert!(content_str.contains("\"temp\":70"));
+    }
+
+    #[test]
+    fn tool_result_uses_tool_name_for_function_response() {
+        let prompt: LanguageModelPrompt = vec![LanguageModelPromptMessage {
+            role: Role::Tool,
+            content: vec![ContentPart::ToolResult {
+                tool_call_id: "call-9".to_string(),
+                result: json!({ "temp": 21 }),
+                tool_name: Some("weather".to_string()),
+                is_error: None,
+                preliminary: None,
+                dynamic: None,
+                provider_options: None,
+            }],
+            ..Default::default()
+        }];
+        let body = build_request_body("gemini-2.0-flash", &default_options(prompt));
+
+        let fr = &body["contents"][0]["parts"][0]["functionResponse"];
+        assert_eq!(fr["id"], "call-9");
+        // `name` carries the real tool name, not the opaque call id —
+        // Gemini pairs functionResponse with the prior functionCall by name.
+        assert_eq!(fr["name"], "weather");
+        assert_eq!(fr["response"]["name"], "weather");
     }
 
     // ── tools → tools array with functionDeclarations ─────────────────────────

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -1919,6 +1919,28 @@ mod request_body {
         assert_eq!(fr["response"]["name"], "weather");
     }
 
+    #[test]
+    fn tool_result_blank_tool_name_falls_back_to_call_id() {
+        // An explicitly blank tool_name is treated as unset and falls back
+        // to the call id (locks the empty-string filter branch).
+        let prompt: LanguageModelPrompt = vec![LanguageModelPromptMessage {
+            role: Role::Tool,
+            content: vec![ContentPart::ToolResult {
+                tool_call_id: "call-blank".to_string(),
+                result: json!({ "ok": true }),
+                tool_name: Some(String::new()),
+                is_error: None,
+                preliminary: None,
+                dynamic: None,
+                provider_options: None,
+            }],
+            ..Default::default()
+        }];
+        let body = build_request_body("gemini-2.0-flash", &default_options(prompt));
+        let fr = &body["contents"][0]["parts"][0]["functionResponse"];
+        assert_eq!(fr["name"], "call-blank");
+    }
+
     // ── tools → tools array with functionDeclarations ─────────────────────────
 
     #[test]


### PR DESCRIPTION
Fixes #111（Round 4 审计 4b-H1，独立校验后口径）

## 问题

`convert_tool_parts` 用 `tool_call_id` 填 Gemini 必填的 `functionResponse.name` 并忽略 `ToolResult.tool_name`。Gemini 按 name 配对 functionResponse 与前序 functionCall；非流式路径无 id 时回传空 name，多轮工具调用几乎必然 400。

## 修复

- 优先使用框架提供的 `tool_name`，未设置时回退 call id（兼容既有调用方）
- `response.name` 与外层 name 保持一致
- 删除失实注释 "We don't have it on ToolResult"（content.rs:128 字段一直存在，TS SDK 正是用 toolName）

## 测试

- `tool_result_becomes_function_response_part` 补 fallback 断言（name == call id）
- 新增 `tool_result_uses_tool_name_for_function_response`（tool_name 优先）
- google_model_test 79 + google_remaining_test 40 + google_provider_tools_test 81 全过；fmt/clippy 干净