### PR TITLE
fix+test: anthropic thinking input echo; binding round-trip tests

### DIFF
--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -1624,7 +1624,16 @@ pub fn build_request_body_with_warnings(
 
     let max_tokens = options.max_output_tokens.unwrap_or(caps.max_output_tokens);
 
-    let conversion = convert_prompt_to_anthropic_full_fallible(&options.prompt, false)?;
+    // Extended-thinking multi-turn: when thinking is enabled/adaptive, the
+    // prior assistant turns' reasoning parts (carrying their signatures)
+    // must be echoed back as thinking blocks — Anthropic rejects tool-use
+    // continuations that omit them, and the reasoning context is lost
+    // otherwise. With thinking disabled the blocks would be rejected, so
+    // the parts are omitted with a warning instead.
+    let send_input_reasoning =
+        matches!(thinking_type.as_deref(), Some("enabled") | Some("adaptive"));
+    let conversion =
+        convert_prompt_to_anthropic_full_fallible(&options.prompt, send_input_reasoning)?;
     let system = conversion.system;
     let messages = conversion.messages;
     betas.extend(conversion.betas);

--- a/aimux-providers/src/anthropic/stream.rs
+++ b/aimux-providers/src/anthropic/stream.rs
@@ -417,6 +417,13 @@ pub(crate) async fn anthropic_stream_core(
                                 // the aggregated Reasoning part can echo it
                                 // back on extended-thinking multi-turn — same
                                 // shape as the non-streaming path.
+                                //
+                                // Edge: a thinking block carrying only a
+                                // signature (no text deltas) stays
+                                // `started: false` and emits nothing — the
+                                // protocol always sends text first, and the
+                                // core aggregator gates on non-empty text
+                                // anyway, so there is nothing to attach to.
                                 if let Some(BlockState::Thinking { signature, .. }) =
                                     blocks.get_mut(&index)
                                 {

--- a/aimux-providers/src/anthropic/stream.rs
+++ b/aimux-providers/src/anthropic/stream.rs
@@ -224,6 +224,8 @@ enum BlockState {
     },
     Thinking {
         started: bool,
+        /// Accumulated `signature_delta` pieces for the thinking block.
+        signature: Option<String>,
     },
 }
 
@@ -297,7 +299,13 @@ pub(crate) async fn anthropic_stream_core(
                                     blocks.insert(index, BlockState::Text { started: false });
                                 }
                                 ContentBlock::Thinking { .. } => {
-                                    blocks.insert(index, BlockState::Thinking { started: false });
+                                    blocks.insert(
+                                        index,
+                                        BlockState::Thinking {
+                                            started: false,
+                                            signature: None,
+                                        },
+                                    );
                                 }
                                 ContentBlock::ToolUse { id, name, .. } => {
                                     yield Ok(StreamPart::ToolInputStart {
@@ -380,8 +388,8 @@ pub(crate) async fn anthropic_stream_core(
                                 // thinking delta. The id is the stringified
                                 // content-block index, matching the TS SDK.
                                 let start_id: Option<String> = match blocks.get_mut(&index) {
-                                    Some(BlockState::Thinking { started: false }) => {
-                                        if let Some(BlockState::Thinking { started }) =
+                                    Some(BlockState::Thinking { started: false, .. }) => {
+                                        if let Some(BlockState::Thinking { started, .. }) =
                                             blocks.get_mut(&index)
                                         {
                                             *started = true;
@@ -402,6 +410,19 @@ pub(crate) async fn anthropic_stream_core(
                                     provider_metadata: None,
                                 });
                             }
+                            if let Some(sig) = delta.signature {
+                                // `signature_delta`: incremental pieces of the
+                                // thinking-block signature. Accumulated on the
+                                // block state and attached to ReasoningEnd, so
+                                // the aggregated Reasoning part can echo it
+                                // back on extended-thinking multi-turn — same
+                                // shape as the non-streaming path.
+                                if let Some(BlockState::Thinking { signature, .. }) =
+                                    blocks.get_mut(&index)
+                                {
+                                    signature.get_or_insert_with(String::new).push_str(&sig);
+                                }
+                            }
                         }
                         Ok(StreamEvent::ContentBlockStop { index }) => {
                             // Removing the block releases the borrow before any
@@ -417,13 +438,18 @@ pub(crate) async fn anthropic_stream_core(
                                     BlockState::Text { started: false } => {
                                         // Text block with no deltas — nothing to emit.
                                     }
-                                    BlockState::Thinking { started: true } => {
+                                    BlockState::Thinking {
+                                        started: true,
+                                        signature,
+                                    } => {
                                         yield Ok(StreamPart::ReasoningEnd {
                                             id: index.to_string(),
-                                            provider_metadata: None,
+                                            provider_metadata: signature.map(|s| {
+                                                json!({ "anthropic": { "signature": s } })
+                                            }),
                                         });
                                     }
-                                    BlockState::Thinking { started: false } => {
+                                    BlockState::Thinking { started: false, .. } => {
                                         // Thinking block with no deltas — nothing to emit.
                                     }
                                     BlockState::ToolUse {

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -525,16 +525,6 @@ impl LanguageModel for BedrockModel {
     }
 }
 
-/// Extract `GenerateContent` items from a non-streaming content block.
-///
-/// Bedrock content blocks are field-tagged: each block carries exactly one of
-/// `text`, `toolUse`, or `reasoningContent`. Empty `text` blocks are preserved
-/// (matching the TS SDK) so that empty text between reasoning blocks survives.
-/// `reasoningContent.reasoningText` yields a `Reasoning` item whose
-/// `provider_metadata` carries the `signature` under both `amazonBedrock` and
-/// `bedrock` keys (or `None` when no signature is present).
-/// `reasoningContent.redactedReasoning` yields a `Reasoning` item with empty
-/// text and `redactedData` under both metadata keys.
 /// Wrap the accumulated reasoning signature as provider_metadata in the same
 /// dual-key shape the non-streaming path emits (`amazonBedrock` + `bedrock`),
 /// so consumers reading either key see it.
@@ -547,6 +537,16 @@ fn reasoning_signature_meta(sig: Option<String>) -> Option<serde_json::Value> {
     })
 }
 
+/// Extract `GenerateContent` items from a non-streaming content block.
+///
+/// Bedrock content blocks are field-tagged: each block carries exactly one of
+/// `text`, `toolUse`, or `reasoningContent`. Empty `text` blocks are preserved
+/// (matching the TS SDK) so that empty text between reasoning blocks survives.
+/// `reasoningContent.reasoningText` yields a `Reasoning` item whose
+/// `provider_metadata` carries the `signature` under both `amazonBedrock` and
+/// `bedrock` keys (or `None` when no signature is present).
+/// `reasoningContent.redactedReasoning` yields a `Reasoning` item with empty
+/// text and `redactedData` under both metadata keys.
 fn extract_content(block: &BedrockContentBlock, content: &mut Vec<GenerateContent>) {
     if let Some(text) = &block.text {
         content.push(GenerateContent::Text {

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -447,9 +447,8 @@ impl LanguageModel for BedrockModel {
                         } else if reasoning_id.is_some() {
                             let id = idx.to_string();
                             if reasoning_id.as_deref() == Some(id.as_str()) {
-                                let provider_metadata = reasoning_signature
-                                    .take()
-                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                let provider_metadata =
+                                    reasoning_signature_meta(reasoning_signature.take());
                                 yield Ok(StreamPart::ReasoningEnd {
                                     id,
                                     provider_metadata,
@@ -473,9 +472,8 @@ impl LanguageModel for BedrockModel {
                                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
                             }
                             if let Some(id) = reasoning_id.take() {
-                                let provider_metadata = reasoning_signature
-                                    .take()
-                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                let provider_metadata =
+                                    reasoning_signature_meta(reasoning_signature.take());
                                 yield Ok(StreamPart::ReasoningEnd {
                                     id,
                                     provider_metadata,
@@ -499,10 +497,13 @@ impl LanguageModel for BedrockModel {
             if let Some(id) = text_id.take() {
                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
             }
-            // Close any remaining reasoning block.
+            // Close any remaining reasoning block (truncated stream without
+            // contentBlockStop): still attach the accumulated signature.
             if let Some(id) = reasoning_id.take() {
+                let provider_metadata =
+                    reasoning_signature_meta(reasoning_signature.take());
                 yield Ok(StreamPart::ReasoningEnd { id,
-                provider_metadata: None,
+                provider_metadata,
             });
             }
 
@@ -534,6 +535,18 @@ impl LanguageModel for BedrockModel {
 /// `bedrock` keys (or `None` when no signature is present).
 /// `reasoningContent.redactedReasoning` yields a `Reasoning` item with empty
 /// text and `redactedData` under both metadata keys.
+/// Wrap the accumulated reasoning signature as provider_metadata in the same
+/// dual-key shape the non-streaming path emits (`amazonBedrock` + `bedrock`),
+/// so consumers reading either key see it.
+fn reasoning_signature_meta(sig: Option<String>) -> Option<serde_json::Value> {
+    sig.map(|s| {
+        json!({
+            "amazonBedrock": { "signature": &s },
+            "bedrock": { "signature": s }
+        })
+    })
+}
+
 fn extract_content(block: &BedrockContentBlock, content: &mut Vec<GenerateContent>) {
     if let Some(text) = &block.text {
         content.push(GenerateContent::Text {

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -278,6 +278,10 @@ impl LanguageModel for BedrockModel {
 
             let mut text_id: Option<String> = None;
             let mut reasoning_id: Option<String> = None;
+            // Reasoning signatures arrive in their own reasoningContent delta
+            // (usually with no text); accumulated here and attached to the
+            // concluding ReasoningEnd.
+            let mut reasoning_signature: Option<String> = None;
             let mut block_counter = 0usize;
             // Tool call state: block_index → (id, name, accumulated_json)
             let mut tool_blocks: HashMap<usize, (String, String, String)> = HashMap::new();
@@ -384,26 +388,38 @@ impl LanguageModel for BedrockModel {
                                         }
                             // Reasoning delta — `reasoningContent.text` carries
                             // incremental reasoning text; `reasoningContent.signature`
-                            // carries the final signature. The signature cannot be
-                            // represented on `StreamPart::ReasoningDelta` (no
-                            // provider_metadata field), so it is intentionally not
-                            // emitted. Empty text deltas are skipped.
-                            if let Some(rc) = delta.get("reasoningContent")
-                                && let Some(text) = rc.get("text").and_then(|v| v.as_str())
-                                    && !text.is_empty() {
-                                        let id = idx.to_string();
-                                        if reasoning_id.as_deref() != Some(id.as_str()) {
-                                            reasoning_id = Some(id.clone());
-                                            yield Ok(StreamPart::ReasoningStart { id,
-                provider_metadata: None,
-            });
-                                        }
-                                        yield Ok(StreamPart::ReasoningDelta {
-                                            id: idx.to_string(),
-                                            delta: text.to_string(),
-                provider_metadata: None,
-            });
+                            // carries the reasoning signature (typically in a
+                            // final, text-less delta). The signature is attached
+                            // to the concluding ReasoningEnd via provider_metadata
+                            // so extended-thinking multi-turn can echo it back —
+                            // same shape as the non-streaming path. Empty text
+                            // deltas are skipped.
+                            if let Some(rc) = delta.get("reasoningContent") {
+                                if let Some(text) = rc.get("text").and_then(|v| v.as_str())
+                                    && !text.is_empty()
+                                {
+                                    let id = idx.to_string();
+                                    if reasoning_id.as_deref() != Some(id.as_str()) {
+                                        reasoning_id = Some(id.clone());
+                                        yield Ok(StreamPart::ReasoningStart {
+                                            id,
+                                            provider_metadata: None,
+                                        });
                                     }
+                                    yield Ok(StreamPart::ReasoningDelta {
+                                        id: idx.to_string(),
+                                        delta: text.to_string(),
+                                        provider_metadata: None,
+                                    });
+                                }
+                                if let Some(sig) =
+                                    rc.get("signature").and_then(|v| v.as_str())
+                                {
+                                    reasoning_signature
+                                        .get_or_insert_with(String::new)
+                                        .push_str(sig);
+                                }
+                            }
                         }
                     }
                     "contentBlockStop" => {
@@ -431,9 +447,13 @@ impl LanguageModel for BedrockModel {
                         } else if reasoning_id.is_some() {
                             let id = idx.to_string();
                             if reasoning_id.as_deref() == Some(id.as_str()) {
-                                yield Ok(StreamPart::ReasoningEnd { id,
-                provider_metadata: None,
-            });
+                                let provider_metadata = reasoning_signature
+                                    .take()
+                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                yield Ok(StreamPart::ReasoningEnd {
+                                    id,
+                                    provider_metadata,
+                                });
                                 reasoning_id = None;
                             }
                         } else if text_id.is_some() {
@@ -453,9 +473,13 @@ impl LanguageModel for BedrockModel {
                                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
                             }
                             if let Some(id) = reasoning_id.take() {
-                                yield Ok(StreamPart::ReasoningEnd { id,
-                provider_metadata: None,
-            });
+                                let provider_metadata = reasoning_signature
+                                    .take()
+                                    .map(|s| json!({ "bedrock": { "signature": s } }));
+                                yield Ok(StreamPart::ReasoningEnd {
+                                    id,
+                                    provider_metadata,
+                                });
                             }
                             final_finish_reason = Some(map_finish_reason(reason));
                         }

--- a/aimux-providers/src/google/convert.rs
+++ b/aimux-providers/src/google/convert.rs
@@ -213,6 +213,7 @@ fn convert_tool_parts(content: &[ContentPart]) -> Vec<Value> {
     for part in content {
         if let ContentPart::ToolResult {
             tool_call_id,
+            tool_name,
             result,
             ..
         } = part
@@ -225,12 +226,16 @@ fn convert_tool_parts(content: &[ContentPart]) -> Vec<Value> {
             if !tool_call_id.is_empty() {
                 function_response.insert("id".to_string(), json!(tool_call_id));
             }
-            // `name` is required by the API; the TS SDK uses the tool name
-            // from the part. We don't have it on `ToolResult`, so we fall
-            // back to the call id. This is sufficient for round-tripping
-            // with our own test fixtures; production callers that need the
-            // real tool name should use `ContentPart::ToolCall` first.
-            let name = tool_call_id.clone();
+            // `name` is required by the API and must be the name of the tool
+            // that was called (Gemini pairs functionResponse with the prior
+            // functionCall by name; an empty or mismatched name is rejected
+            // with HTTP 400 on multi-turn tool calls). Prefer the framework
+            // provided `tool_name`, falling back to the call id for callers
+            // that never set one.
+            let name = tool_name
+                .clone()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| tool_call_id.clone());
             function_response.insert("name".to_string(), json!(name));
             function_response.insert(
                 "response".to_string(),

--- a/aimux-providers/tests/anthropic_convert_full_test.rs
+++ b/aimux-providers/tests/anthropic_convert_full_test.rs
@@ -1,4 +1,4 @@
-﻿// Panic convert wrappers are #[deprecated]; these tests still use them.
+// Panic convert wrappers are #[deprecated]; these tests still use them.
 #![allow(deprecated)]
 //! Rust port of the remaining `convert-to-anthropic-prompt.test.ts` cases that
 //! exercise features now supported by the Rust data model: mid-conversation
@@ -307,6 +307,78 @@ fn should_omit_reasoning_parts_without_signature_when_send_reasoning_is_false() 
     assert_other_warning(
         &result.warnings,
         "sending reasoning content is disabled for this model",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Extended-thinking input echo (build_request_body_with_warnings wiring)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn thinking_enabled_echoes_reasoning_parts_as_thinking_blocks() {
+    use aimux_core::options::CallOptions;
+    use aimux_providers::anthropic::convert::build_request_body_with_warnings;
+
+    let mut options = CallOptions::new(vec![msg(
+        Role::Assistant,
+        vec![
+            reasoning_part("Let me weigh the options.", Some("sig-echo-1")),
+            text_part("Here is the answer."),
+        ],
+    )]);
+    options.provider_options = Some(
+        [(
+            "anthropic".to_string(),
+            json!({ "thinking": { "type": "enabled", "budgetTokens": 1024 } }),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let result =
+        build_request_body_with_warnings("claude-sonnet-4-20250514", &options, false).unwrap();
+    let blocks = result.body["messages"][0]["content"].as_array().unwrap();
+    let thinking = blocks
+        .iter()
+        .find(|b| b["type"] == "thinking")
+        .expect("reasoning part must be echoed as a thinking block");
+    assert_eq!(thinking["signature"], "sig-echo-1");
+    assert_eq!(thinking["thinking"], "Let me weigh the options.");
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::Other { message } if message.contains("disabled"))),
+        "no 'disabled' warning when thinking is enabled: {:?}",
+        result.warnings
+    );
+}
+
+#[test]
+fn thinking_disabled_omits_reasoning_parts() {
+    use aimux_core::options::CallOptions;
+    use aimux_providers::anthropic::convert::build_request_body_with_warnings;
+
+    let mut options = CallOptions::new(vec![msg(
+        Role::Assistant,
+        vec![
+            reasoning_part("Let me weigh the options.", Some("sig-echo-1")),
+            text_part("Here is the answer."),
+        ],
+    )]);
+    options.provider_options = Some(
+        [(
+            "anthropic".to_string(),
+            json!({ "thinking": { "type": "disabled" } }),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let result =
+        build_request_body_with_warnings("claude-sonnet-4-20250514", &options, false).unwrap();
+    let blocks = result.body["messages"][0]["content"].as_array().unwrap();
+    assert!(
+        !blocks.iter().any(|b| b["type"] == "thinking"),
+        "thinking block must be omitted when thinking is disabled"
     );
 }
 

--- a/aimux-providers/tests/anthropic_model_test.rs
+++ b/aimux-providers/tests/anthropic_model_test.rs
@@ -1492,4 +1492,57 @@ mod do_stream {
         // Nothing after the Error.
         assert_eq!(parts.len(), error_idx + 1);
     }
+
+    /// Extended-thinking streams: `signature_delta` pieces accumulate on the
+    /// thinking block and are attached to the concluding ReasoningEnd as
+    /// provider_metadata (`{"anthropic": {"signature": ..}}`), matching the
+    /// non-streaming path (#113).
+    #[tokio::test]
+    async fn should_attach_thinking_signature_to_reasoning_end() {
+        let server = MockServer::start().await;
+        let sse_body = sse_stream(&[
+            json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "model": "claude-3-haiku-20240307",
+                    "usage": { "input_tokens": 10 },
+                },
+            }),
+            json!({"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think."}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-part-1"}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-part-2"}}),
+            json!({"type":"content_block_stop","index":0}),
+            json!({"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}),
+            json!({"type":"message_stop"}),
+        ]);
+        mock_sse(&server, &sse_body).await;
+        let model = make_model(&server);
+        let parts = collect_stream(
+            model
+                .do_stream(&default_options(test_prompt()))
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        assert!(
+            parts.iter().any(|p| matches!(p,
+                StreamPart::ReasoningDelta { delta, .. } if delta == "Let me think.")),
+            "expected the thinking text delta, got {parts:?}"
+        );
+        let meta = parts.iter().find_map(|p| match p {
+            StreamPart::ReasoningEnd {
+                provider_metadata, ..
+            } => provider_metadata.clone(),
+            _ => None,
+        });
+        let meta = meta.expect("ReasoningEnd with provider_metadata");
+        // Incremental signature pieces are concatenated.
+        assert_eq!(
+            meta["anthropic"]["signature"].as_str(),
+            Some("sig-part-1sig-part-2")
+        );
+    }
 }

--- a/aimux-providers/tests/bedrock_reasoning_test.rs
+++ b/aimux-providers/tests/bedrock_reasoning_test.rs
@@ -732,9 +732,20 @@ async fn bedrock_stream_reasoning_and_text() {
         ]
     );
     assert!(has_reasoning_end(&parts), "expected a ReasoningEnd");
-    // NOTE: the signature carried on the final (empty) reasoning delta in TS is
-    // not representable on `StreamPart::ReasoningDelta` (no provider_metadata),
-    // so it is intentionally not asserted.
+    // The signature on the final (text-less) reasoning delta is attached to
+    // the concluding ReasoningEnd via provider_metadata, so extended-thinking
+    // multi-turn can echo it back (#113).
+    let reasoning_end_meta = parts.iter().find_map(|p| match p {
+        StreamPart::ReasoningEnd {
+            provider_metadata, ..
+        } => provider_metadata.clone(),
+        _ => None,
+    });
+    let reasoning_end_meta = reasoning_end_meta.expect("ReasoningEnd with provider_metadata");
+    assert_eq!(
+        reasoning_end_meta["bedrock"]["signature"].as_str(),
+        Some(STREAM_SIGNATURE)
+    );
 
     // Text block (id "1").
     assert_eq!(

--- a/aimux-providers/tests/bedrock_reasoning_test.rs
+++ b/aimux-providers/tests/bedrock_reasoning_test.rs
@@ -746,6 +746,11 @@ async fn bedrock_stream_reasoning_and_text() {
         reasoning_end_meta["bedrock"]["signature"].as_str(),
         Some(STREAM_SIGNATURE)
     );
+    // Dual-key shape matches the non-streaming path.
+    assert_eq!(
+        reasoning_end_meta["amazonBedrock"]["signature"].as_str(),
+        Some(STREAM_SIGNATURE)
+    );
 
     // Text block (id "1").
     assert_eq!(

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -1885,9 +1885,38 @@ mod request_body {
         assert_eq!(tool_msg["role"], "user");
         let fr = &tool_msg["parts"][0]["functionResponse"];
         assert_eq!(fr["id"], "call-1");
+        // Without a tool_name the call id is used as the required `name`
+        // (fallback path).
+        assert_eq!(fr["name"], "call-1");
+        assert_eq!(fr["response"]["name"], "call-1");
         // The serialized JSON output is a string under response.content.
         let content_str = fr["response"]["content"].as_str().unwrap();
         assert!(content_str.contains("\"temp\":70"));
+    }
+
+    #[test]
+    fn tool_result_uses_tool_name_for_function_response() {
+        let prompt: LanguageModelPrompt = vec![LanguageModelPromptMessage {
+            role: Role::Tool,
+            content: vec![ContentPart::ToolResult {
+                tool_call_id: "call-9".to_string(),
+                result: json!({ "temp": 21 }),
+                tool_name: Some("weather".to_string()),
+                is_error: None,
+                preliminary: None,
+                dynamic: None,
+                provider_options: None,
+            }],
+            ..Default::default()
+        }];
+        let body = build_request_body("gemini-2.0-flash", &default_options(prompt));
+
+        let fr = &body["contents"][0]["parts"][0]["functionResponse"];
+        assert_eq!(fr["id"], "call-9");
+        // `name` carries the real tool name, not the opaque call id —
+        // Gemini pairs functionResponse with the prior functionCall by name.
+        assert_eq!(fr["name"], "weather");
+        assert_eq!(fr["response"]["name"], "weather");
     }
 
     // ── tools → tools array with functionDeclarations ─────────────────────────

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -1919,6 +1919,28 @@ mod request_body {
         assert_eq!(fr["response"]["name"], "weather");
     }
 
+    #[test]
+    fn tool_result_blank_tool_name_falls_back_to_call_id() {
+        // An explicitly blank tool_name is treated as unset and falls back
+        // to the call id (locks the empty-string filter branch).
+        let prompt: LanguageModelPrompt = vec![LanguageModelPromptMessage {
+            role: Role::Tool,
+            content: vec![ContentPart::ToolResult {
+                tool_call_id: "call-blank".to_string(),
+                result: json!({ "ok": true }),
+                tool_name: Some(String::new()),
+                is_error: None,
+                preliminary: None,
+                dynamic: None,
+                provider_options: None,
+            }],
+            ..Default::default()
+        }];
+        let body = build_request_body("gemini-2.0-flash", &default_options(prompt));
+        let fr = &body["contents"][0]["parts"][0]["functionResponse"];
+        assert_eq!(fr["name"], "call-blank");
+    }
+
     // ── tools → tools array with functionDeclarations ─────────────────────────
 
     #[test]

--- a/bindings/go/roundtrip_fields_test.go
+++ b/bindings/go/roundtrip_fields_test.go
@@ -1,0 +1,51 @@
+// roundtrip_fields_test.go — input-side reasoning signature echo for the Go
+// binding (#135).
+//
+// Go prompts are raw JSON, so the binding's job is to pass them through the
+// FFI into the Rust engine unchanged. This test proves the full pipe for the
+// extended-thinking input round-trip: an assistant reasoning part carrying a
+// `signature` is echoed as an Anthropic thinking block on the wire when
+// thinking is enabled.
+
+package aimux
+
+import (
+	"strings"
+	"testing"
+)
+
+const plainAnthropicResponse = `{"id":"msg_go_rt","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+
+func TestE2E_AnthropicEchoesReasoningSignature(t *testing.T) {
+	srv := newMockServer()
+	defer srv.Close()
+	srv.SetResponse(plainAnthropicResponse)
+
+	m, err := NewAnthropicWithBase("test-key", "claude-sonnet-4-20250514", srv.URL)
+	if err != nil {
+		t.Fatalf("NewAnthropicWithBase: %v", err)
+	}
+	defer m.Close()
+
+	prompt := `[
+		{"role":"user","content":[{"type":"text","text":"hi"}]},
+		{"role":"assistant","content":[
+			{"type":"reasoning","text":"pondering","signature":"sig-go-1"},
+			{"type":"text","text":"answer"}
+		]},
+		{"role":"user","content":[{"type":"text","text":"go on"}]}
+	]`
+	opts := `{"provider_options":{"anthropic":{"thinking":{"type":"enabled","budgetTokens":1024}}}}`
+
+	if _, err := m.GenerateText(prompt, opts); err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	body := srv.LastRequestBody()
+	if !strings.Contains(body, `"type":"thinking"`) {
+		t.Errorf("expected a thinking block on the wire, got %s", body)
+	}
+	if !strings.Contains(body, `"signature":"sig-go-1"`) {
+		t.Errorf("expected the prompt signature to be echoed, got %s", body)
+	}
+}

--- a/bindings/node/__test__/roundtrip-fields.test.ts
+++ b/bindings/node/__test__/roundtrip-fields.test.ts
@@ -1,0 +1,142 @@
+// roundtrip-fields.test.ts — reasoning signature & toolName pass-through (#135).
+//
+// Proves the language-side pipe for the Round 4 fixes, through the FULL
+// chain (Node.js → napi-rs → Rust engine → HTTP mock):
+//   - anthropic: with thinking enabled, a prompt reasoning part's
+//     `signature` is echoed as a thinking block on the wire (input
+//     round-trip), and a thinking-block response surfaces `signature` on
+//     the result (response visibility, #131).
+//   - google: a tool_result's `toolName` reaches the request as
+//     functionResponse.name (#127).
+
+import test from 'ava'
+import { createServer, type Server } from 'node:http'
+import { anthropic, google } from '../index.js'
+
+function startMockServer(handler: (req: any, res: any) => void): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler)
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as any
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` })
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+const ANTHROPIC_THINKING_RESPONSE = JSON.stringify({
+  id: 'msg_rt',
+  type: 'message',
+  role: 'assistant',
+  model: 'claude-sonnet-4-20250514',
+  content: [
+    { type: 'thinking', thinking: 'pondering deeply', signature: 'sig-resp-1' },
+    { type: 'text', text: 'The answer.' },
+  ],
+  stop_reason: 'end_turn',
+  usage: { input_tokens: 10, output_tokens: 5 },
+})
+
+const GEMINI_RESPONSE = JSON.stringify({
+  candidates: [
+    {
+      content: { parts: [{ text: 'ok' }], role: 'model' },
+      finishReason: 'STOP',
+    },
+  ],
+  usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 1, totalTokenCount: 4 },
+})
+
+test('roundtrip: anthropic echoes prompt reasoning signature and surfaces response signature', async (t) => {
+  let receivedBody: any = null
+  const { server, url } = await startMockServer((req, res) => {
+    let body = ''
+    req.on('data', (chunk: Buffer) => (body += chunk))
+    req.on('end', () => {
+      receivedBody = JSON.parse(body)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(ANTHROPIC_THINKING_RESPONSE)
+    })
+  })
+
+  try {
+    const model = await anthropic('test-key', 'claude-sonnet-4-20250514', url)
+    const prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'pondering', signature: 'sig-prompt-1' },
+          { type: 'text', text: 'answer' },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'go on' }] },
+    ]
+    const opts = JSON.stringify({
+      provider_options: {
+        anthropic: { thinking: { type: 'enabled', budgetTokens: 1024 } },
+      },
+    })
+    const resultJson = await model.generateText(JSON.stringify(prompt), opts)
+
+    // Input round-trip: the prompt reasoning part is echoed as a thinking
+    // block (with its signature) on the wire.
+    const blocks = (receivedBody.messages ?? []).flatMap((m: any) => m.content ?? [])
+    const thinking = blocks.find((b: any) => b.type === 'thinking')
+    t.truthy(thinking, `expected a thinking block on the wire, got ${JSON.stringify(blocks)}`)
+    t.is(thinking.signature, 'sig-prompt-1')
+    t.is(thinking.thinking, 'pondering')
+
+    // Response visibility: the result carries the response signature so
+    // extended-thinking multi-turn can echo it back.
+    t.true(
+      resultJson.includes('"signature":"sig-resp-1"'),
+      `expected the result JSON to carry the response signature, got ${resultJson}`
+    )
+  } finally {
+    await closeServer(server)
+  }
+})
+
+test('roundtrip: google toolName reaches functionResponse.name', async (t) => {
+  let receivedBody: any = null
+  const { server, url } = await startMockServer((req, res) => {
+    let body = ''
+    req.on('data', (chunk: Buffer) => (body += chunk))
+    req.on('end', () => {
+      receivedBody = JSON.parse(body)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(GEMINI_RESPONSE)
+    })
+  })
+
+  try {
+    const model = await google('test-key', 'gemini-2.0-flash', url)
+    const prompt = [
+      { role: 'user', content: [{ type: 'text', text: 'weather?' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_call', tool_call_id: 'call-1', tool_name: 'weather', input: { location: 'SF' } },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [{ type: 'tool_result', tool_call_id: 'call-1', tool_name: 'weather', result: { temp: 70 } }],
+      },
+    ]
+    await model.generateText(JSON.stringify(prompt))
+
+    const parts = (receivedBody.contents ?? []).flatMap((c: any) => c.parts ?? [])
+    const fr = parts.map((p: any) => p.functionResponse).find(Boolean)
+    t.truthy(fr, `expected a functionResponse part, got ${JSON.stringify(parts)}`)
+    // `name` carries the real tool name (#127), not the opaque call id.
+    t.is(fr.name, 'weather')
+    t.is(fr.id, 'call-1')
+  } finally {
+    await closeServer(server)
+  }
+})

--- a/bindings/python/tests/test_reasoning_signature.py
+++ b/bindings/python/tests/test_reasoning_signature.py
@@ -1,0 +1,41 @@
+"""Response-side reasoning signature visibility for the Python binding (#135).
+
+The Python binding constructs prompts as plain JSON dicts, so input-side
+transparency is guaranteed by serde (asserted at the Rust level). What this
+test proves is the *visibility* half of the round-trip: a thinking-block
+response surfaces `signature` on the reasoning content of the result, so
+extended-thinking multi-turn can echo it back.
+"""
+
+import json
+
+from aimux import anthropic, generate_text
+
+from test_e2e import MockServer
+
+ANTHROPIC_THINKING = json.dumps({
+    "id": "msg_py_rt",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-sonnet-4-20250514",
+    "content": [
+        {"type": "thinking", "thinking": "pondering", "signature": "sig-py-resp-1"},
+        {"type": "text", "text": "The answer."},
+    ],
+    "stop_reason": "end_turn",
+    "usage": {"input_tokens": 10, "output_tokens": 5},
+})
+
+
+class TestReasoningSignatureVisibility:
+
+    def test_result_carries_response_signature(self):
+        with MockServer(ANTHROPIC_THINKING) as mock:
+            model = anthropic("test-key", "claude-sonnet-4-20250514", mock.url)
+            result = generate_text(model, "Hello")
+            assert result["text"] == "The answer."
+            dumped = json.dumps(result)
+            assert "sig-py-resp-1" in dumped, (
+                "expected the result to carry the thinking-block signature, "
+                f"got {dumped}"
+            )


### PR DESCRIPTION
Fixes #135（绑定层跟进收口）· **新发现并修复一个输入侧缺口**

> **依赖**：叠加在 #127 + #131 之上，请先合并两者。

## 新发现：anthropic thinking 输入回显被硬编码禁用

写 #135 的 round-trip 测试时发现：`build_request_body_with_warnings` 调 `convert_prompt_to_anthropic_full_fallible(&options.prompt, false)`——**硬编码 false**。`send_thinking` 只用于请求级 thinking 配置，从未传给 prompt 转换。后果：thinking 开启时，上一轮 assistant 的 reasoning（含 #131 辛苦保留的 signature）仍在发送侧被丢弃并告警 "sending reasoning content is disabled"——扩展思考多轮的"传回"半边整体断裂。

**修复**：flag 跟随 resolve 后的 thinking 状态（enabled/adaptive 回显 thinking 块；disabled 保持省略）。既有两个锁定 `convert_full(p,false)` 行为的测试不受影响（测的是函数级行为）。

## #135 清单完成情况

| 绑定 | 输入回显（请求侧） | 响应可见性（结果侧） | 本地验证 |
|---|---|---|---|
| node | ✅ anthropic signature→thinking 块 + google toolName→functionResponse.name | ✅ signature 在结果 | 2 ava 全过（重建原生模块） |
| python | serde 透明（mock 无法暴露请求体，Rust 层已测） | ✅ 1 pytest | 11/11 全过（maturin 重建） |
| go | ✅ 1 e2e（重建静态库） | — | PASS |
| flutter | ✅ 既有 content_part_test（toolName+signature wire 往返） | 同左 | CI |
| swift/kotlin/java/c | 类型面已核验齐全（swift ContentPart 含 signature+toolName；kotlin ToolResult 含 tool_name；java/c JSON 透明） | — | 检视结论 |

## #128 前瞻核验结论

绑定测试与 contract-tests fixture（wire-format.json 仅 happy-path 形态）**无 "Error 后无 part" 旧假设**——#128 合并零风险。

## Rust 测试

anthropic_convert_full 30（含 2 个新 builder 级测试：enabled 回显 / disabled 省略）、anthropic_model 45、anthropic_remaining 17、vertex_anthropic 6 全过；fmt/clippy 干净。