### PR TITLE
fix(providers): emit Finish after in-stream errors in anthropic do_stream

### DIFF
--- a/aimux-providers/src/anthropic/stream.rs
+++ b/aimux-providers/src/anthropic/stream.rs
@@ -270,6 +270,7 @@ pub(crate) async fn anthropic_stream_core(
         let mut final_usage = Usage::default();
         let mut final_finish_reason: Option<FinishReason> = None;
         let mut response_meta_emitted = false;
+        let mut stream_errored = false;
 
         while let Some(event) = sse.next().await {
             match event {
@@ -491,7 +492,12 @@ pub(crate) async fn anthropic_stream_core(
                                     ..Default::default()
                                 }),
                             });
-                            return;
+                            // Finish is the final-chunk contract: it must
+                            // still terminate the stream after an in-stream
+                            // error (openai and google do the same), so
+                            // downstream aggregators see a well-formed end.
+                            stream_errored = true;
+                            break;
                         }
                         Ok(_) | Err(_) => {}
                     }
@@ -500,18 +506,30 @@ pub(crate) async fn anthropic_stream_core(
                     yield Ok(StreamPart::Error {
                         error: AiMuxError::InvalidResponseData(e.to_string()),
                     });
-                    return;
+                    stream_errored = true;
+                    break;
                 }
             }
         }
 
         // Final part: Finish.
         yield Ok(StreamPart::Finish {
-            finish_reason: final_finish_reason.unwrap_or(FinishReason {
-                unified: FinishReasonUnified::Stop,
-                raw: None,
-            }),
-            usage: final_usage,
+            finish_reason: if stream_errored {
+                FinishReason {
+                    unified: FinishReasonUnified::Error,
+                    raw: None,
+                }
+            } else {
+                final_finish_reason.unwrap_or(FinishReason {
+                    unified: FinishReasonUnified::Stop,
+                    raw: None,
+                })
+            },
+            usage: if stream_errored {
+                Usage::default()
+            } else {
+                final_usage
+            },
             provider_metadata: None,
         });
     };

--- a/aimux-providers/tests/anthropic_model_test.rs
+++ b/aimux-providers/tests/anthropic_model_test.rs
@@ -1477,7 +1477,8 @@ mod do_stream {
         .await;
 
         // The stream must contain a StreamPart::Error carrying the provider
-        // message, and must NOT emit a Finish after it.
+        // message, followed by an error-finish (Finish is the final-chunk
+        // contract, matching openai/google — see #112).
         let error_idx = parts
             .iter()
             .position(|p| matches!(p, StreamPart::Error { .. }));
@@ -1489,7 +1490,12 @@ mod do_stream {
             }
             _ => unreachable!(),
         }
-        // Nothing after the Error.
-        assert_eq!(parts.len(), error_idx + 1);
+        // Error is followed by exactly one Finish with unified=Error.
+        assert_eq!(parts.len(), error_idx + 2);
+        assert!(matches!(
+            &parts[error_idx + 1],
+            StreamPart::Finish { finish_reason, .. }
+                if matches!(finish_reason.unified, FinishReasonUnified::Error)
+        ));
     }
 }

--- a/aimux-providers/tests/provider_error_test.rs
+++ b/aimux-providers/tests/provider_error_test.rs
@@ -554,6 +554,15 @@ mod anthropic_stream_errors {
                 StreamPart::Error { error: AiMuxError::ApiCall(m) } if m.message == "Overloaded")),
             "expected a StreamPart::Error carrying 'Overloaded', got {parts:?}"
         );
+        // Finish is the final-chunk contract: the stream must terminate with
+        // an error-finish even when the very first event is an error.
+        assert!(
+            matches!(parts.last(),
+                Some(StreamPart::Finish { finish_reason, .. })
+                    if matches!(finish_reason.unified,
+                        aimux_core::prelude::FinishReasonUnified::Error)),
+            "expected the last part to be Finish with unified=Error, got {parts:?}"
+        );
     }
 
     /// TS: "should forward error chunks" + "should forward overloaded error
@@ -598,6 +607,16 @@ mod anthropic_stream_errors {
                 StreamPart::Error { error: AiMuxError::ApiCall(m) } if m.message == "Overloaded")),
             "expected a StreamPart::Error carrying 'Overloaded', got {parts:?}"
         );
+
+        // Finish=final chunk: a mid-stream error must still be followed by a
+        // Finish part (error finish), never leave the stream unterminated.
+        assert!(
+            matches!(parts.last(),
+                Some(StreamPart::Finish { finish_reason, .. })
+                    if matches!(finish_reason.unified,
+                        aimux_core::prelude::FinishReasonUnified::Error)),
+            "expected the last part to be Finish with unified=Error, got {parts:?}"
+        );
     }
 
     /// TS: "should forward error chunks" — a generic (non-overloaded) error
@@ -627,6 +646,13 @@ mod anthropic_stream_errors {
             parts.iter().any(|p| matches!(p,
                 StreamPart::Error { error: AiMuxError::ApiCall(m) } if m.message == "test error")),
             "expected a StreamPart::Error carrying 'test error', got {parts:?}"
+        );
+        assert!(
+            matches!(parts.last(),
+                Some(StreamPart::Finish { finish_reason, .. })
+                    if matches!(finish_reason.unified,
+                        aimux_core::prelude::FinishReasonUnified::Error)),
+            "expected the last part to be Finish with unified=Error, got {parts:?}"
         );
     }
 }

--- a/aimux-providers/tests/provider_error_test.rs
+++ b/aimux-providers/tests/provider_error_test.rs
@@ -617,6 +617,14 @@ mod anthropic_stream_errors {
                         aimux_core::prelude::FinishReasonUnified::Error)),
             "expected the last part to be Finish with unified=Error, got {parts:?}"
         );
+        // Error-finish zeroes usage: the message_start input_tokens (17)
+        // must not leak into the final part (mirrors openai behaviour).
+        if let Some(StreamPart::Finish { usage, .. }) = parts.last() {
+            assert_eq!(
+                usage.input_tokens.total, None,
+                "usage must be zeroed on error finish"
+            );
+        }
     }
 
     /// TS: "should forward error chunks" — a generic (non-overloaded) error


### PR DESCRIPTION
Fixes #112（Round 4 审计 4b-H2，经独立校验）

## 问题

anthropic 流错误（overloaded 等）yield Error 后直接 `return`，跳过终止 Finish——违反 "Finish=Final chunk" 契约（`stream_part.rs:42`、RFC-0026:384），openai/google 均为 Error+Finish。校验确认的实际影响：openai 兼容层把错误流误报为 finish_reason "stop"（openai_output.rs:863-867）、moa 丢失参考 usage。

## 修复

对齐 openai 模式：`stream_errored` 标志 + `break`，最终 Finish 以 `unified: Error` + 清零 usage 收尾。

## 测试

- anthropic_model_test `should_forward_in_stream_error_event` 从锁定旧错误行为的断言（"Error 后无任何部分"）更新为新契约（Error 后恰一个 error-Finish）
- provider_error_test 三个流错误用例补 Finish 终结断言
- anthropic_model 44 + provider_error 21 全过；fmt/clippy 干净
- `anthropic_aws_sigv4_auth` 失败为 #125 预存环境问题（http_proxy），与本改动无关