### PR TITLE
fix(providers): include non-default port in SigV4 host header

### DIFF
--- a/aimux-providers/src/bedrock/sigv4.rs
+++ b/aimux-providers/src/bedrock/sigv4.rs
@@ -57,7 +57,16 @@ pub fn sign_request(
 ) -> SignedRequest {
     let parsed =
         url::Url::parse(url).unwrap_or_else(|_| url::Url::parse("http://localhost").unwrap());
-    let host = parsed.host_str().unwrap_or("");
+    // The signed host must match the wire host: keep the port whenever the
+    // URL carries a non-default one (Url::port() is Some only for non-default
+    // ports). Signing a bare host diverges from the Host header reqwest would
+    // otherwise send, so gateways and proxies on non-standard ports reject the
+    // signature (observed as 502 when an env proxy forwarded a signed
+    // loopback request whose host lacked the port).
+    let host = match parsed.port() {
+        Some(port) => format!("{}:{}", parsed.host_str().unwrap_or(""), port),
+        None => parsed.host_str().unwrap_or("").to_string(),
+    };
     let path = parsed.path();
     let query = parsed.query().unwrap_or("");
 
@@ -160,4 +169,56 @@ fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
     let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(data);
     mac.finalize().into_bytes().to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn creds() -> AwsCredentials {
+        AwsCredentials {
+            access_key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
+            session_token: None,
+            region: "us-east-1".to_string(),
+        }
+    }
+
+    fn host_header(signed: &SignedRequest) -> String {
+        signed
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("host"))
+            .map(|(_, v)| v.clone())
+            .expect("signed request carries a host header")
+    }
+
+    #[test]
+    fn host_keeps_non_default_port() {
+        let signed = sign_request(
+            &creds(),
+            "bedrock",
+            "POST",
+            "http://127.0.0.1:54321/model/x/invoke",
+            "{}",
+            &[],
+        );
+        assert_eq!(host_header(&signed), "127.0.0.1:54321");
+    }
+
+    #[test]
+    fn host_omits_default_port() {
+        let signed = sign_request(
+            &creds(),
+            "bedrock",
+            "POST",
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/invoke",
+            "{}",
+            &[],
+        );
+        assert_eq!(
+            host_header(&signed),
+            "bedrock-runtime.us-east-1.amazonaws.com"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #125（Round 4 审计 + 独立校验发现的真实签名缺陷；"时间敏感"机理已被校验推翻）

## 问题

`sign_request` 用 `Url::host_str()` 构造被签名 host，丢失端口。非 443/80 端点的签名 host 与线上 Host 头不一致：环境 `http_proxy`（无 no_proxy）转发该回环请求时返回空体 502——这正是 anthropic_aws_sigv4_auth 等测试在插桩/代理环境失败的根因（全链路无任何 x-amz-date 时间校验）。

## 修复

`Url::port()` 仅对非默认端口返回 Some，据此决定是否附加 `:port`。生产影响：任何走非标准端口网关/代理的 AWS 签名请求此前必然被拒。

## 测试

- sigv4.rs 新增单测：非默认端口保留（`127.0.0.1:54321`）/ 默认端口省略
- **回归实证**：此前在代理环境下失败的三个测试二进制全部转绿——anthropic_aws_model_test 13/13、aws_polly_test 14/14、bedrock_model_test 19/19（本机即带 http_proxy 的环境）
- fmt/clippy 干净