### PR TITLE
fix(providers): carry reasoning signature through streaming (bedrock + anthropic)

### DIFF
--- a/aimux-providers/src/anthropic/stream.rs
+++ b/aimux-providers/src/anthropic/stream.rs
@@ -417,6 +417,13 @@ pub(crate) async fn anthropic_stream_core(
                                 // the aggregated Reasoning part can echo it
                                 // back on extended-thinking multi-turn — same
                                 // shape as the non-streaming path.
+                                //
+                                // Edge: a thinking block carrying only a
+                                // signature (no text deltas) stays
+                                // `started: false` and emits nothing — the
+                                // protocol always sends text first, and the
+                                // core aggregator gates on non-empty text
+                                // anyway, so there is nothing to attach to.
                                 if let Some(BlockState::Thinking { signature, .. }) =
                                     blocks.get_mut(&index)
                                 {

--- a/aimux-providers/src/anthropic/stream.rs
+++ b/aimux-providers/src/anthropic/stream.rs
@@ -224,6 +224,8 @@ enum BlockState {
     },
     Thinking {
         started: bool,
+        /// Accumulated `signature_delta` pieces for the thinking block.
+        signature: Option<String>,
     },
 }
 
@@ -297,7 +299,13 @@ pub(crate) async fn anthropic_stream_core(
                                     blocks.insert(index, BlockState::Text { started: false });
                                 }
                                 ContentBlock::Thinking { .. } => {
-                                    blocks.insert(index, BlockState::Thinking { started: false });
+                                    blocks.insert(
+                                        index,
+                                        BlockState::Thinking {
+                                            started: false,
+                                            signature: None,
+                                        },
+                                    );
                                 }
                                 ContentBlock::ToolUse { id, name, .. } => {
                                     yield Ok(StreamPart::ToolInputStart {
@@ -380,8 +388,8 @@ pub(crate) async fn anthropic_stream_core(
                                 // thinking delta. The id is the stringified
                                 // content-block index, matching the TS SDK.
                                 let start_id: Option<String> = match blocks.get_mut(&index) {
-                                    Some(BlockState::Thinking { started: false }) => {
-                                        if let Some(BlockState::Thinking { started }) =
+                                    Some(BlockState::Thinking { started: false, .. }) => {
+                                        if let Some(BlockState::Thinking { started, .. }) =
                                             blocks.get_mut(&index)
                                         {
                                             *started = true;
@@ -402,6 +410,19 @@ pub(crate) async fn anthropic_stream_core(
                                     provider_metadata: None,
                                 });
                             }
+                            if let Some(sig) = delta.signature {
+                                // `signature_delta`: incremental pieces of the
+                                // thinking-block signature. Accumulated on the
+                                // block state and attached to ReasoningEnd, so
+                                // the aggregated Reasoning part can echo it
+                                // back on extended-thinking multi-turn — same
+                                // shape as the non-streaming path.
+                                if let Some(BlockState::Thinking { signature, .. }) =
+                                    blocks.get_mut(&index)
+                                {
+                                    signature.get_or_insert_with(String::new).push_str(&sig);
+                                }
+                            }
                         }
                         Ok(StreamEvent::ContentBlockStop { index }) => {
                             // Removing the block releases the borrow before any
@@ -417,13 +438,18 @@ pub(crate) async fn anthropic_stream_core(
                                     BlockState::Text { started: false } => {
                                         // Text block with no deltas — nothing to emit.
                                     }
-                                    BlockState::Thinking { started: true } => {
+                                    BlockState::Thinking {
+                                        started: true,
+                                        signature,
+                                    } => {
                                         yield Ok(StreamPart::ReasoningEnd {
                                             id: index.to_string(),
-                                            provider_metadata: None,
+                                            provider_metadata: signature.map(|s| {
+                                                json!({ "anthropic": { "signature": s } })
+                                            }),
                                         });
                                     }
-                                    BlockState::Thinking { started: false } => {
+                                    BlockState::Thinking { started: false, .. } => {
                                         // Thinking block with no deltas — nothing to emit.
                                     }
                                     BlockState::ToolUse {

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -525,16 +525,6 @@ impl LanguageModel for BedrockModel {
     }
 }
 
-/// Extract `GenerateContent` items from a non-streaming content block.
-///
-/// Bedrock content blocks are field-tagged: each block carries exactly one of
-/// `text`, `toolUse`, or `reasoningContent`. Empty `text` blocks are preserved
-/// (matching the TS SDK) so that empty text between reasoning blocks survives.
-/// `reasoningContent.reasoningText` yields a `Reasoning` item whose
-/// `provider_metadata` carries the `signature` under both `amazonBedrock` and
-/// `bedrock` keys (or `None` when no signature is present).
-/// `reasoningContent.redactedReasoning` yields a `Reasoning` item with empty
-/// text and `redactedData` under both metadata keys.
 /// Wrap the accumulated reasoning signature as provider_metadata in the same
 /// dual-key shape the non-streaming path emits (`amazonBedrock` + `bedrock`),
 /// so consumers reading either key see it.
@@ -547,6 +537,16 @@ fn reasoning_signature_meta(sig: Option<String>) -> Option<serde_json::Value> {
     })
 }
 
+/// Extract `GenerateContent` items from a non-streaming content block.
+///
+/// Bedrock content blocks are field-tagged: each block carries exactly one of
+/// `text`, `toolUse`, or `reasoningContent`. Empty `text` blocks are preserved
+/// (matching the TS SDK) so that empty text between reasoning blocks survives.
+/// `reasoningContent.reasoningText` yields a `Reasoning` item whose
+/// `provider_metadata` carries the `signature` under both `amazonBedrock` and
+/// `bedrock` keys (or `None` when no signature is present).
+/// `reasoningContent.redactedReasoning` yields a `Reasoning` item with empty
+/// text and `redactedData` under both metadata keys.
 fn extract_content(block: &BedrockContentBlock, content: &mut Vec<GenerateContent>) {
     if let Some(text) = &block.text {
         content.push(GenerateContent::Text {

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -447,9 +447,8 @@ impl LanguageModel for BedrockModel {
                         } else if reasoning_id.is_some() {
                             let id = idx.to_string();
                             if reasoning_id.as_deref() == Some(id.as_str()) {
-                                let provider_metadata = reasoning_signature
-                                    .take()
-                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                let provider_metadata =
+                                    reasoning_signature_meta(reasoning_signature.take());
                                 yield Ok(StreamPart::ReasoningEnd {
                                     id,
                                     provider_metadata,
@@ -473,9 +472,8 @@ impl LanguageModel for BedrockModel {
                                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
                             }
                             if let Some(id) = reasoning_id.take() {
-                                let provider_metadata = reasoning_signature
-                                    .take()
-                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                let provider_metadata =
+                                    reasoning_signature_meta(reasoning_signature.take());
                                 yield Ok(StreamPart::ReasoningEnd {
                                     id,
                                     provider_metadata,
@@ -499,10 +497,13 @@ impl LanguageModel for BedrockModel {
             if let Some(id) = text_id.take() {
                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
             }
-            // Close any remaining reasoning block.
+            // Close any remaining reasoning block (truncated stream without
+            // contentBlockStop): still attach the accumulated signature.
             if let Some(id) = reasoning_id.take() {
+                let provider_metadata =
+                    reasoning_signature_meta(reasoning_signature.take());
                 yield Ok(StreamPart::ReasoningEnd { id,
-                provider_metadata: None,
+                provider_metadata,
             });
             }
 
@@ -534,6 +535,18 @@ impl LanguageModel for BedrockModel {
 /// `bedrock` keys (or `None` when no signature is present).
 /// `reasoningContent.redactedReasoning` yields a `Reasoning` item with empty
 /// text and `redactedData` under both metadata keys.
+/// Wrap the accumulated reasoning signature as provider_metadata in the same
+/// dual-key shape the non-streaming path emits (`amazonBedrock` + `bedrock`),
+/// so consumers reading either key see it.
+fn reasoning_signature_meta(sig: Option<String>) -> Option<serde_json::Value> {
+    sig.map(|s| {
+        json!({
+            "amazonBedrock": { "signature": &s },
+            "bedrock": { "signature": s }
+        })
+    })
+}
+
 fn extract_content(block: &BedrockContentBlock, content: &mut Vec<GenerateContent>) {
     if let Some(text) = &block.text {
         content.push(GenerateContent::Text {

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -278,6 +278,10 @@ impl LanguageModel for BedrockModel {
 
             let mut text_id: Option<String> = None;
             let mut reasoning_id: Option<String> = None;
+            // Reasoning signatures arrive in their own reasoningContent delta
+            // (usually with no text); accumulated here and attached to the
+            // concluding ReasoningEnd.
+            let mut reasoning_signature: Option<String> = None;
             let mut block_counter = 0usize;
             // Tool call state: block_index → (id, name, accumulated_json)
             let mut tool_blocks: HashMap<usize, (String, String, String)> = HashMap::new();
@@ -384,26 +388,38 @@ impl LanguageModel for BedrockModel {
                                         }
                             // Reasoning delta — `reasoningContent.text` carries
                             // incremental reasoning text; `reasoningContent.signature`
-                            // carries the final signature. The signature cannot be
-                            // represented on `StreamPart::ReasoningDelta` (no
-                            // provider_metadata field), so it is intentionally not
-                            // emitted. Empty text deltas are skipped.
-                            if let Some(rc) = delta.get("reasoningContent")
-                                && let Some(text) = rc.get("text").and_then(|v| v.as_str())
-                                    && !text.is_empty() {
-                                        let id = idx.to_string();
-                                        if reasoning_id.as_deref() != Some(id.as_str()) {
-                                            reasoning_id = Some(id.clone());
-                                            yield Ok(StreamPart::ReasoningStart { id,
-                provider_metadata: None,
-            });
-                                        }
-                                        yield Ok(StreamPart::ReasoningDelta {
-                                            id: idx.to_string(),
-                                            delta: text.to_string(),
-                provider_metadata: None,
-            });
+                            // carries the reasoning signature (typically in a
+                            // final, text-less delta). The signature is attached
+                            // to the concluding ReasoningEnd via provider_metadata
+                            // so extended-thinking multi-turn can echo it back —
+                            // same shape as the non-streaming path. Empty text
+                            // deltas are skipped.
+                            if let Some(rc) = delta.get("reasoningContent") {
+                                if let Some(text) = rc.get("text").and_then(|v| v.as_str())
+                                    && !text.is_empty()
+                                {
+                                    let id = idx.to_string();
+                                    if reasoning_id.as_deref() != Some(id.as_str()) {
+                                        reasoning_id = Some(id.clone());
+                                        yield Ok(StreamPart::ReasoningStart {
+                                            id,
+                                            provider_metadata: None,
+                                        });
                                     }
+                                    yield Ok(StreamPart::ReasoningDelta {
+                                        id: idx.to_string(),
+                                        delta: text.to_string(),
+                                        provider_metadata: None,
+                                    });
+                                }
+                                if let Some(sig) =
+                                    rc.get("signature").and_then(|v| v.as_str())
+                                {
+                                    reasoning_signature
+                                        .get_or_insert_with(String::new)
+                                        .push_str(sig);
+                                }
+                            }
                         }
                     }
                     "contentBlockStop" => {
@@ -431,9 +447,13 @@ impl LanguageModel for BedrockModel {
                         } else if reasoning_id.is_some() {
                             let id = idx.to_string();
                             if reasoning_id.as_deref() == Some(id.as_str()) {
-                                yield Ok(StreamPart::ReasoningEnd { id,
-                provider_metadata: None,
-            });
+                                let provider_metadata = reasoning_signature
+                                    .take()
+                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                yield Ok(StreamPart::ReasoningEnd {
+                                    id,
+                                    provider_metadata,
+                                });
                                 reasoning_id = None;
                             }
                         } else if text_id.is_some() {
@@ -453,9 +473,13 @@ impl LanguageModel for BedrockModel {
                                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
                             }
                             if let Some(id) = reasoning_id.take() {
-                                yield Ok(StreamPart::ReasoningEnd { id,
-                provider_metadata: None,
-            });
+                                let provider_metadata = reasoning_signature
+                                    .take()
+                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                yield Ok(StreamPart::ReasoningEnd {
+                                    id,
+                                    provider_metadata,
+                                });
                             }
                             final_finish_reason = Some(map_finish_reason(reason));
                         }

--- a/aimux-providers/tests/anthropic_model_test.rs
+++ b/aimux-providers/tests/anthropic_model_test.rs
@@ -1492,4 +1492,57 @@ mod do_stream {
         // Nothing after the Error.
         assert_eq!(parts.len(), error_idx + 1);
     }
+
+    /// Extended-thinking streams: `signature_delta` pieces accumulate on the
+    /// thinking block and are attached to the concluding ReasoningEnd as
+    /// provider_metadata (`{"anthropic": {"signature": ..}}`), matching the
+    /// non-streaming path (#113).
+    #[tokio::test]
+    async fn should_attach_thinking_signature_to_reasoning_end() {
+        let server = MockServer::start().await;
+        let sse_body = sse_stream(&[
+            json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "model": "claude-3-haiku-20240307",
+                    "usage": { "input_tokens": 10 },
+                },
+            }),
+            json!({"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think."}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-part-1"}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-part-2"}}),
+            json!({"type":"content_block_stop","index":0}),
+            json!({"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}),
+            json!({"type":"message_stop"}),
+        ]);
+        mock_sse(&server, &sse_body).await;
+        let model = make_model(&server);
+        let parts = collect_stream(
+            model
+                .do_stream(&default_options(test_prompt()))
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        assert!(
+            parts.iter().any(|p| matches!(p,
+                StreamPart::ReasoningDelta { delta, .. } if delta == "Let me think.")),
+            "expected the thinking text delta, got {parts:?}"
+        );
+        let meta = parts.iter().find_map(|p| match p {
+            StreamPart::ReasoningEnd {
+                provider_metadata, ..
+            } => provider_metadata.clone(),
+            _ => None,
+        });
+        let meta = meta.expect("ReasoningEnd with provider_metadata");
+        // Incremental signature pieces are concatenated.
+        assert_eq!(
+            meta["anthropic"]["signature"].as_str(),
+            Some("sig-part-1sig-part-2")
+        );
+    }
 }

--- a/aimux-providers/tests/bedrock_reasoning_test.rs
+++ b/aimux-providers/tests/bedrock_reasoning_test.rs
@@ -732,9 +732,20 @@ async fn bedrock_stream_reasoning_and_text() {
         ]
     );
     assert!(has_reasoning_end(&parts), "expected a ReasoningEnd");
-    // NOTE: the signature carried on the final (empty) reasoning delta in TS is
-    // not representable on `StreamPart::ReasoningDelta` (no provider_metadata),
-    // so it is intentionally not asserted.
+    // The signature on the final (text-less) reasoning delta is attached to
+    // the concluding ReasoningEnd via provider_metadata, so extended-thinking
+    // multi-turn can echo it back (#113).
+    let reasoning_end_meta = parts.iter().find_map(|p| match p {
+        StreamPart::ReasoningEnd {
+            provider_metadata, ..
+        } => provider_metadata.clone(),
+        _ => None,
+    });
+    let reasoning_end_meta = reasoning_end_meta.expect("ReasoningEnd with provider_metadata");
+    assert_eq!(
+        reasoning_end_meta["bedrock"]["signature"].as_str(),
+        Some(STREAM_SIGNATURE)
+    );
 
     // Text block (id "1").
     assert_eq!(

--- a/aimux-providers/tests/bedrock_reasoning_test.rs
+++ b/aimux-providers/tests/bedrock_reasoning_test.rs
@@ -746,6 +746,11 @@ async fn bedrock_stream_reasoning_and_text() {
         reasoning_end_meta["bedrock"]["signature"].as_str(),
         Some(STREAM_SIGNATURE)
     );
+    // Dual-key shape matches the non-streaming path.
+    assert_eq!(
+        reasoning_end_meta["amazonBedrock"]["signature"].as_str(),
+        Some(STREAM_SIGNATURE)
+    );
 
     // Text block (id "1").
     assert_eq!(


### PR DESCRIPTION
Fixes #113（Round 4 审计 4c-H1 + 独立校验扩大范围）

## 问题

- **bedrock**：流式丢弃 `reasoningContent.signature`（model.rs:388 注释声称 ReasoningDelta 无 provider_metadata 字段——实有，stream_part.rs:143，且代码自己就在构造它）；非流式却保留 → 两路径行为分裂
- **anthropic**：流式忽略 `signature_delta`（DeltaBlock.signature 已解析未使用）；仅非流式保留
- 后果：聚合后的流式 Reasoning 无签名 → 扩展思考多轮回放时整块 reasoning 被丢弃（bedrock convert.rs 丢无签名块）

## 修复

signature 统一挂到 `ReasoningEnd.provider_metadata`（`{"bedrock"/"anthropic": {"signature"}}`）——core 聚合器（generate.rs:275-293）已有 `extract_reasoning_signature` 支持该形状并落入 `ContentPart::Reasoning`，与非流式路径完全对齐。

## 测试

- bedrock `bedrock_stream_reasoning_and_text`：fixture 原本就带 signature 事件（旧注释"无法断言"），现断言 ReasoningEnd metadata
- anthropic 新增 `should_attach_thinking_signature_to_reasoning_end`：两段 signature_delta 拼接 + metadata 断言
- 套件：anthropic_model 45 / bedrock_reasoning 28 / anthropic_remaining 17 / anthropic_convert_full 18 全过
- `bedrock_sigv4_auth` 失败为 #125 预存环境问题（修复在 PR #129），与本改动无关