### PR TITLE
chore: fix all rustdoc warnings, add rustdoc -D warnings to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy (deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Rustdoc (deny warnings)
+        run: cargo doc --workspace --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
       - name: Test workspace
         run: cargo test --workspace
 

--- a/aimux-core/src/generate.rs
+++ b/aimux-core/src/generate.rs
@@ -949,7 +949,7 @@ pub async fn generate_text_as_openai(
 ///
 /// This is the OpenAI-compatible equivalent of [`stream_text`]. Internally
 /// it calls `stream_text`, then converts the `StreamPart` stream into a
-/// [`ChatCompletionChunk`] stream via [`to_chat_completion_stream`].
+/// `ChatCompletionChunk` stream via [`to_chat_completion_stream`].
 ///
 /// Works with **any** provider (OpenAI, Anthropic, Google, …) — the output is
 /// always standard OpenAI Chat Completions streaming chunks.

--- a/aimux-core/src/recording.rs
+++ b/aimux-core/src/recording.rs
@@ -173,7 +173,7 @@ fn default_finalized() -> bool {
 pub struct HttpRecord {
     pub method: String,
     pub url: String,
-    /// 敏感头(authorization/cookie/含 api-key/key/x-amz-security-token 等)已脱敏为 "[REDACTED]"。
+    /// 敏感头(authorization/cookie/含 api-key/key/x-amz-security-token 等)已脱敏为 "\[REDACTED\]"。
     pub headers: Vec<(String, String)>,
     /// 明文(脱敏后);None = 无 body。
     pub body: Option<String>,
@@ -538,7 +538,7 @@ impl JsonlRecorder {
     }
 
     /// 在 `dir` 下创建录制器并启动 writer 线程(兼容入口:FFI `aimux_init_recording`
-    /// 及绑定均以 infallible `new` 调用,A9 要求保持兼容)。内部委托 [`try_new`],
+    /// 及绑定均以 infallible `new` 调用,A9 要求保持兼容)。内部委托 [`JsonlRecorder::try_new`],
     /// 失败时降级为无 writer 的 no-op recorder(`tx = None`,事件静默丢弃),
     /// 行为等价于原先 `create_dir_all().ok()` + writer 打开文件失败早退。
     pub fn new(dir: impl Into<PathBuf>) -> Self {

--- a/aimux-core/src/replay.rs
+++ b/aimux-core/src/replay.rs
@@ -44,9 +44,9 @@ pub trait ReplayMatcher: Send + Sync {
 /// (call_id/abort_signal/recording_context)不参与比较。
 ///
 /// headers/provider_options/body_overrides 用**脱敏感知比较**:录制侧这些
-/// 字段经 [`recording::redact_json`](crate::recording::redact_json) 脱敏
+/// 字段经 `recording::redact_json` 脱敏
 /// (敏感键值→`"[REDACTED]"`),脱敏值视为通配,匹配任意显式请求值;非脱敏
-/// 部分仍精确比较。规则见 [`redaction_aware_eq`]。
+/// 部分仍精确比较。规则见 `redaction_aware_eq`。
 pub struct ExactMatcher {
     provider: String,
     model_id: String,
@@ -126,7 +126,7 @@ fn canonical_recording_key(rec: &Recording) -> serde_json::Value {
 
 /// 脱敏感知比较(用于 headers/provider_options/body_overrides)。
 ///
-/// 录制侧这些字段经 [`recording::redact_json`](crate::recording::redact_json)
+/// 录制侧这些字段经 `recording::redact_json`
 /// 脱敏:敏感键(authorization/api-key/apikey/key/token/cookie/...)的**值**
 /// 被替换为字符串 `"[REDACTED]"`(键名保留)。比较规则(**保守原则——宁可 miss
 /// 不可误 hit**):

--- a/aimux-core/src/util.rs
+++ b/aimux-core/src/util.rs
@@ -2,9 +2,9 @@
 //!
 //! This module is a facade — the implementations live in dedicated modules:
 //!
-//! - [`json_repair`] — `fix_json` + `parse_partial_json` (from `fix-json.ts`
+//! - `json_repair` — `fix_json` + `parse_partial_json` (from `fix-json.ts`
 //!   and `parse-partial-json.ts`)
-//! - [`math`] — `cosine_similarity` (from `cosine-similarity.ts`)
+//! - `math` — `cosine_similarity` (from `cosine-similarity.ts`)
 //!
 //! The re-exports below keep `aimux_core::util::*` paths working for existing
 //! consumers.

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -26,7 +26,7 @@
 //! not allow a panic to propagate — the process terminates (and under this
 //! workspace's release profile, `panic = "abort"`, it terminates at the panic
 //! site). Either way the re-entrant call must be rejected before it reaches
-//! the runtime; the thread-local guard in [`ffi_block_on`] does that
+//! the runtime; the thread-local guard in `ffi_block_on` does that
 //! (issue M7).
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 // `extern "C"` entry points dereference raw pointers (`*const c_char`) by
@@ -202,7 +202,7 @@ thread_local! {
     /// this thread. tokio rejects nested `block_on` with a **panic**; Rust's
     /// non-unwind `extern "C"` ABI terminates the process rather than letting
     /// the panic propagate (and `panic = "abort"` terminates at the panic site).
-    /// [`ffi_block_on`] checks this guard and turns that re-entrant call into
+    /// `ffi_block_on` checks this guard and turns that re-entrant call into
     /// a failure sentinel + optional AimuxError instead (issue M7).
     static IN_FFI_BLOCK_ON: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
@@ -325,7 +325,7 @@ pub const AIMUX_E_OTHER: i32 = 14;
 /// Layout must match `aimux-error.h` `AimuxError` (40 bytes).
 ///
 /// On failure the callee overwrites every field; `message` is allocated with
-/// [`into_cstring_raw`] and the caller releases it with `aimux_free_string`.
+/// `into_cstring_raw` and the caller releases it with `aimux_free_string`.
 /// `error_value` is the lossless externally-tagged serde JSON of the source
 /// [`AiMuxError`] (null when the failure was synthesized at the FFI boundary
 /// and has no core error value). `reserved` is future ABI room (the

--- a/aimux-provider-utils/src/multipart.rs
+++ b/aimux-provider-utils/src/multipart.rs
@@ -32,7 +32,7 @@ impl MultipartForm {
     /// Add a text field.
     ///
     /// `name` is validated before it is interpolated into the MIME headers; see
-    /// [`validate_multipart_param`] for the rules.
+    /// `validate_multipart_param` for the rules.
     pub fn text(&mut self, name: &str, value: &str) -> Result<&mut Self, AiMuxError> {
         validate_multipart_param(name, "name")?;
         self.parts
@@ -48,7 +48,7 @@ impl MultipartForm {
     /// Add a binary file field with a filename and media type.
     ///
     /// `name`, `filename` and `media_type` are validated before they are
-    /// interpolated into the MIME headers; see [`validate_multipart_param`] for
+    /// interpolated into the MIME headers; see `validate_multipart_param` for
     /// the rules.
     pub fn file(
         &mut self,

--- a/aimux-providers/src/anthropic/stream.rs
+++ b/aimux-providers/src/anthropic/stream.rs
@@ -1,18 +1,18 @@
 //! Shared Anthropic request/streaming core.
 //!
 //! The standard Anthropic provider ([`crate::anthropic::model`]) and the
-//! Anthropic-AWS provider ([`crate::anthropic_aws::model`]) speak the exact
+//! Anthropic-AWS provider (`crate::anthropic_aws::model`) speak the exact
 //! same Messages API. The only differences are endpoint, authentication
 //! (Bearer/x-api-key vs AWS SigV4) and the wire body encoding (`Json` vs
 //! `Bytes`, the latter preventing re-serialization from invalidating the SigV4
 //! signature).
 //!
 //! This module factors out the parts that are identical across both providers:
-//! - [`build_anthropic_request`] — serialize the body once, build auth headers
+//! - `build_anthropic_request` — serialize the body once, build auth headers
 //!   via a closure, and choose the wire encoding.
-//! - [`anthropic_generate_core`] — non-streaming send + response parsing.
-//! - [`anthropic_stream_core`] — streaming send + the Anthropic SSE event loop.
-//! - [`parse_anthropic_content`] — shared content-block → `GenerateContent`
+//! - `anthropic_generate_core` — non-streaming send + response parsing.
+//! - `anthropic_stream_core` — streaming send + the Anthropic SSE event loop.
+//! - `parse_anthropic_content` — shared content-block → `GenerateContent`
 //!   mapping used by the non-streaming path.
 
 use std::collections::HashMap;

--- a/aimux-providers/src/anthropic_aws/mod.rs
+++ b/aimux-providers/src/anthropic_aws/mod.rs
@@ -13,7 +13,7 @@
 //! - **Authentication**: AWS SigV4 signing (service name
 //!   `aws-external-anthropic`) or `x-api-key` header.
 //!
-//! Reference: https://docs.anthropic.com/en/api/messages
+//! Reference: <https://docs.anthropic.com/en/api/messages>
 
 use aimux_core::error::AiMuxError;
 use aimux_core::language_model::LanguageModel;

--- a/aimux-providers/src/azure/mod.rs
+++ b/aimux-providers/src/azure/mod.rs
@@ -5,7 +5,7 @@
 //! parameter and authenticates via either an `api-key` header or an Azure AD
 //! (Microsoft Entra ID) bearer token.
 //!
-//! See [`AzureProvider`] and [`AzureConfig`](model::AzureConfig).
+//! See [`AzureProvider`] and [`AzureConfig`].
 
 pub mod model;
 pub mod responses;

--- a/aimux-providers/src/azure/model.rs
+++ b/aimux-providers/src/azure/model.rs
@@ -170,7 +170,7 @@ impl AzureConfig {
     /// Create a config from environment variables.
     ///
     /// Reads `AZURE_API_KEY` (required) and `AZURE_RESOURCE_NAME` (optional —
-    /// may also be supplied via [`with_resource_name`]).
+    /// may also be supplied via `with_resource_name`).
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "AZURE_API_KEY", "Azure OpenAI")?;
         let mut config = Self::new()

--- a/aimux-providers/src/azure/responses.rs
+++ b/aimux-providers/src/azure/responses.rs
@@ -10,7 +10,7 @@
 //!    `{base}/v1/responses?api-version={v}`; the deployment-based form is
 //!    `{base}/deployments/{deployment}/responses?api-version={v}`.
 //! 2. **Authentication** — either an `api-key` header (API key) or a `Bearer`
-//!    token supplied by a [`TokenProvider`] (Azure AD / Microsoft Entra ID).
+//!    token supplied by a `TokenProvider` (Azure AD / Microsoft Entra ID).
 //!    The two are mutually exclusive.
 //! 3. **File ID prefix** — Azure file IDs use the `assistant-` prefix. When a
 //!    file content part's data starts with `assistant-`, it is passed through

--- a/aimux-providers/src/bedrock/event_stream.rs
+++ b/aimux-providers/src/bedrock/event_stream.rs
@@ -8,8 +8,8 @@
 //! This module implements just enough of the format to decode Bedrock stream
 //! events and to encode them in tests.
 //!
-//! Reference: https://docs.aws.amazon.com/transcribe/latest/dg/event-stream.md
-//!            https://github.com/smithy-lang/smithy-typescript/tree/main/packages/eventstream-codec
+//! Reference: <https://docs.aws.amazon.com/transcribe/latest/dg/event-stream.md>
+//!            <https://github.com/smithy-lang/smithy-typescript/tree/main/packages/eventstream-codec>
 
 /// CRC32 lookup table (IEEE polynomial 0xEDB88320).
 const CRC32_TABLE: [u32; 256] = {

--- a/aimux-providers/src/bedrock/sigv4.rs
+++ b/aimux-providers/src/bedrock/sigv4.rs
@@ -5,7 +5,7 @@
 //! the `Authorization` header and supporting `X-Amz-*` headers that AWS
 //! expects.
 //!
-//! Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+//! Reference: <https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html>
 //!
 //! This is a self-contained implementation using only `sha2` + `hmac` (no AWS
 //! SDK dependency). It supports:

--- a/aimux-providers/src/bedrock/types.rs
+++ b/aimux-providers/src/bedrock/types.rs
@@ -5,7 +5,7 @@
 //! is a unified interface across all model providers (Anthropic, Meta, Mistral,
 //! etc.), so the request/response format is provider-agnostic.
 //!
-//! Reference: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+//! Reference: <https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html>
 
 #![allow(dead_code)]
 

--- a/aimux-providers/src/bedrock_mantle.rs
+++ b/aimux-providers/src/bedrock_mantle.rs
@@ -4,7 +4,7 @@
 //! `https://bedrock-mantle.{region}.api.aws/v1` (region defaults to `us-east-1`).
 //! Provider-specific details are the region-aware base URL and the
 //! `BEDROCK_MANTLE_API_KEY` environment variable; everything else is delegated
-//! to the shared [`OpenAIProvider`](crate::openai::OpenAIProvider).
+//! to the shared [`OpenAIProvider`].
 //!
 //! # Authentication
 //!

--- a/aimux-providers/src/llamafile.rs
+++ b/aimux-providers/src/llamafile.rs
@@ -3,7 +3,7 @@
 //!
 //! llamafile exposes an OpenAI-compatible Chat Completions API at
 //! `http://127.0.0.1:8080/v1` by default. The Rust
-//! [`OpenAIProvider`](crate::openai::OpenAIProvider) appends `/chat/completions`
+//! [`OpenAIProvider`] appends `/chat/completions`
 //! to this base URL, yielding `http://127.0.0.1:8080/v1/chat/completions`.
 //!
 //! Unlike hosted providers, llamafile runs locally and does not require

--- a/aimux-providers/src/lmstudio.rs
+++ b/aimux-providers/src/lmstudio.rs
@@ -3,7 +3,7 @@
 //!
 //! LM Studio exposes an OpenAI-compatible Chat Completions API at
 //! `http://127.0.0.1:1234/v1` by default. The Rust
-//! [`OpenAIProvider`](crate::openai::OpenAIProvider) appends `/chat/completions`
+//! [`OpenAIProvider`] appends `/chat/completions`
 //! to this base URL, yielding `http://127.0.0.1:1234/v1/chat/completions`.
 //!
 //! Unlike hosted providers, LM Studio runs locally and does not require

--- a/aimux-providers/src/local.rs
+++ b/aimux-providers/src/local.rs
@@ -1,6 +1,6 @@
 //! Local LLM provider — a thin OpenAI-compatible wrapper.
 //!
-//! See <localhost> for API documentation. Exposes an OpenAI-compatible
+//! See `localhost` for API documentation. Exposes an OpenAI-compatible
 //! Chat Completions API at `http://127.0.0.1:8080/v1`. The `LOCAL_LLM_BASE_URL` environment
 //! variable holds a *base URL* (not an API key); when unset, the default
 //! endpoint is used. A placeholder API key is sent in the `Authorization`

--- a/aimux-providers/src/mistralrs.rs
+++ b/aimux-providers/src/mistralrs.rs
@@ -3,7 +3,7 @@
 //!
 //! mistral.rs exposes an OpenAI-compatible Chat Completions API at
 //! `http://127.0.0.1:8080/v1` by default. The Rust
-//! [`OpenAIProvider`](crate::openai::OpenAIProvider) appends `/chat/completions`
+//! [`OpenAIProvider`] appends `/chat/completions`
 //! to this base URL, yielding `http://127.0.0.1:8080/v1/chat/completions`.
 //!
 //! Like llamafile, mistral.rs runs locally and does not require authentication.

--- a/aimux-providers/src/ollama.rs
+++ b/aimux-providers/src/ollama.rs
@@ -3,7 +3,7 @@
 //!
 //! Ollama exposes an OpenAI-compatible Chat Completions API at
 //! `http://127.0.0.1:11434/v1` by default. The Rust
-//! [`OpenAIProvider`](crate::openai::OpenAIProvider) appends `/chat/completions`
+//! [`OpenAIProvider`] appends `/chat/completions`
 //! to this base URL, yielding `http://127.0.0.1:11434/v1/chat/completions`.
 //!
 //! Unlike hosted providers, Ollama runs locally and does not require

--- a/aimux-providers/src/openai/model.rs
+++ b/aimux-providers/src/openai/model.rs
@@ -62,7 +62,7 @@ impl OpenAIModel {
 
 /// Build the auth + provider-level headers from a config (no per-call headers).
 ///
-/// Shared by [`OpenAIModel::build_headers`] and the model-listing path
+/// Shared by `OpenAIModel::build_headers` and the model-listing path
 /// ([`execute_list_models`]) so both use identical auth wiring.
 pub fn build_auth_headers(config: &super::OpenAIConfig) -> HashMap<String, String> {
     let mut headers = HashMap::new();
@@ -212,7 +212,7 @@ impl LanguageModel for OpenAIModel {
     /// Provider identity for recording/routing. Uses `config.provider` (the
     /// registry entry name, e.g. `"deepseek"`/`"groq"`) rather than a hardcoded
     /// `"openai"`, so OpenAI-compatible providers keep their real identity —
-    /// mirroring the Responses path ([`OpenAIResponsesModel::provider`]).
+    /// mirroring the Responses path (`OpenAIResponsesModel::provider`).
     /// Direct `OpenAIProvider` use defaults to `"openai"`.
     fn provider(&self) -> &str {
         &self.config.provider

--- a/aimux-providers/src/openai/responses/mod.rs
+++ b/aimux-providers/src/openai/responses/mod.rs
@@ -55,7 +55,7 @@ use responses_convert::build_header_list;
 /// Does **not** hold an HTTP client — `http::send` / `http::send_stream` use
 /// the process-wide shared `Client` internally (RFC-0009 §4.1).
 ///
-/// Created via [`OpenAIResponsesProvider`](super::OpenAIResponsesProvider) or
+/// Created via `OpenAIResponsesProvider` or
 /// directly with [`OpenAIResponsesModel::new`].
 pub struct OpenAIResponsesModel {
     model_id: String,

--- a/aimux-providers/src/openrouter.rs
+++ b/aimux-providers/src/openrouter.rs
@@ -3,7 +3,7 @@
 //! OpenRouter exposes an OpenAI-compatible Chat Completions API at
 //! `https://openrouter.ai/api/v1`. The only provider-specific detail is the
 //! base URL and the `OPENROUTER_API_KEY` environment variable; everything else
-//! is delegated to the shared [`OpenAIProvider`](crate::openai::OpenAIProvider).
+//! is delegated to the shared [`OpenAIProvider`].
 
 use aimux_core::error::AiMuxError;
 use aimux_core::language_model::LanguageModel;

--- a/aimux-providers/src/vertex/anthropic_model.rs
+++ b/aimux-providers/src/vertex/anthropic_model.rs
@@ -12,7 +12,7 @@
 //! construction and authentication differ from the standard Anthropic provider,
 //! and both come from the parent Vertex provider ([`super::VertexAuth`]).
 //!
-//! Reference: https://docs.cloud.google.com/claude-on-vertex-ai
+//! Reference: <https://docs.cloud.google.com/claude-on-vertex-ai>
 
 use std::collections::HashMap;
 

--- a/aimux-providers/src/vertex/mod.rs
+++ b/aimux-providers/src/vertex/mod.rs
@@ -4,7 +4,7 @@
 //! (`{location}-aiplatform.googleapis.com/v1beta1/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent`).
 //!
 //! Vertex AI uses the same request/response format as the Google Gemini API,
-//! so this provider reuses the shared [`google::convert`] message conversion
+//! so this provider reuses the shared `google::convert` message conversion
 //! logic. The differences are:
 //! - **Endpoint**: Vertex uses a project/location-scoped URL instead of the
 //!   public Gemini API URL.
@@ -12,7 +12,7 @@
 //!   (obtained from a service account or `gcloud auth print-access-token`)
 //!   instead of an API key. Express mode (API key) is also supported.
 //!
-//! Reference: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini
+//! Reference: <https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini>
 
 use aimux_core::error::AiMuxError;
 use aimux_core::language_model::LanguageModel;

--- a/aimux-providers/src/vertex_ai_ai21_models.rs
+++ b/aimux-providers/src/vertex_ai_ai21_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"ai21/jamba-1.5-large"`, `"ai21/jamba-1.5-mini"`.

--- a/aimux-providers/src/vertex_ai_anthropic_models.rs
+++ b/aimux-providers/src/vertex_ai_anthropic_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"anthropic/claude-sonnet-4"`, `"anthropic/claude-opus-4"`.

--- a/aimux-providers/src/vertex_ai_deepseek_models.rs
+++ b/aimux-providers/src/vertex_ai_deepseek_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"deepseek-ai/deepseek-v3.1-maas"`, `"deepseek-ai/deepseek-r1-0528-maas"`.

--- a/aimux-providers/src/vertex_ai_llama_models.rs
+++ b/aimux-providers/src/vertex_ai_llama_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"meta/llama-4-scout-17b-16e-instruct-maas"`, `"meta/llama-4-maverick-17b-128e-instruct-maas"`.

--- a/aimux-providers/src/vertex_ai_minimax_models.rs
+++ b/aimux-providers/src/vertex_ai_minimax_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"minimax/minimax-m2-maas"`.

--- a/aimux-providers/src/vertex_ai_mistral_models.rs
+++ b/aimux-providers/src/vertex_ai_mistral_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"mistralai/mistral-large-2411"`, `"mistralai/codestral-2501"`.

--- a/aimux-providers/src/vertex_ai_moonshot_models.rs
+++ b/aimux-providers/src/vertex_ai_moonshot_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"moonshotai/kimi-k2-thinking-maas"`.

--- a/aimux-providers/src/vertex_ai_openai_models.rs
+++ b/aimux-providers/src/vertex_ai_openai_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"openai/gpt-oss-120b-maas"`, `"openai/gpt-oss-20b-maas"`.

--- a/aimux-providers/src/vertex_ai_qwen_models.rs
+++ b/aimux-providers/src/vertex_ai_qwen_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"qwen/qwen3-coder-480b-a35b-instruct-maas"`, `"qwen/qwen3-next-80b-a3b-instruct-maas"`.

--- a/aimux-providers/src/vertex_ai_zai_models.rs
+++ b/aimux-providers/src/vertex_ai_zai_models.rs
@@ -14,7 +14,7 @@
 //! used by the native Vertex provider), sent as `Authorization: Bearer <token>`.
 //!
 //! Because the endpoint is OpenAI-compatible, this provider is a thin wrapper
-//! over [`OpenAIProvider`](crate::openai::OpenAIProvider): only the base URL,
+//! over [`OpenAIProvider`]: only the base URL,
 //! the Bearer-token env var, and the provider name differ. The shared
 //! `OpenAIProvider` appends `/chat/completions` to the configured base URL.
 //! Sample model ids: `"zai-org/glm-4.7-maas"`, `"zai-org/glm-5-maas"`.


### PR DESCRIPTION
Fixes #117 的 rustdoc 部分（coverage job 另行跟进）

## 修复

`RUSTDOCFLAGS="-D warnings" cargo doc --workspace` 此前 **47 error 横跨 4 crate**（core 7 / providers 36 / provider-utils 2 / ffi 2），现为 **0 error、8 crate 文档全量生成**：

| 类别 | 数量 | 处理 |
|---|---|---|
| 冗余显式链接目标（10 个 vertex_ai 系列同模式等） | 17 | 改 intra-doc 简写 `[`X`]` |
| 裸 URL | 7 | 自动链接 `<url>` |
| 失效链接 | 12 | 纯代码文本（可解析的补真实路径，如 `JsonlRecorder::try_new`） |
| 公开文档链到私有项 | 10 | 纯代码文本 |
| 未闭合 HTML 标签 / 字面 `[REDACTED]` | 2 | 转义 |

## CI

rust-test job 新增 **Rustdoc (deny warnings)** 步骤（`RUSTDOCFLAGS: -D warnings`），基线从此受强制。

## 验证

fmt/clippy 干净；aimux-core lib 测试通过（文档级修改，无行为变化）。