### PR TITLE
chore: drop unused deps, remove stale dead_code allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 # URL
 url = "2"
 
-
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 
 # Streaming
-tokio-stream = "0.1"
 bytes = "1"
 async-stream = "0.3"
 
@@ -63,8 +62,6 @@ tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 # URL
 url = "2"
 
-# Cache directories (RFC-0027 catalogue cache)
-dirs = "5"
 
 # Logging
 tracing = "0.1"

--- a/aimux-core/src/trace/store.rs
+++ b/aimux-core/src/trace/store.rs
@@ -70,7 +70,6 @@ pub(crate) struct MatchInfo {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct LcpResult {
     pub lcp_bytes: u64,
-    #[allow(dead_code)]
     pub matched_blocks: u32,
     pub matched: Option<MatchInfo>,
     /// Block-0 had a candidate that failed the TTL check (timing violation)

--- a/aimux-providers/Cargo.toml
+++ b/aimux-providers/Cargo.toml
@@ -21,11 +21,9 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
-bytes = { workspace = true }
 async-stream = { workspace = true }
 base64 = "0.22"
 sha2 = "0.10"
@@ -34,7 +32,6 @@ hex = "0.4"
 chrono = "0.4"
 url = { workspace = true }
 percent-encoding = "2"
-dirs = { workspace = true }
 
 [features]
 default = ["realtime"]

--- a/aimux-stream/Cargo.toml
+++ b/aimux-stream/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/aimux-stream"
 [dependencies]
 futures = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = { workspace = true }
 pin-project-lite = { workspace = true }
 bytes = { workspace = true }
 serde = { workspace = true }

--- a/tools/aimux-cli/Cargo.toml
+++ b/tools/aimux-cli/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 aimux-core = { workspace = true }
 aimux-providers = { workspace = true }
 clap = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Fixes #123（Round 4 审计 architecture-rules + 独立校验）

## 清理

- 移除 5 个未使用依赖（cargo-machete + 逐项 src grep 验证）：`tools/aimux-cli` 的 serde、`aimux-stream` 的 tokio-stream、`aimux-providers` 的 bytes/dirs/thiserror
- 校验修正：bytes 在 src 与 tests 均无引用，整体移除（初稿"移 dev-deps"是误判）
- 移除 `LcpResult::matched_blocks` 上过期的 `#[allow(dead_code)]`（layer.rs:263 生产代码在读取）

## 验证

- `cargo machete` 0 未使用依赖；workspace check/clippy/fmt 全绿；aimux-core lib 测试 268/268
- 其余 `allow(dead_code)` 项（item 级 9 处 + 模块级 9 处）留待逐条处理（见 issue）