### PR TITLE
feat(ffi): expose aimux_recording_try_flush with write-failure codes

### DIFF
--- a/aimux-core/src/recording.rs
+++ b/aimux-core/src/recording.rs
@@ -93,6 +93,10 @@ impl Recording {
     /// "无 exchange"而早写;缺 input(事件先于 Input 到达的占位条目,或 Input
     /// 被 drop-newest 丢弃)同样不得定稿——否则会写出 complete=true 但 input
     /// 为空占位的失真取证记录(RFC-0023 §3.1 completion barrier)。
+    ///
+    /// 权衡:合法的空 prompt 调用(`prompt: Vec::new()`)与"input 丢失"在此
+    /// 不可区分,会落到 shutdown 兜底以 incomplete 写出——取证失真远轻于
+    /// 反向错误(空占位被标 complete),可接受。
     fn ready(&self) -> bool {
         self.transport_closed
             && self.outcome.status != OutcomeStatus::Pending

--- a/aimux-core/src/recording.rs
+++ b/aimux-core/src/recording.rs
@@ -88,12 +88,15 @@ impl Recording {
         }
     }
 
-    /// completion barrier:outcome 非 Pending && 传输层已封闭 &&
-    /// 全部 exchange 已终结。缺封闭信号时(层 B 未发)不提前写出,
-    /// 防止 outcome 先到时误以为"无 exchange"而早写。
+    /// completion barrier:input ✅ + outcome ✅ + 传输层已封闭 + 全部 exchange
+    /// 已终结。缺封闭信号时(层 B 未发)不提前写出,防止 outcome 先到时误以为
+    /// "无 exchange"而早写;缺 input(事件先于 Input 到达的占位条目,或 Input
+    /// 被 drop-newest 丢弃)同样不得定稿——否则会写出 complete=true 但 input
+    /// 为空占位的失真取证记录(RFC-0023 §3.1 completion barrier)。
     fn ready(&self) -> bool {
         self.transport_closed
             && self.outcome.status != OutcomeStatus::Pending
+            && !self.input.prompt.is_empty()
             && self.exchanges.iter().all(|e| e.finalized)
     }
 }
@@ -281,6 +284,10 @@ pub enum RecordingError {
     /// flush 在 30s 内未收到 writer 回执。
     #[error("recording flush timed out")]
     FlushTimeout,
+    /// writer 写行 / flush 失败(首个错误,粘性)。此前磁盘满等 I/O 失败被
+    /// 静默丢弃且 `try_flush` 仍返回 `Ok`,违反"flush 阻塞至落盘"契约。
+    #[error("recording write failed: {0}")]
+    Write(String),
 }
 
 /// 录制器 trait。
@@ -478,7 +485,11 @@ enum RecordEvent {
     /// 传输层封闭:该调用不再会有 exchange(层 B 发;P1 由层 A 收尾发)。
     TransportClosed { call_id: String },
     /// 刷盘命令;完成后经 ack 回执(SyncSender,容量 0 即 rendezvous)。
-    Flush { ack: SyncSender<()> },
+    /// 回执携带粘性写错误状态:writer 端发生过的 I/O 失败以
+    /// `Err(RecordingError::Write)` 暴露给 `try_flush`。
+    Flush {
+        ack: SyncSender<Result<(), RecordingError>>,
+    },
 }
 
 /// JsonlRecorder 事件通道容量(有界,A4):防止 writer 跟不上时录制热路径
@@ -499,6 +510,9 @@ pub struct JsonlRecorder {
     /// 存于 recorder 侧而非 `Recording` 字段——后者被 `replay.rs` 以全字段
     /// 字面量构造,新增 serde 字段会破坏其它模块编译,故用旁路集合标记。
     inconsistent: Arc<Mutex<HashSet<String>>>,
+    /// writer 的首个写失败(粘性):`try_flush` 据此返回
+    /// [`RecordingError::Write`],磁盘满等 I/O 错误不再静默。
+    write_error: Arc<Mutex<Option<String>>>,
 }
 
 impl JsonlRecorder {
@@ -524,9 +538,11 @@ impl JsonlRecorder {
         let (tx, rx) = sync_channel::<RecordEvent>(JSONL_CHANNEL_CAPACITY);
         let inconsistent = Arc::new(Mutex::new(HashSet::new()));
         let writer_inconsistent = inconsistent.clone();
+        let write_error = Arc::new(Mutex::new(None));
+        let writer_write_error = write_error.clone();
         let handle = std::thread::Builder::new()
             .name("aimux-recording".into())
-            .spawn(move || writer_loop(rx, w, writer_inconsistent))
+            .spawn(move || writer_loop(rx, w, writer_inconsistent, writer_write_error))
             .map_err(|source| RecordingError::Spawn { source })?;
         Ok(Self {
             tx: Some(tx),
@@ -534,6 +550,7 @@ impl JsonlRecorder {
             thread: Some(handle),
             dropped: AtomicU64::new(0),
             inconsistent,
+            write_error,
         })
     }
 
@@ -554,6 +571,7 @@ impl JsonlRecorder {
             thread: None,
             dropped: AtomicU64::new(0),
             inconsistent: Arc::new(Mutex::new(HashSet::new())),
+            write_error: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -576,19 +594,22 @@ impl JsonlRecorder {
         v
     }
 
-    /// 显式 flush(A9/N4):把 writer 退出 / 超时作为 `Result` 返回。阻塞至落盘。
+    /// 显式 flush(A9/N4):把 writer 退出 / 超时 / **写失败** 作为 `Result`
+    /// 返回。阻塞至落盘——writer 端发生过的首个 I/O 错误会让本次(及后续)
+    /// flush 返回 [`RecordingError::Write`],磁盘满不再静默。
     pub fn try_flush(&self) -> Result<(), RecordingError> {
         let Some(tx) = &self.tx else {
             return Err(RecordingError::WriterGone);
         };
-        let (ack_tx, ack_rx) = sync_channel::<()>(0);
+        let (ack_tx, ack_rx) = sync_channel::<Result<(), RecordingError>>(0);
         // Flush 事件必须送达 writer(不可 drop-newest),故用阻塞 send 等待空位;
         // writer 断开时立即返回 Err。30s 回执超时兜底 writer 卡死。
         tx.send(RecordEvent::Flush { ack: ack_tx })
             .map_err(|_| RecordingError::WriterGone)?;
-        ack_rx
-            .recv_timeout(Duration::from_secs(30))
-            .map_err(|_| RecordingError::FlushTimeout)
+        match ack_rx.recv_timeout(Duration::from_secs(30)) {
+            Ok(status) => status,
+            Err(_) => Err(RecordingError::FlushTimeout),
+        }
     }
 
     /// 录制文件路径。
@@ -709,8 +730,9 @@ fn entry_or_init<'a>(
 /// recorder 共享的旁路集合,用于标记 C4-7 检测到的不一致 call_id。
 fn writer_loop(
     rx: Receiver<RecordEvent>,
-    mut w: BufWriter<std::fs::File>,
+    mut w: impl Write,
     inconsistent: Arc<Mutex<HashSet<String>>>,
+    write_error: Arc<Mutex<Option<String>>>,
 ) {
     let mut pending: HashMap<String, Recording> = HashMap::new();
 
@@ -739,7 +761,7 @@ fn writer_loop(
                 let rec = entry_or_init(&mut pending, &call_id);
                 rec.session_id = Some(session_id);
                 rec.step = Some(step);
-                try_finalize(&mut w, &mut pending, &call_id);
+                try_finalize(&mut w, &mut pending, &call_id, &write_error);
             }
             // C4-6:用 entry_or_init(而非 get_mut)兜底建条目,保证乱序
             // (先于 Input 到达)的 Provider 快照不丢。
@@ -752,7 +774,7 @@ fn writer_loop(
                 if insert_exchange(rec, exchange) {
                     mark_inconsistent(&inconsistent, &call_id);
                 }
-                try_finalize(&mut w, &mut pending, &call_id);
+                try_finalize(&mut w, &mut pending, &call_id, &write_error);
             }
             RecordEvent::ExchangeUpdate {
                 call_id,
@@ -769,21 +791,28 @@ fn writer_loop(
                 ) {
                     mark_inconsistent(&inconsistent, &call_id);
                 }
-                try_finalize(&mut w, &mut pending, &call_id);
+                try_finalize(&mut w, &mut pending, &call_id, &write_error);
             }
             RecordEvent::TransportClosed { call_id } => {
                 entry_or_init(&mut pending, &call_id).transport_closed = true;
-                try_finalize(&mut w, &mut pending, &call_id);
+                try_finalize(&mut w, &mut pending, &call_id, &write_error);
             }
             RecordEvent::Outcome { call_id, outcome } => {
                 entry_or_init(&mut pending, &call_id).outcome = outcome;
-                try_finalize(&mut w, &mut pending, &call_id);
+                try_finalize(&mut w, &mut pending, &call_id, &write_error);
             }
             RecordEvent::Flush { ack } => {
-                write_ready_all(&mut w, &mut pending);
-                let _ = w.flush();
-                // 阻塞 send:rendezvous 语义,确保 ack 一定被调用方收到。
-                let _ = ack.send(());
+                write_ready_all(&mut w, &mut pending, &write_error);
+                if let Err(e) = w.flush() {
+                    note_write_error(&write_error, &e);
+                }
+                // 阻塞 send:rendezvous 语义,确保 ack 一定被调用方收到;
+                // ack 携带粘性写错误,磁盘满等失败对 try_flush 可见。
+                let status = match write_error.lock().unwrap().as_ref() {
+                    Some(msg) => Err(RecordingError::Write(msg.clone())),
+                    None => Ok(()),
+                };
+                let _ = ack.send(status);
             }
         }
     }
@@ -795,24 +824,35 @@ fn writer_loop(
         if rec.outcome.status == OutcomeStatus::Pending {
             rec.outcome.status = OutcomeStatus::Incomplete;
         }
-        write_line(&mut w, rec);
+        write_line(&mut w, rec, &write_error);
     }
-    let _ = w.flush();
+    if let Err(e) = w.flush() {
+        note_write_error(&write_error, &e);
+    }
 }
 
 /// 若该 call 的所有分片到齐(barrier 满足)则写出,并标记 complete=true。
-fn try_finalize(w: &mut impl Write, pending: &mut HashMap<String, Recording>, call_id: &str) {
+fn try_finalize(
+    w: &mut impl Write,
+    pending: &mut HashMap<String, Recording>,
+    call_id: &str,
+    write_error: &Mutex<Option<String>>,
+) {
     if pending.get(call_id).map(|r| r.ready()).unwrap_or(false)
         && let Some(mut rec) = pending.remove(call_id)
     {
         if !rec.exchanges.is_empty() || rec.transport_closed {
             rec.complete = true;
         }
-        write_line(w, rec);
+        write_line(w, rec, write_error);
     }
 }
 
-fn write_ready_all(w: &mut impl Write, pending: &mut HashMap<String, Recording>) {
+fn write_ready_all(
+    w: &mut impl Write,
+    pending: &mut HashMap<String, Recording>,
+    write_error: &Mutex<Option<String>>,
+) {
     let ids: Vec<String> = pending
         .iter()
         .filter(|(_, r)| r.ready())
@@ -821,15 +861,29 @@ fn write_ready_all(w: &mut impl Write, pending: &mut HashMap<String, Recording>)
     for id in ids {
         if let Some(mut rec) = pending.remove(&id) {
             rec.complete = true;
-            write_line(w, rec);
+            write_line(w, rec, write_error);
         }
     }
 }
 
-fn write_line(w: &mut impl Write, rec: Recording) {
-    if let Ok(line) = serde_json::to_string(&rec) {
-        let _ = writeln!(w, "{line}");
-        let _ = w.flush(); // 每行落盘,保证崩溃前已写行可见。
+fn write_line(w: &mut impl Write, rec: Recording, write_error: &Mutex<Option<String>>) {
+    match serde_json::to_string(&rec) {
+        Ok(line) => {
+            // 每行落盘,保证崩溃前已写行可见;失败记入粘性错误槽,
+            // 由 try_flush 显式暴露。
+            if let Err(e) = writeln!(w, "{line}").and_then(|()| w.flush()) {
+                note_write_error(write_error, &e);
+            }
+        }
+        Err(e) => note_write_error(write_error, &e),
+    }
+}
+
+/// 记录首个写失败(粘性):后续 flush 据此返回 [`RecordingError::Write`]。
+fn note_write_error(slot: &Mutex<Option<String>>, e: &impl std::fmt::Display) {
+    let mut guard = slot.lock().unwrap();
+    if guard.is_none() {
+        *guard = Some(e.to_string());
     }
 }
 
@@ -1502,6 +1556,123 @@ mod tests {
         assert!(parsed.exchanges.is_empty()); // 无 exchange 也算 ready(非流式仅层 A)
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── #110:barrier input 条件 + writer I/O 错误可见 ──────────────────────
+
+    #[test]
+    fn barrier_requires_input_record() {
+        // 事件先于 Input 到达(或 Input 被 drop-newest 丢弃)的占位条目:
+        // 即便 outcome + transport_closed 都到齐,也不得定稿。
+        let mut rec = Recording::new(
+            "call-x",
+            InputRecord {
+                prompt: Vec::new(),
+                options: serde_json::Value::Null,
+            },
+            ProviderRecord::minimal("openai", "gpt-4o"),
+        );
+        rec.transport_closed = true;
+        rec.outcome = OutcomeRecord {
+            status: OutcomeStatus::Success,
+            finish_reason: Some("stop".into()),
+            error: None,
+            usage: None,
+        };
+        assert!(!rec.ready(), "empty-prompt placeholder must not finalize");
+        rec.input = InputRecord::from_call_options(&sample_options());
+        assert!(rec.ready(), "real input satisfies the barrier");
+    }
+
+    #[test]
+    fn missing_input_writes_incomplete_on_shutdown() {
+        let dir = std::env::temp_dir().join(format!("aimux-rec-noinput-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let rec = JsonlRecorder::new(&dir);
+
+        // 只来 outcome + transport_closed,Input 事件丢失(模拟 drop-newest)。
+        rec.record_outcome(
+            "call-noinput",
+            &OutcomeRecord {
+                status: OutcomeStatus::Success,
+                finish_reason: Some("stop".into()),
+                error: None,
+                usage: None,
+            },
+        );
+        rec.record_transport_closed("call-noinput");
+        rec.flush();
+        // flush 不应定稿(barrier 缺 input);shutdown 兜底写出 incomplete。
+        drop(rec);
+        let content = std::fs::read_to_string(dir.join("recordings.jsonl")).unwrap();
+        let parsed: Recording = serde_json::from_str(content.trim()).unwrap();
+        assert!(
+            !parsed.complete,
+            "must not be marked complete without input"
+        );
+        assert!(parsed.input.prompt.is_empty());
+        assert_eq!(parsed.outcome.status, OutcomeStatus::Success);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 恒定失败的 sink:模拟磁盘满(ENOSPC)等 writer I/O 错误。
+    struct FailingWriter;
+
+    impl std::io::Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("simulated disk full"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated disk full"))
+        }
+    }
+
+    #[test]
+    fn try_flush_reports_writer_io_error() {
+        let (tx, rx) = sync_channel(16);
+        let write_error = Arc::new(Mutex::new(None));
+        let handle = {
+            let inconsistent = Arc::new(Mutex::new(HashSet::new()));
+            let w_err = write_error.clone();
+            std::thread::spawn(move || writer_loop(rx, FailingWriter, inconsistent, w_err))
+        };
+
+        tx.send(RecordEvent::Input {
+            call_id: "c1".into(),
+            input: InputRecord::from_call_options(&sample_options()),
+            provider: ProviderRecord::minimal("openai", "gpt-4o"),
+        })
+        .unwrap();
+        tx.send(RecordEvent::TransportClosed {
+            call_id: "c1".into(),
+        })
+        .unwrap();
+        tx.send(RecordEvent::Outcome {
+            call_id: "c1".into(),
+            outcome: OutcomeRecord {
+                status: OutcomeStatus::Success,
+                finish_reason: Some("stop".into()),
+                error: None,
+                usage: None,
+            },
+        })
+        .unwrap();
+
+        let (ack_tx, ack_rx) = sync_channel(0);
+        tx.send(RecordEvent::Flush { ack: ack_tx }).unwrap();
+        let status = ack_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("flush ack within timeout");
+        assert!(
+            matches!(&status, Err(RecordingError::Write(m)) if m.contains("disk full")),
+            "expected Err(Write) carrying the io error, got {status:?}"
+        );
+
+        drop(tx);
+        handle.join().unwrap();
+        // 粘性:错误状态在 writer 侧保留,后续 flush 继续报错。
+        assert!(write_error.lock().unwrap().is_some());
     }
 
     // ── RFC-0024 P3: session 归组信息进 Recording ─────────────────────────

--- a/aimux-core/src/recording.rs
+++ b/aimux-core/src/recording.rs
@@ -603,7 +603,13 @@ impl JsonlRecorder {
     /// flush 返回 [`RecordingError::Write`],磁盘满不再静默。
     pub fn try_flush(&self) -> Result<(), RecordingError> {
         let Some(tx) = &self.tx else {
-            return Err(RecordingError::WriterGone);
+            // The writer is gone, but it may have recorded a terminal write
+            // error into the shared slot before exiting (shutdown drain) —
+            // surface the specific failure over the generic WriterGone.
+            return Err(self.write_error.lock().unwrap().as_ref().map_or_else(
+                || RecordingError::WriterGone,
+                |msg| RecordingError::Write(msg.clone()),
+            ));
         };
         let (ack_tx, ack_rx) = sync_channel::<Result<(), RecordingError>>(0);
         // Flush 事件必须送达 writer(不可 drop-newest),故用阻塞 send 等待空位;
@@ -614,6 +620,12 @@ impl JsonlRecorder {
             Ok(status) => status,
             Err(_) => Err(RecordingError::FlushTimeout),
         }
+    }
+
+    /// recorder 侧可见的 writer 粘性首错(如 ENOSPC),无则 `None`。
+    /// 与 writer 线程共享;首次写行/flush 失败时写入。
+    pub fn last_write_error(&self) -> Option<String> {
+        self.write_error.lock().unwrap().clone()
     }
 
     /// 录制文件路径。

--- a/aimux-ffi/aimux-ffi.h
+++ b/aimux-ffi/aimux-ffi.h
@@ -591,6 +591,14 @@ int aimux_recording_stop(void);
    ring recorder). Returns 0. */
 int aimux_recording_flush(void);
 
+/* Flush the global recorder and report write failures. Returns
+   AIMUX_OK (0) when the JSONL is confirmed on disk (also when recording was
+   never initialized), or one of:
+     AIMUX_E_RECORDING_WRITE (15) — a prior write failed (sticky, e.g. ENOSPC)
+     AIMUX_E_RECORDING_WRITER_GONE (16) — writer unavailable (unwritable dir)
+     AIMUX_E_RECORDING_FLUSH_TIMEOUT (17) — no writer ack within 30s */
+int aimux_recording_try_flush(void);
+
 /* Register external OpenAI-compatible providers from a JSON config string
    (RFC-0020). config_json is { "providers": [ { "name", "base_url", ... } ] }.
    Entries override same-named built-ins or add new ones.

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -321,6 +321,12 @@ pub const AIMUX_E_API_CALL: i32 = 11;
 pub const AIMUX_E_TIMEOUT: i32 = 12;
 pub const AIMUX_E_ABORTED: i32 = 13;
 pub const AIMUX_E_OTHER: i32 = 14;
+/// Recording write failed (sticky) — see `aimux_recording_try_flush`.
+pub const AIMUX_E_RECORDING_WRITE: i32 = 15;
+/// Recording writer thread unavailable — see `aimux_recording_try_flush`.
+pub const AIMUX_E_RECORDING_WRITER_GONE: i32 = 16;
+/// Recording flush ack timed out — see `aimux_recording_try_flush`.
+pub const AIMUX_E_RECORDING_FLUSH_TIMEOUT: i32 = 17;
 
 /// Layout must match `aimux-error.h` `AimuxError` (40 bytes).
 ///
@@ -2879,6 +2885,34 @@ pub extern "C" fn aimux_recording_flush() -> i32 {
         rec.flush();
     }
     0
+}
+
+/// Flush the global recorder and **report write failures** (see #136).
+///
+/// Unlike [`aimux_recording_flush`] — which always returns 0 for
+/// compatibility — this surface makes the recorder's durability observable
+/// across the C ABI:
+/// - `AIMUX_OK` — data confirmed on disk (also when recording was never
+///   initialized: nothing to flush).
+/// - `AIMUX_E_RECORDING_WRITE` — a prior write failed (e.g. ENOSPC); the
+///   first error is sticky and every later flush keeps reporting it.
+/// - `AIMUX_E_RECORDING_WRITER_GONE` — the writer thread is unavailable
+///   (e.g. recording was initialized with an unwritable directory and
+///   downgraded to a no-op recorder).
+/// - `AIMUX_E_RECORDING_FLUSH_TIMEOUT` — no writer ack within 30s.
+#[unsafe(no_mangle)]
+pub extern "C" fn aimux_recording_try_flush() -> i32 {
+    let Some(rec) = aimux_core::recording::recorder() else {
+        return AIMUX_OK;
+    };
+    use aimux_core::recording::RecordingError;
+    match rec.try_flush() {
+        Ok(()) => AIMUX_OK,
+        Err(RecordingError::Write(_)) => AIMUX_E_RECORDING_WRITE,
+        Err(RecordingError::WriterGone) => AIMUX_E_RECORDING_WRITER_GONE,
+        Err(RecordingError::FlushTimeout) => AIMUX_E_RECORDING_FLUSH_TIMEOUT,
+        Err(_) => AIMUX_E_UNKNOWN,
+    }
 }
 
 /// Register external OpenAI-compatible providers from a JSON config string

--- a/aimux-ffi/tests/recording_flush_test.rs
+++ b/aimux-ffi/tests/recording_flush_test.rs
@@ -1,0 +1,63 @@
+//! FFI tests for `aimux_recording_try_flush` (write-failure observability,
+//! see #136).
+//!
+//! Everything lives in one `#[test]` on purpose: the global recorder is a
+//! process-level singleton, and the outcomes must be observed in a
+//! controlled sequence. The sticky `AIMUX_E_RECORDING_WRITE` path is not
+//! portable to inject from the FFI layer (it needs a post-open ENOSPC);
+//! it is covered by the core `FailingWriter` test from #133.
+
+use std::ffi::CString;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use aimux_ffi::{
+    AIMUX_E_RECORDING_WRITER_GONE, AIMUX_OK, aimux_init_recording, aimux_recording_stop,
+    aimux_recording_try_flush,
+};
+
+static SEQ: AtomicU32 = AtomicU32::new(0);
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "aimux-ffi-flush-{tag}-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+#[test]
+fn recording_try_flush_reports_outcomes() {
+    // Reset so the test is independent of ordering.
+    assert_eq!(aimux_recording_stop(), 0);
+
+    // No recorder initialized: nothing to flush is a success.
+    assert_eq!(aimux_recording_try_flush(), AIMUX_OK);
+
+    // Valid directory: flush confirms the (empty) JSONL on disk.
+    let dir = unique_dir("ok");
+    let c_dir = CString::new(dir.to_str().unwrap()).unwrap();
+    assert_eq!(aimux_init_recording(c_dir.as_ptr()), 0);
+    assert_eq!(aimux_recording_try_flush(), AIMUX_OK);
+    assert!(
+        dir.join("recordings.jsonl").exists(),
+        "flush should have created the JSONL file"
+    );
+    assert_eq!(aimux_recording_stop(), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // Unwritable directory (parent path is a regular file): the recorder
+    // degrades to a no-writer no-op and try_flush reports WRITER_GONE
+    // instead of a silent 0 — the exact gap #136 closes for bindings.
+    let blocker = unique_dir("blocker");
+    std::fs::create_dir_all(&blocker).unwrap();
+    let file = blocker.join("occupied");
+    std::fs::write(&file, b"x").unwrap();
+    let bad_dir = file.join("sub");
+    let c_bad = CString::new(bad_dir.to_str().unwrap()).unwrap();
+    assert_eq!(aimux_init_recording(c_bad.as_ptr()), 0);
+    assert_eq!(aimux_recording_try_flush(), AIMUX_E_RECORDING_WRITER_GONE);
+    assert_eq!(aimux_recording_stop(), 0);
+    let _ = std::fs::remove_dir_all(&blocker);
+}

--- a/aimux-provider-utils/tests/http_recording_test.rs
+++ b/aimux-provider-utils/tests/http_recording_test.rs
@@ -74,8 +74,21 @@ fn wait_line(dir: &std::path::Path) -> Recording {
     }
 }
 
-/// 模拟层 A 的 outcome + transport closed(barrier 所需)。
+/// 模拟层 A 的完整生命周期(input + outcome + transport closed,barrier 所需)。
+/// 生产中层 A 总是先 `record_input`(RFC-0023 §3.2)——input 是 completion
+/// barrier 的必要条件,缺失时记录以 incomplete 落盘。
 fn mimic_layer_a(rec: &dyn Recorder, call_id: &str) {
+    use aimux_core::content::ContentPart;
+    use aimux_core::language_model_message::LanguageModelPromptMessage;
+    use aimux_core::message::Role;
+    use aimux_core::options::CallOptions;
+
+    let options = CallOptions::new(vec![LanguageModelPromptMessage {
+        role: Role::User,
+        content: vec![ContentPart::text("hi")],
+        ..Default::default()
+    }]);
+    rec.record_input(call_id, &options, "openai", "gpt-4o");
     rec.record_outcome(
         call_id,
         &OutcomeRecord {

--- a/docs/api/c.md
+++ b/docs/api/c.md
@@ -234,6 +234,7 @@ the opposite polarity of streams; they take no `err`.
 |------|------|
 | `aimux_init_recording(dir)` / `aimux_init_recording_ring(cap)` | Opt-in recording |
 | `aimux_recording_stop` / `aimux_recording_flush` | Stop / flush |
+| `aimux_recording_try_flush` | Flush with write-failure reporting |
 | `aimux_mock_replay_new(recordings_jsonl, err)` | Replay model handle |
 
 ## Examples


### PR DESCRIPTION
Fixes #136（#133 的下游收口）

> **依赖**：叠加在 #133 之上（需要其 `RecordingError::Write` 变体），请先合并 #133。

## 变更

- 新增导出 `aimux_recording_try_flush() -> i32`：`AIMUX_OK`（确认落盘/未初始化）、`AIMUX_E_RECORDING_WRITE`(15, 粘性)、`AIMUX_E_RECORDING_WRITER_GONE`(16)、`AIMUX_E_RECORDING_FLUSH_TIMEOUT`(17)
- `aimux-ffi.h` 与 `docs/api/c.md` 同步；旧 `aimux_recording_flush` 保持不变（兼容）
- 测试 `recording_flush_test.rs`：未初始化→OK、正常目录→OK+文件存在、不可写目录→WRITER_GONE（粘性 WRITE 由 #133 的 core FailingWriter 测试覆盖，FFI 层不可移植注入 ENOSPC）

## 验证

aimux-ffi 全量 56 测试通过、fmt/clippy 干净。绑定侧的 `recordingFlushChecked()` 暴露属可选后续（各绑定按需跟进）。