### PR TITLE
fix(providers): stop dropping response data providers already parsed (resubmit #101 + its review follow-ups)

### DIFF
--- a/aimux-core/src/generate.rs
+++ b/aimux-core/src/generate.rs
@@ -300,6 +300,15 @@ impl StreamTextResult {
                             provider_options: provider_metadata,
                         });
                         reasoning_text_buf.clear();
+                    } else if provider_metadata.is_some() {
+                        // No visible summary text, but the part carries
+                        // provider data (e.g. OpenAI encrypted reasoning with
+                        // store=false) that must round-trip on the next turn.
+                        response_content_parts.push(ContentPart::Reasoning {
+                            text: String::new(),
+                            signature: None,
+                            provider_options: provider_metadata,
+                        });
                     }
                 }
                 StreamPart::ToolCall {

--- a/aimux-core/tests/m11_m12_m6_test.rs
+++ b/aimux-core/tests/m11_m12_m6_test.rs
@@ -258,3 +258,109 @@ async fn consume_stream_builds_response_messages() {
         _ => panic!("expected Parts"),
     }
 }
+
+/// A mock model whose stream carries a reasoning block with provider
+/// metadata but NO summary text (OpenAI Responses with store=false can
+/// return encrypted reasoning without any summary deltas).
+struct MetadataOnlyReasoningModel;
+
+#[async_trait]
+impl LanguageModel for MetadataOnlyReasoningModel {
+    fn provider(&self) -> &str {
+        "mock"
+    }
+    fn model_id(&self) -> &str {
+        "mock-meta-reasoning"
+    }
+    async fn do_generate(&self, _options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
+        unimplemented!()
+    }
+    async fn do_stream(&self, _options: &CallOptions) -> Result<StreamResult, AiMuxError> {
+        let meta = serde_json::json!({
+            "openai": {
+                "itemId": "rs_1",
+                "reasoningEncryptedContent": "enc-blob-123",
+            }
+        });
+        let parts: Vec<Result<StreamPart, AiMuxError>> = vec![
+            Ok(StreamPart::StreamStart { warnings: vec![] }),
+            Ok(StreamPart::ReasoningStart {
+                id: "rs_1:0".into(),
+                provider_metadata: Some(meta.clone()),
+            }),
+            // No ReasoningDelta at all — no visible summary text.
+            Ok(StreamPart::ReasoningEnd {
+                id: "rs_1:0".into(),
+                provider_metadata: Some(meta),
+            }),
+            Ok(StreamPart::TextDelta {
+                id: "t1".into(),
+                delta: "Done.".into(),
+                provider_metadata: None,
+            }),
+            Ok(StreamPart::Finish {
+                finish_reason: FinishReason {
+                    unified: FinishReasonUnified::Stop,
+                    raw: Some("stop".into()),
+                },
+                usage: Usage::default(),
+                provider_metadata: None,
+            }),
+        ];
+        Ok(StreamResult {
+            stream: Box::pin(stream::iter(parts)),
+            request_body: None,
+            response_headers: None,
+        })
+    }
+}
+
+/// Regression: a reasoning part with provider metadata but no summary text
+/// used to be dropped from response_messages entirely, losing the
+/// encrypted reasoning blob (it must round-trip on the next turn).
+#[tokio::test]
+async fn consume_keeps_metadata_only_reasoning_in_response_messages() {
+    let result = aimux_core::generate::stream_text(
+        &MetadataOnlyReasoningModel,
+        "hi",
+        GenerateTextOptions::default(),
+    )
+    .await
+    .unwrap();
+    let agg = result.consume().await.unwrap();
+
+    // No visible reasoning text at the top level...
+    assert!(
+        agg.reasoning.is_empty(),
+        "no summary text, no ReasoningPart"
+    );
+
+    // ...but the reasoning part must survive in response_messages with its
+    // provider metadata, or the next turn loses the encrypted blob.
+    let msg = &agg.response_messages[0];
+    match &msg.content {
+        MessageContent::Parts(parts) => {
+            let reasoning = parts
+                .iter()
+                .find(|p| matches!(p, aimux_core::content::ContentPart::Reasoning { .. }));
+            match reasoning {
+                Some(aimux_core::content::ContentPart::Reasoning {
+                    text,
+                    provider_options: Some(po),
+                    ..
+                }) => {
+                    assert!(text.is_empty());
+                    assert_eq!(po["openai"]["itemId"], serde_json::json!("rs_1"));
+                    assert_eq!(
+                        po["openai"]["reasoningEncryptedContent"],
+                        serde_json::json!("enc-blob-123")
+                    );
+                }
+                other => panic!(
+                    "response_messages must keep the metadata-carrying reasoning part, got {other:?}"
+                ),
+            }
+        }
+        _ => panic!("expected Parts"),
+    }
+}

--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -86,6 +86,12 @@ pub fn convert_prompt_to_anthropic_full_fallible(
 /// `code_execution_tool_result`, …). Anthropic rejects a bare `tool_result`
 /// block inside an assistant message with HTTP 400, so a result whose tool
 /// cannot be resolved is dropped with a warning rather than emitted.
+///
+/// # Errors
+///
+/// Same as [`convert_prompt_to_anthropic_full_fallible`]: `AiMuxError::InvalidArgument`
+/// / `UnsupportedFunctionality` when a message part cannot be represented in the
+/// Anthropic wire format.
 pub fn convert_prompt_to_anthropic_full_with_tools(
     prompt: &LanguageModelPrompt,
     send_reasoning: bool,

--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -18,7 +18,7 @@
 //!   conversion with `send_reasoning = false`, discarding the betas and
 //!   warnings.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use aimux_core::content::ContentPart;
 use aimux_core::error::AiMuxError;
@@ -30,6 +30,7 @@ use serde_json::{Map, Value, json};
 
 use crate::anthropic::cache_control::CacheControlValidator;
 use crate::anthropic::prepare_tools::{AnthropicTool, prepare_tools_with_provider};
+use crate::anthropic::tool_name_mapping::ToolNameMapping;
 
 /// Beta header emitted when a PDF file part is present.
 const BETA_PDFS: &str = "pdfs-2024-09-25";
@@ -73,6 +74,29 @@ pub fn convert_prompt_to_anthropic_full_fallible(
     prompt: &LanguageModelPrompt,
     send_reasoning: bool,
 ) -> Result<AnthropicPromptConversion, AiMuxError> {
+    convert_prompt_to_anthropic_full_with_tools(prompt, send_reasoning, &ToolNameMapping::default())
+}
+
+/// [`convert_prompt_to_anthropic_full_fallible`] with the call's tool-name
+/// mapping.
+///
+/// The mapping is only consulted for **assistant-role** `ToolResult` parts,
+/// where the caller's tool name has to be resolved back to Anthropic's wire
+/// name to pick the right provider-executed result block (`web_search_tool_result`,
+/// `code_execution_tool_result`, …). Anthropic rejects a bare `tool_result`
+/// block inside an assistant message with HTTP 400, so a result whose tool
+/// cannot be resolved is dropped with a warning rather than emitted.
+pub fn convert_prompt_to_anthropic_full_with_tools(
+    prompt: &LanguageModelPrompt,
+    send_reasoning: bool,
+    tool_names: &ToolNameMapping,
+) -> Result<AnthropicPromptConversion, AiMuxError> {
+    // Ids of tool calls that were executed over MCP. Their results must be sent
+    // back as `mcp_tool_result`, not as a provider-tool result block. Upstream
+    // scopes this set to one merged assistant block; scanning the whole prompt
+    // is a superset of that and is safe because tool call ids are unique.
+    let mcp_tool_use_ids = collect_mcp_tool_use_ids(prompt);
+
     let mut system: Vec<Value> = Vec::new();
     let mut messages: Vec<Value> = Vec::new();
     let mut betas: BTreeSet<String> = BTreeSet::new();
@@ -190,17 +214,33 @@ pub fn convert_prompt_to_anthropic_full_fallible(
                 let n = msg.content.len();
                 for (idx, p) in msg.content.iter().enumerate() {
                     let is_last_part = idx + 1 == n;
-                    if let Some(block) = convert_part_to_anthropic(
-                        p,
-                        send_reasoning,
-                        &mut betas,
-                        &mut warnings,
-                        &mut validator,
-                        is_last_part,
-                        msg.provider_options.as_ref(),
-                        "assistant message part",
-                        "assistant message",
-                    )? {
+                    // Assistant-role tool results are provider-executed results;
+                    // Anthropic only accepts a bare `tool_result` in a *user*
+                    // message, so they take a dedicated path.
+                    let block = if let ContentPart::ToolResult { .. } = p {
+                        convert_assistant_tool_result(
+                            p,
+                            tool_names,
+                            &mcp_tool_use_ids,
+                            &mut warnings,
+                            &mut validator,
+                            is_last_part,
+                            msg.provider_options.as_ref(),
+                        )
+                    } else {
+                        convert_part_to_anthropic(
+                            p,
+                            send_reasoning,
+                            &mut betas,
+                            &mut warnings,
+                            &mut validator,
+                            is_last_part,
+                            msg.provider_options.as_ref(),
+                            "assistant message part",
+                            "assistant message",
+                        )?
+                    };
+                    if let Some(block) = block {
                         acc.push(block);
                     }
                 }
@@ -526,6 +566,343 @@ fn convert_part_to_anthropic(
     }))
 }
 
+// ── assistant-role tool results (provider-executed) ─────────────────────────
+
+/// Collect the tool call ids that were executed over MCP.
+///
+/// Their results have to go back as `mcp_tool_result`, so they are indexed
+/// before any message is converted. The marker is the one the response side
+/// writes on an `mcp_tool_use` block (`stream.rs`):
+/// `providerOptions.anthropic.type == "mcp-tool-use"`.
+fn collect_mcp_tool_use_ids(prompt: &LanguageModelPrompt) -> HashSet<&str> {
+    let mut ids = HashSet::new();
+    for msg in prompt {
+        if msg.role != Role::Assistant {
+            continue;
+        }
+        for part in &msg.content {
+            if let ContentPart::ToolCall {
+                tool_call_id,
+                provider_options: Some(opts),
+                ..
+            } = part
+                && opts
+                    .get("anthropic")
+                    .and_then(|a| a.get("type"))
+                    .and_then(|t| t.as_str())
+                    == Some("mcp-tool-use")
+            {
+                ids.insert(tool_call_id.as_str());
+            }
+        }
+    }
+    ids
+}
+
+/// Clone `key` out of `value`, defaulting to `null`.
+fn field(value: &Value, key: &str) -> Value {
+    value.get(key).cloned().unwrap_or(Value::Null)
+}
+
+/// The error code carried by a result payload.
+///
+/// The response side emits `errorCode`; wire-shaped payloads that passed
+/// through unmapped keep `error_code`. Both are accepted so a replayed result
+/// round-trips either way.
+fn result_error_code(value: &Value, fallback: &str) -> String {
+    value
+        .get("errorCode")
+        .or_else(|| value.get("error_code"))
+        .and_then(|c| c.as_str())
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+/// Convert an assistant-role `ContentPart::ToolResult` into the matching
+/// Anthropic provider-executed result block.
+///
+/// Anthropic only accepts a bare `tool_result` block inside a **user** message;
+/// emitting one on an assistant message is a hard HTTP 400. This mirrors the TS
+/// `convertToAnthropicPrompt` assistant `tool-result` branch (:871-1285): the
+/// tool name is resolved back to Anthropic's wire name and dispatched to the
+/// typed result block, and anything unrecognised is dropped with a warning
+/// rather than sent as a bare `tool_result`.
+///
+/// Returns `None` when the part is skipped.
+fn convert_assistant_tool_result(
+    part: &ContentPart,
+    tool_names: &ToolNameMapping,
+    mcp_tool_use_ids: &HashSet<&str>,
+    warnings: &mut Vec<Warning>,
+    validator: &mut CacheControlValidator,
+    is_last_part: bool,
+    message_provider_options: Option<&Value>,
+) -> Option<Value> {
+    let ContentPart::ToolResult {
+        tool_call_id,
+        tool_name,
+        result,
+        is_error,
+        provider_options,
+        ..
+    } = part
+    else {
+        return None;
+    };
+
+    // cache_control: part ?? output ?? (is_last_part ? message) — the same
+    // resolution order the bare `tool_result` path uses.
+    let cache_control = match validator.get_cache_control(
+        provider_options.as_ref(),
+        "assistant message part",
+        true,
+    ) {
+        Some(v) => Some(v),
+        None => match extract_tool_result_output_provider_options(result) {
+            Some(out_opts) => {
+                validator.get_cache_control(Some(out_opts), "tool result output", true)
+            }
+            None => {
+                if is_last_part {
+                    validator.get_cache_control(message_provider_options, "assistant message", true)
+                } else {
+                    None
+                }
+            }
+        },
+    };
+
+    // The payload is carried bare, with the error flag alongside it. Upstream
+    // reads both off a `{ type, value }` envelope instead; reconstructing that
+    // envelope here would mean guessing, and a legitimate payload that happens
+    // to look like one (`{"type":"error","value":...}`) would be unwrapped and
+    // have its `is_error` overwritten. The envelope belongs on the type.
+    let value = result;
+    let is_error = is_error.unwrap_or(false);
+    let tool_name = tool_name.as_deref().unwrap_or_default();
+    let payload_type = value.get("type").and_then(|t| t.as_str());
+
+    let mut block = if mcp_tool_use_ids.contains(tool_call_id.as_str()) {
+        json!({
+            "type": "mcp_tool_result",
+            "tool_use_id": tool_call_id,
+            "is_error": is_error,
+            "content": value,
+        })
+    } else {
+        let (block_type, content) = match tool_names.to_provider_tool_name(tool_name) {
+            "code_execution" => match assistant_code_execution_content(value, payload_type) {
+                Some(v) => v,
+                None => {
+                    warnings.push(Warning::Other {
+                        message: format!(
+                            "provider executed tool result output value is not a valid code execution result for tool {tool_name}"
+                        ),
+                    });
+                    return None;
+                }
+            },
+            "web_fetch" => (
+                "web_fetch_tool_result",
+                assistant_web_fetch_content(value, is_error),
+            ),
+            "web_search" => (
+                "web_search_tool_result",
+                assistant_web_search_content(value),
+            ),
+            "tool_search_tool_regex" | "tool_search_tool_bm25" => (
+                "tool_search_tool_result",
+                assistant_tool_search_content(value),
+            ),
+            "advisor" => (
+                "advisor_tool_result",
+                assistant_advisor_content(value, payload_type),
+            ),
+            _ => {
+                warnings.push(Warning::Other {
+                    message: format!(
+                        "provider executed tool result for tool {tool_name} is not supported"
+                    ),
+                });
+                return None;
+            }
+        };
+        json!({
+            "type": block_type,
+            "tool_use_id": tool_call_id,
+            "content": content,
+        })
+    };
+
+    if let Some(cc) = cache_control {
+        block["cache_control"] = cc;
+    }
+    Some(block)
+}
+
+/// `code_execution` result payload → `(block type, wire content)`.
+///
+/// The three code-execution tool versions and the bash / text-editor subtools
+/// all report through this one caller-facing tool name, so the payload's own
+/// `type` selects the block (upstream :928-1064).
+fn assistant_code_execution_content(
+    value: &Value,
+    payload_type: Option<&str>,
+) -> Option<(&'static str, Value)> {
+    let content = || value.get("content").cloned().unwrap_or(json!([]));
+    Some(match payload_type {
+        Some("code_execution_result") => (
+            "code_execution_tool_result",
+            json!({
+                "type": "code_execution_result",
+                "stdout": field(value, "stdout"),
+                "stderr": field(value, "stderr"),
+                "return_code": field(value, "return_code"),
+                "content": content(),
+            }),
+        ),
+        Some("encrypted_code_execution_result") => (
+            "code_execution_tool_result",
+            json!({
+                "type": "encrypted_code_execution_result",
+                "encrypted_stdout": field(value, "encrypted_stdout"),
+                "stderr": field(value, "stderr"),
+                "return_code": field(value, "return_code"),
+                "content": content(),
+            }),
+        ),
+        Some("code_execution_tool_result_error") => (
+            "code_execution_tool_result",
+            json!({
+                "type": "code_execution_tool_result_error",
+                "error_code": result_error_code(value, "unknown"),
+            }),
+        ),
+        Some("bash_code_execution_result") => (
+            "bash_code_execution_tool_result",
+            json!({
+                "type": "bash_code_execution_result",
+                "stdout": field(value, "stdout"),
+                "stderr": field(value, "stderr"),
+                "return_code": field(value, "return_code"),
+                "content": content(),
+            }),
+        ),
+        Some("bash_code_execution_tool_result_error") => (
+            "bash_code_execution_tool_result",
+            json!({
+                "type": "bash_code_execution_tool_result_error",
+                "error_code": result_error_code(value, "unknown"),
+            }),
+        ),
+        // The response side passes text-editor results through unmapped, so
+        // they are already in wire shape.
+        Some(t) if t.starts_with("text_editor_code_execution") => {
+            ("text_editor_code_execution_tool_result", value.clone())
+        }
+        _ => return None,
+    })
+}
+
+/// `web_fetch` result payload → wire `web_fetch_tool_result.content`
+/// (upstream :1070-1130). Re-snake-cases the camelCase response shape.
+fn assistant_web_fetch_content(value: &Value, is_error: bool) -> Value {
+    if is_error || value.get("type").and_then(|t| t.as_str()) == Some("web_fetch_tool_result_error")
+    {
+        return json!({
+            "type": "web_fetch_tool_result_error",
+            "error_code": result_error_code(value, "unavailable"),
+        });
+    }
+    let inner = value.get("content").cloned().unwrap_or(Value::Null);
+    let source = inner.get("source").cloned().unwrap_or(Value::Null);
+    json!({
+        "type": "web_fetch_result",
+        "url": field(value, "url"),
+        "retrieved_at": field(value, "retrievedAt"),
+        "content": {
+            "type": "document",
+            "title": field(&inner, "title"),
+            "citations": field(&inner, "citations"),
+            "source": {
+                "type": field(&source, "type"),
+                "media_type": field(&source, "mediaType"),
+                "data": field(&source, "data"),
+            },
+        },
+    })
+}
+
+/// `web_search` result payload → wire `web_search_tool_result.content`
+/// (upstream :1133-1196). A success payload is the result array.
+fn assistant_web_search_content(value: &Value) -> Value {
+    match value.as_array() {
+        Some(results) => Value::Array(
+            results
+                .iter()
+                .map(|r| {
+                    json!({
+                        "url": field(r, "url"),
+                        "title": field(r, "title"),
+                        "page_age": field(r, "pageAge"),
+                        "encrypted_content": field(r, "encryptedContent"),
+                        "type": field(r, "type"),
+                    })
+                })
+                .collect(),
+        ),
+        None => json!({
+            "type": "web_search_tool_result_error",
+            "error_code": result_error_code(value, "unavailable"),
+        }),
+    }
+}
+
+/// `tool_search_tool_*` result payload → wire `tool_search_tool_result.content`
+/// (upstream :1198-1233).
+fn assistant_tool_search_content(value: &Value) -> Value {
+    match value.as_array() {
+        Some(refs) => json!({
+            "type": "tool_search_tool_search_result",
+            "tool_references": refs
+                .iter()
+                .map(|r| json!({ "type": "tool_reference", "tool_name": field(r, "toolName") }))
+                .collect::<Vec<_>>(),
+        }),
+        None => json!({
+            "type": "tool_search_tool_result_error",
+            "error_code": result_error_code(value, "unavailable"),
+        }),
+    }
+}
+
+/// `advisor` result payload → wire `advisor_tool_result.content`
+/// (upstream :1235-1285).
+fn assistant_advisor_content(value: &Value, payload_type: Option<&str>) -> Value {
+    let with_stop_reason = |mut v: Value| {
+        if let Some(sr) = value.get("stopReason")
+            && !sr.is_null()
+        {
+            v["stop_reason"] = sr.clone();
+        }
+        v
+    };
+    match payload_type {
+        Some("advisor_result") => with_stop_reason(json!({
+            "type": "advisor_result",
+            "text": field(value, "text"),
+        })),
+        Some("advisor_redacted_result") => with_stop_reason(json!({
+            "type": "advisor_redacted_result",
+            "encrypted_content": field(value, "encryptedContent"),
+        })),
+        _ => json!({
+            "type": "advisor_tool_result_error",
+            "error_code": result_error_code(value, "unavailable"),
+        }),
+    }
+}
+
 /// Extract provider_options from a tool-result `output` value, mirroring the TS
 /// `outputProviderOptions` resolution.
 ///
@@ -761,7 +1138,16 @@ fn convert_reasoning_part(
         .and_then(|a| a.get("redactedData"))
         .and_then(|v| v.as_str());
 
-    if let Some(sig) = signature {
+    // #6: Fall back to `providerOptions.anthropic.signature` when the
+    // `signature` field is None (upstream convert-to-anthropic-prompt.ts:669-690).
+    let effective_signature = signature.or_else(|| {
+        provider_options
+            .and_then(|o| o.get("anthropic"))
+            .and_then(|a| a.get("signature"))
+            .and_then(|v| v.as_str())
+    });
+
+    if let Some(sig) = effective_signature {
         // Thinking blocks cannot carry cache_control directly — they are cached
         // implicitly when in previous assistant turns. Validate to emit a
         // helpful warning if a value was set.
@@ -1640,8 +2026,11 @@ pub fn build_request_body_with_warnings(
     // the parts are omitted with a warning instead.
     let send_input_reasoning =
         matches!(thinking_type.as_deref(), Some("enabled") | Some("adaptive"));
-    let conversion =
-        convert_prompt_to_anthropic_full_fallible(&options.prompt, send_input_reasoning)?;
+    let conversion = convert_prompt_to_anthropic_full_with_tools(
+        &options.prompt,
+        send_input_reasoning,
+        &ToolNameMapping::new(options.tools.as_deref()),
+    )?;
     let system = conversion.system;
     let messages = conversion.messages;
     betas.extend(conversion.betas);

--- a/aimux-providers/src/anthropic/mod.rs
+++ b/aimux-providers/src/anthropic/mod.rs
@@ -7,6 +7,7 @@ pub mod model;
 pub mod prepare_tools;
 pub mod sanitize_json_schema;
 pub mod stream;
+pub mod tool_name_mapping;
 pub mod types;
 pub mod usage;
 

--- a/aimux-providers/src/anthropic/model.rs
+++ b/aimux-providers/src/anthropic/model.rs
@@ -16,6 +16,7 @@ use aimux_core::result::{GenerateResult, StreamResult};
 use super::AnthropicConfig;
 use super::convert::build_request_body_with_warnings;
 use super::stream::{BodyEncoding, anthropic_generate_core, anthropic_stream_core};
+use super::tool_name_mapping::ToolNameMapping;
 use aimux_provider_utils::RetryConfig;
 
 /// An Anthropic language model (e.g. `claude-sonnet-4-20250514`).
@@ -131,6 +132,7 @@ impl LanguageModel for AnthropicModel {
             options.abort_signal.clone(),
             options.timeout.map(Into::into),
             options.recording_context.clone(),
+            &ToolNameMapping::new(options.tools.as_deref()),
         )
         .await
     }
@@ -151,6 +153,7 @@ impl LanguageModel for AnthropicModel {
             options.abort_signal.clone(),
             options.timeout.map(Into::into),
             options.recording_context.clone(),
+            ToolNameMapping::new(options.tools.as_deref()),
         )
         .await
     }

--- a/aimux-providers/src/anthropic/prepare_tools.rs
+++ b/aimux-providers/src/anthropic/prepare_tools.rs
@@ -321,7 +321,11 @@ fn prepare_function_tool(
 
 /// Map a provider-defined tool `id` to its Anthropic tool definition, returning
 /// `None` (so the caller emits an "unsupported" warning) when the id is unknown.
-fn prepare_provider_tool(id: &str, args: &Value, betas: &mut BTreeSet<String>) -> Option<Value> {
+pub(crate) fn prepare_provider_tool(
+    id: &str,
+    args: &Value,
+    betas: &mut BTreeSet<String>,
+) -> Option<Value> {
     Some(match id {
         "anthropic.computer_20241022" => {
             betas.insert("computer-use-2024-10-22".to_string());

--- a/aimux-providers/src/anthropic/stream.rs
+++ b/aimux-providers/src/anthropic/stream.rs
@@ -16,6 +16,7 @@
 //!   mapping used by the non-streaming path.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use futures::StreamExt;
 
@@ -31,9 +32,10 @@ use aimux_provider_utils::{
     HttpBody, HttpMethod, HttpRequest, RequestTimeout, RetryConfig, send_stream_timed, send_timed,
 };
 use aimux_stream::SseStream;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::convert::parse_stop_reason;
+use super::tool_name_mapping::ToolNameMapping;
 use super::types::{AnthropicResponse, ContentBlock, StreamEvent};
 
 /// How the request body is sent over the wire.
@@ -86,15 +88,350 @@ fn build_anthropic_request(
     })
 }
 
+/// Read a string field, dropping absent / non-string values.
+fn str_field(v: &Value, key: &str) -> Option<String> {
+    v.get(key).and_then(|x| x.as_str()).map(str::to_string)
+}
+
+/// Process-wide counter backing [`generate_source_id`].
+static SOURCE_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Unique id for a `Source` derived from a web-search result. Upstream calls
+/// `this.generateId()` at the same points.
+fn generate_source_id() -> String {
+    format!(
+        "anthropic-source-{}",
+        SOURCE_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// `web_search_result` → the camel-cased shape upstream exposes (:1243-1249).
+fn map_web_search_result(result: &Value) -> Value {
+    json!({
+        "url": result.get("url").cloned().unwrap_or(Value::Null),
+        "title": result.get("title").cloned().unwrap_or(Value::Null),
+        "pageAge": result.get("page_age").cloned().unwrap_or(Value::Null),
+        "encryptedContent": result.get("encrypted_content").cloned().unwrap_or(Value::Null),
+        "type": result.get("type").cloned().unwrap_or(Value::Null),
+    })
+}
+
+/// `web_fetch_tool_result.content` → `(result, is_error)` (upstream :1196-1231).
+fn map_web_fetch_result(payload: &Value) -> (Value, Option<bool>) {
+    if payload.get("type").and_then(|t| t.as_str()) != Some("web_fetch_result") {
+        return (
+            json!({
+                "type": "web_fetch_tool_result_error",
+                "errorCode": payload.get("error_code").cloned().unwrap_or(Value::Null),
+            }),
+            Some(true),
+        );
+    }
+    let inner = payload.get("content").cloned().unwrap_or(Value::Null);
+    let source = inner.get("source").cloned().unwrap_or(Value::Null);
+    (
+        json!({
+            "type": "web_fetch_result",
+            "url": payload.get("url").cloned().unwrap_or(Value::Null),
+            "retrievedAt": payload.get("retrieved_at").cloned().unwrap_or(Value::Null),
+            "content": {
+                "type": "document",
+                "title": inner.get("title").cloned().unwrap_or(Value::Null),
+                "citations": inner.get("citations").cloned().unwrap_or(Value::Null),
+                "source": {
+                    "type": source.get("type").cloned().unwrap_or(Value::Null),
+                    "mediaType": source.get("media_type").cloned().unwrap_or(Value::Null),
+                    "data": source.get("data").cloned().unwrap_or(Value::Null),
+                },
+            },
+        }),
+        None,
+    )
+}
+
+/// `code_execution_tool_result.content` → `(result, is_error)`
+/// (upstream :1281-1320, covering the plain and encrypted result shapes).
+fn map_code_execution_result(payload: &Value) -> (Value, Option<bool>) {
+    let content = payload.get("content").cloned().unwrap_or(json!([]));
+    match payload.get("type").and_then(|t| t.as_str()) {
+        Some("code_execution_result") => (
+            json!({
+                "type": "code_execution_result",
+                "stdout": payload.get("stdout").cloned().unwrap_or(Value::Null),
+                "stderr": payload.get("stderr").cloned().unwrap_or(Value::Null),
+                "return_code": payload.get("return_code").cloned().unwrap_or(Value::Null),
+                "content": content,
+            }),
+            None,
+        ),
+        Some("encrypted_code_execution_result") => (
+            json!({
+                "type": "encrypted_code_execution_result",
+                "encrypted_stdout": payload.get("encrypted_stdout").cloned()
+                    .unwrap_or(Value::Null),
+                "stderr": payload.get("stderr").cloned().unwrap_or(Value::Null),
+                "return_code": payload.get("return_code").cloned().unwrap_or(Value::Null),
+                "content": content,
+            }),
+            None,
+        ),
+        _ => (
+            json!({
+                "type": "code_execution_tool_result_error",
+                "errorCode": payload.get("error_code").cloned().unwrap_or(Value::Null),
+            }),
+            Some(true),
+        ),
+    }
+}
+
+/// `tool_search_tool_result.content` → `(result, is_error)` (upstream :1355-1370).
+///
+/// The success payload collapses to the tool-reference array itself.
+fn map_tool_search_result(payload: &Value) -> (Value, Option<bool>) {
+    let refs = payload
+        .get("content")
+        .and_then(|c| c.as_array())
+        .or_else(|| payload.get("tool_references").and_then(|r| r.as_array()));
+    match refs {
+        Some(refs) => (
+            Value::Array(
+                refs.iter()
+                    .map(|r| {
+                        json!({
+                            "type": r.get("type").cloned().unwrap_or(Value::Null),
+                            "toolName": r.get("tool_name").cloned().unwrap_or(Value::Null),
+                        })
+                    })
+                    .collect(),
+            ),
+            None,
+        ),
+        None => (
+            json!({
+                "type": "tool_search_tool_result_error",
+                "errorCode": payload.get("error_code").cloned().unwrap_or(Value::Null),
+            }),
+            Some(true),
+        ),
+    }
+}
+
+/// `advisor_tool_result.content` → `(result, is_error)` (upstream :1382-1400).
+fn map_advisor_result(payload: &Value) -> (Value, Option<bool>) {
+    let stop_reason = payload.get("stop_reason").cloned();
+    let with_stop_reason = |mut v: Value| {
+        if let Some(sr) = stop_reason.clone()
+            && !sr.is_null()
+        {
+            v["stopReason"] = sr;
+        }
+        v
+    };
+    match payload.get("type").and_then(|t| t.as_str()) {
+        Some("advisor_result") => (
+            with_stop_reason(json!({
+                "type": "advisor_result",
+                "text": payload.get("text").cloned().unwrap_or(Value::Null),
+            })),
+            None,
+        ),
+        Some("advisor_redacted_result") => (
+            with_stop_reason(json!({
+                "type": "advisor_redacted_result",
+                "encryptedContent": payload.get("encrypted_content").cloned()
+                    .unwrap_or(Value::Null),
+            })),
+            None,
+        ),
+        _ => (
+            json!({
+                "type": "advisor_tool_result_error",
+                "errorCode": payload.get("error_code").cloned().unwrap_or(Value::Null),
+            }),
+            Some(true),
+        ),
+    }
+}
+
+/// Which `tool_search_*` provider name this call registered.
+///
+/// Anthropic reports both regex and bm25 searches through one result block, so
+/// upstream probes which variant the caller renamed and defaults to regex
+/// (:1337-1352).
+fn tool_search_provider_name(names: &ToolNameMapping) -> &'static str {
+    if names.to_custom_tool_name("tool_search_tool_bm25") != "tool_search_tool_bm25" {
+        "tool_search_tool_bm25"
+    } else {
+        "tool_search_tool_regex"
+    }
+}
+
+/// Stream parts for a server-tool result block.
+///
+/// Result blocks arrive complete on `content_block_start`, so the payload
+/// mapping is shared with [`parse_anthropic_content`]; only the part type
+/// differs. Returns an empty vec for blocks that are not results.
+pub(crate) fn stream_parts_for_result_block(
+    block: &ContentBlock,
+    names: &ToolNameMapping,
+    mcp_tool_calls: &HashMap<String, (String, String)>,
+) -> Vec<StreamPart> {
+    let tool_result =
+        |tool_name: String, (result, is_error): (Value, Option<bool>), tool_use_id: &str| {
+            StreamPart::ToolResult {
+                tool_call_id: tool_use_id.to_string(),
+                tool_name,
+                result,
+                is_error,
+                preliminary: None,
+                dynamic: None,
+                provider_metadata: None,
+            }
+        };
+
+    match block {
+        ContentBlock::WebSearchToolResult {
+            tool_use_id,
+            content,
+        } => {
+            let name = names.to_custom_tool_name("web_search").to_string();
+            let Some(results) = content.as_array() else {
+                return vec![StreamPart::ToolResult {
+                    tool_call_id: tool_use_id.clone(),
+                    tool_name: name,
+                    result: json!({
+                        "type": "web_search_tool_result_error",
+                        "errorCode": content.get("error_code").cloned().unwrap_or(Value::Null),
+                    }),
+                    is_error: Some(true),
+                    preliminary: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                }];
+            };
+            // The tool result, then one Source per hit — the same pair the
+            // non-streaming path emits.
+            let mut parts = vec![tool_result(
+                name,
+                (
+                    Value::Array(results.iter().map(map_web_search_result).collect()),
+                    None,
+                ),
+                tool_use_id,
+            )];
+            parts.extend(results.iter().map(|result| StreamPart::Source {
+                id: generate_source_id(),
+                source_type: "url".to_string(),
+                url: str_field(result, "url"),
+                title: str_field(result, "title"),
+                provider_metadata: Some(json!({
+                    "anthropic": {
+                        "pageAge": result.get("page_age").cloned().unwrap_or(Value::Null),
+                    }
+                })),
+            }));
+            parts
+        }
+        ContentBlock::WebFetchToolResult {
+            tool_use_id,
+            content,
+        } => vec![tool_result(
+            names.to_custom_tool_name("web_fetch").to_string(),
+            map_web_fetch_result(content),
+            tool_use_id,
+        )],
+        ContentBlock::CodeExecutionToolResult {
+            tool_use_id,
+            content,
+        } => vec![tool_result(
+            names.to_custom_tool_name("code_execution").to_string(),
+            map_code_execution_result(content),
+            tool_use_id,
+        )],
+        ContentBlock::BashCodeExecutionToolResult {
+            tool_use_id,
+            content,
+        }
+        | ContentBlock::TextEditorCodeExecutionToolResult {
+            tool_use_id,
+            content,
+        } => vec![tool_result(
+            names.to_custom_tool_name("code_execution").to_string(),
+            (content.clone(), None),
+            tool_use_id,
+        )],
+        ContentBlock::ToolSearchToolResult {
+            tool_use_id,
+            content,
+        } => vec![tool_result(
+            names
+                .to_custom_tool_name(tool_search_provider_name(names))
+                .to_string(),
+            map_tool_search_result(content),
+            tool_use_id,
+        )],
+        ContentBlock::AdvisorToolResult {
+            tool_use_id,
+            content,
+        } => vec![tool_result(
+            names.to_custom_tool_name("advisor").to_string(),
+            map_advisor_result(content),
+            tool_use_id,
+        )],
+        ContentBlock::McpToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => {
+            let call = mcp_tool_calls.get(tool_use_id);
+            vec![StreamPart::ToolResult {
+                tool_call_id: tool_use_id.clone(),
+                tool_name: call.map(|(name, _)| name.clone()).unwrap_or_default(),
+                result: content.clone(),
+                is_error: *is_error,
+                preliminary: None,
+                dynamic: Some(true),
+                provider_metadata: call.map(|(_, server)| {
+                    json!({
+                        "anthropic": { "type": "mcp-tool-use", "serverName": server }
+                    })
+                }),
+            }]
+        }
+        _ => Vec::new(),
+    }
+}
+
 /// Map Anthropic response content blocks into `GenerateContent` items.
 ///
-/// Text / tool_use / thinking / server_tool_use blocks are surfaced; result
-/// blocks (web_search_tool_result, code_execution_tool_result, ...) and any
-/// unknown block type are intentionally dropped — `GenerateContent` has no
-/// provider-tool-result variant, and none of the current tests assert on their
-/// content.
-fn parse_anthropic_content(blocks: &[ContentBlock]) -> Vec<GenerateContent> {
+/// Text / tool_use / thinking / server_tool_use blocks are surfaced, and every
+/// server-tool result block becomes a `ToolResult` whose payload is reshaped to
+/// match the upstream contract. `web_search` results additionally produce
+/// `Source` items, which is how their URLs reach `result.sources`.
+///
+/// `names` maps Anthropic's wire tool names back to the names the caller used;
+/// pass the mapping built from `CallOptions.tools`.
+pub(crate) fn parse_anthropic_content(
+    blocks: &[ContentBlock],
+    names: &ToolNameMapping,
+) -> Vec<GenerateContent> {
     let mut content = Vec::new();
+    // `mcp_tool_result` inherits the name and server of the `mcp_tool_use` it
+    // answers, so index those first (upstream keeps the same lookup table).
+    let mut mcp_tool_calls: HashMap<&str, (&str, &str)> = HashMap::new();
+    for block in blocks {
+        if let ContentBlock::McpToolUse {
+            id,
+            name,
+            server_name,
+            ..
+        } = block
+        {
+            mcp_tool_calls.insert(id.as_str(), (name.as_str(), server_name.as_str()));
+        }
+    }
+
     for block in blocks {
         match block {
             ContentBlock::Text { text } => {
@@ -138,6 +475,196 @@ fn parse_anthropic_content(blocks: &[ContentBlock]) -> Vec<GenerateContent> {
                     provider_metadata: None,
                 });
             }
+            // MCP tool use — provider-executed + dynamic (upstream :1166-1182).
+            ContentBlock::McpToolUse {
+                id,
+                name,
+                input,
+                server_name,
+            } => {
+                content.push(GenerateContent::ToolCall {
+                    tool_call_id: id.clone(),
+                    tool_name: name.clone(),
+                    input: input.clone(),
+                    provider_executed: Some(true),
+                    dynamic: Some(true),
+                    thought_signature: None,
+                    provider_metadata: Some(json!({
+                        "anthropic": { "type": "mcp-tool-use", "serverName": server_name }
+                    })),
+                });
+            }
+            // Redacted thinking — upstream emits as reasoning with redactedData
+            ContentBlock::RedactedThinking { data } => {
+                content.push(GenerateContent::Reasoning {
+                    text: String::new(),
+                    provider_metadata: Some(json!({
+                        "anthropic": { "redactedData": data }
+                    })),
+                });
+            }
+            // ── Server-tool result blocks → GenerateContent::ToolResult ──
+            // Payload shapes mirror the TS `doGenerate` switch one-for-one
+            // (anthropic-language-model.ts:1196-1400): keys are camel-cased and
+            // optional members normalized, so a caller written against the
+            // upstream contract reads the same fields.
+            ContentBlock::WebSearchToolResult {
+                tool_use_id,
+                content: payload,
+            } => {
+                // Success is an array of results; anything else is the error
+                // object (upstream branches on `Array.isArray`).
+                match payload.as_array() {
+                    Some(results) => {
+                        content.push(GenerateContent::ToolResult {
+                            tool_call_id: tool_use_id.clone(),
+                            tool_name: names.to_custom_tool_name("web_search").to_string(),
+                            result: Value::Array(
+                                results.iter().map(map_web_search_result).collect(),
+                            ),
+                            is_error: None,
+                            preliminary: None,
+                            dynamic: None,
+                            provider_metadata: None,
+                        });
+                        // Each result also becomes a `Source` — that is how the
+                        // URLs and titles reach `result.sources`.
+                        for result in results {
+                            content.push(GenerateContent::Source {
+                                id: generate_source_id(),
+                                source_type: "url".to_string(),
+                                url: str_field(result, "url"),
+                                title: str_field(result, "title"),
+                                provider_metadata: Some(json!({
+                                    "anthropic": {
+                                        "pageAge": result.get("page_age").cloned()
+                                            .unwrap_or(Value::Null),
+                                    }
+                                })),
+                            });
+                        }
+                    }
+                    None => content.push(GenerateContent::ToolResult {
+                        tool_call_id: tool_use_id.clone(),
+                        tool_name: names.to_custom_tool_name("web_search").to_string(),
+                        result: json!({
+                            "type": "web_search_tool_result_error",
+                            "errorCode": payload.get("error_code").cloned()
+                                .unwrap_or(Value::Null),
+                        }),
+                        is_error: Some(true),
+                        preliminary: None,
+                        dynamic: None,
+                        provider_metadata: None,
+                    }),
+                }
+            }
+            ContentBlock::WebFetchToolResult {
+                tool_use_id,
+                content: payload,
+            } => {
+                let (result, is_error) = map_web_fetch_result(payload);
+                content.push(GenerateContent::ToolResult {
+                    tool_call_id: tool_use_id.clone(),
+                    tool_name: names.to_custom_tool_name("web_fetch").to_string(),
+                    result,
+                    is_error,
+                    preliminary: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                });
+            }
+            ContentBlock::CodeExecutionToolResult {
+                tool_use_id,
+                content: payload,
+            } => {
+                let (result, is_error) = map_code_execution_result(payload);
+                content.push(GenerateContent::ToolResult {
+                    tool_call_id: tool_use_id.clone(),
+                    tool_name: names.to_custom_tool_name("code_execution").to_string(),
+                    result,
+                    is_error,
+                    preliminary: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                });
+            }
+            // Upstream shares one arm for these two and passes `content`
+            // through unmapped (anthropic-language-model.ts:1323-1334).
+            ContentBlock::BashCodeExecutionToolResult {
+                tool_use_id,
+                content: payload,
+            }
+            | ContentBlock::TextEditorCodeExecutionToolResult {
+                tool_use_id,
+                content: payload,
+            } => {
+                content.push(GenerateContent::ToolResult {
+                    tool_call_id: tool_use_id.clone(),
+                    tool_name: names.to_custom_tool_name("code_execution").to_string(),
+                    result: payload.clone(),
+                    is_error: None,
+                    preliminary: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                });
+            }
+            ContentBlock::ToolSearchToolResult {
+                tool_use_id,
+                content: payload,
+            } => {
+                let (result, is_error) = map_tool_search_result(payload);
+                content.push(GenerateContent::ToolResult {
+                    tool_call_id: tool_use_id.clone(),
+                    tool_name: names
+                        .to_custom_tool_name(tool_search_provider_name(names))
+                        .to_string(),
+                    result,
+                    is_error,
+                    preliminary: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                });
+            }
+            ContentBlock::AdvisorToolResult {
+                tool_use_id,
+                content: payload,
+            } => {
+                let (result, is_error) = map_advisor_result(payload);
+                content.push(GenerateContent::ToolResult {
+                    tool_call_id: tool_use_id.clone(),
+                    tool_name: names.to_custom_tool_name("advisor").to_string(),
+                    result,
+                    is_error,
+                    preliminary: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                });
+            }
+            // MCP tool result — dynamic, and it inherits the name and metadata
+            // of the `mcp_tool_use` block it answers (upstream :1184-1194).
+            ContentBlock::McpToolResult {
+                tool_use_id,
+                content: payload,
+                is_error,
+            } => {
+                let call = mcp_tool_calls.get(tool_use_id.as_str());
+                content.push(GenerateContent::ToolResult {
+                    tool_call_id: tool_use_id.clone(),
+                    tool_name: call
+                        .map(|(name, _)| (*name).to_string())
+                        .unwrap_or_default(),
+                    result: payload.clone(),
+                    is_error: *is_error,
+                    preliminary: None,
+                    dynamic: Some(true),
+                    provider_metadata: call.map(|(_, server)| {
+                        json!({
+                            "anthropic": { "type": "mcp-tool-use", "serverName": server }
+                        })
+                    }),
+                });
+            }
             _ => {}
         }
     }
@@ -162,6 +689,7 @@ pub(crate) async fn anthropic_generate_core(
     abort_signal: Option<AbortSignal>,
     timeout: Option<RequestTimeout>,
     recording_context: Option<aimux_core::recording::RecordingContext>,
+    tool_names: &ToolNameMapping,
 ) -> Result<GenerateResult, AiMuxError> {
     let request = build_anthropic_request(
         endpoint,
@@ -175,7 +703,7 @@ pub(crate) async fn anthropic_generate_core(
 
     let data: AnthropicResponse = serde_json::from_slice(&resp.body)?;
 
-    let content = parse_anthropic_content(&data.content);
+    let content = parse_anthropic_content(&data.content, tool_names);
 
     let finish_reason = data
         .stop_reason
@@ -249,6 +777,7 @@ pub(crate) async fn anthropic_stream_core(
     abort_signal: Option<AbortSignal>,
     timeout: Option<RequestTimeout>,
     recording_context: Option<aimux_core::recording::RecordingContext>,
+    tool_names: ToolNameMapping,
 ) -> Result<StreamResult, AiMuxError> {
     let request = build_anthropic_request(
         endpoint,
@@ -273,6 +802,9 @@ pub(crate) async fn anthropic_stream_core(
         let mut final_finish_reason: Option<FinishReason> = None;
         let mut response_meta_emitted = false;
         let mut stream_errored = false;
+        // id → (tool name, server name), so `mcp_tool_result` can inherit them
+        // from the `mcp_tool_use` it answers.
+        let mut mcp_tool_calls: HashMap<String, (String, String)> = HashMap::new();
 
         while let Some(event) = sse.next().await {
             match event {
@@ -323,12 +855,70 @@ pub(crate) async fn anthropic_stream_core(
                                         accumulated_json: String::new(),
                                     });
                                 }
-                                // Server-side / provider-executed tool blocks
-                                // (server_tool_use, mcp_tool_use, result
-                                // blocks, ...) are not yet streamed as
-                                // first-class parts; ignore them here so an
-                                // unknown block type never aborts the stream.
-                                _ => {}
+                                // Server-side tool use — emit as ToolCall.
+                                ContentBlock::ServerToolUse { id, name, input } => {
+                                    yield Ok(StreamPart::ToolCall {
+                                        tool_call_id: id.clone(),
+                                        tool_name: tool_names
+                                            .to_custom_tool_name(&name)
+                                            .to_string(),
+                                        input: input.clone(),
+                                        provider_executed: Some(true),
+                                        dynamic: None,
+                                        thought_signature: None,
+                                        provider_metadata: None,
+                                    });
+                                }
+                                // MCP tool use — provider-executed + dynamic.
+                                ContentBlock::McpToolUse { id, name, input, server_name } => {
+                                    mcp_tool_calls
+                                        .insert(id.clone(), (name.clone(), server_name.clone()));
+                                    yield Ok(StreamPart::ToolCall {
+                                        tool_call_id: id.clone(),
+                                        tool_name: name.clone(),
+                                        input: input.clone(),
+                                        provider_executed: Some(true),
+                                        dynamic: Some(true),
+                                        thought_signature: None,
+                                        provider_metadata: Some(json!({
+                                            "anthropic": {
+                                                "type": "mcp-tool-use",
+                                                "serverName": server_name,
+                                            }
+                                        })),
+                                    });
+                                }
+                                // Redacted thinking — emit as ReasoningStart.
+                                ContentBlock::RedactedThinking { data } => {
+                                    let id = index.to_string();
+                                    yield Ok(StreamPart::ReasoningStart {
+                                        id: id.clone(),
+                                        provider_metadata: Some(json!({
+                                            "anthropic": { "redactedData": data }
+                                        })),
+                                    });
+                                    blocks.insert(
+                                        index,
+                                        BlockState::Thinking {
+                                            started: true,
+                                            signature: None,
+                                        },
+                                    );
+                                }
+                                // Server-tool result blocks arrive whole on
+                                // `content_block_start`, so they reuse the
+                                // non-streaming payload mapping. Upstream
+                                // mirrors its `doGenerate` switch here too
+                                // (anthropic-language-model.ts:1901-2178).
+                                other => {
+                                    for part in stream_parts_for_result_block(
+                                        &other,
+                                        &tool_names,
+                                        &mcp_tool_calls,
+                                    ) {
+                                        yield Ok(part);
+                                    }
+                                }
                             }
                         }
                         Ok(StreamEvent::ContentBlockDelta { index, delta }) => {

--- a/aimux-providers/src/anthropic/tool_name_mapping.rs
+++ b/aimux-providers/src/anthropic/tool_name_mapping.rs
@@ -1,0 +1,192 @@
+//! Bidirectional mapping between user-facing tool names and Anthropic's
+//! provider tool names.
+//!
+//! A [`ProviderTool`](aimux_core::tool::ProviderTool) carries both an `id` (`anthropic.web_search_20250305`)
+//! and a `name` — the name the caller uses to refer to that tool in this
+//! request. Anthropic's wire format uses its own fixed name (`web_search`), so
+//! the two differ whenever the caller renames a provider tool.
+//!
+//! Both directions are needed:
+//! - **response side** — a `web_search_tool_result` block names the tool
+//!   `web_search`; the caller expects to see their own name on the resulting
+//!   `ToolResult`.
+//! - **prompt side** — a replayed `ToolResult` carries the caller's name; the
+//!   converter must recover the provider name to pick the right result block
+//!   type (`web_search_tool_result` vs `code_execution_tool_result` vs …).
+//!
+//! Mirrors `createToolNameMapping` in
+//! `reference/vercel-ai/provider-utils/src/create-tool-name-mapping.ts`, with
+//! the Anthropic id→name table from `anthropic-language-model.ts`.
+
+use std::collections::HashMap;
+
+use aimux_core::tool::Tool;
+
+/// Anthropic provider tool id → the tool name Anthropic uses on the wire.
+///
+/// Kept in sync with the `name` field each id produces in
+/// [`prepare_tools`](super::prepare_tools).
+fn provider_tool_name(id: &str) -> Option<&'static str> {
+    Some(match id {
+        "anthropic.code_execution_20250522"
+        | "anthropic.code_execution_20250825"
+        | "anthropic.code_execution_20260120" => "code_execution",
+        "anthropic.computer_20241022"
+        | "anthropic.computer_20250124"
+        | "anthropic.computer_20251124" => "computer",
+        "anthropic.text_editor_20241022" | "anthropic.text_editor_20250124" => "str_replace_editor",
+        "anthropic.text_editor_20250429" | "anthropic.text_editor_20250728" => {
+            "str_replace_based_edit_tool"
+        }
+        "anthropic.bash_20241022" | "anthropic.bash_20250124" => "bash",
+        "anthropic.memory_20250818" => "memory",
+        "anthropic.web_search_20250305" | "anthropic.web_search_20260209" => "web_search",
+        "anthropic.web_fetch_20250910" | "anthropic.web_fetch_20260209" => "web_fetch",
+        "anthropic.tool_search_regex_20251119" => "tool_search_tool_regex",
+        "anthropic.tool_search_bm25_20251119" => "tool_search_tool_bm25",
+        "anthropic.advisor_20260301" => "advisor",
+        _ => return None,
+    })
+}
+
+/// Bidirectional tool-name mapping for one model call.
+///
+/// Only provider tools that the caller actually passed are mapped; every other
+/// name passes through unchanged.
+#[derive(Debug, Default, Clone)]
+pub struct ToolNameMapping {
+    custom_to_provider: HashMap<String, String>,
+    provider_to_custom: HashMap<String, String>,
+}
+
+impl ToolNameMapping {
+    /// Build the mapping from the tools passed on this call.
+    pub fn new(tools: Option<&[Tool]>) -> Self {
+        let mut mapping = ToolNameMapping::default();
+        for tool in tools.unwrap_or(&[]) {
+            if let Tool::Provider(pt) = tool
+                && let Some(provider_name) = provider_tool_name(&pt.id)
+            {
+                mapping
+                    .custom_to_provider
+                    .insert(pt.name.clone(), provider_name.to_string());
+                mapping
+                    .provider_to_custom
+                    .insert(provider_name.to_string(), pt.name.clone());
+            }
+        }
+        mapping
+    }
+
+    /// Caller's name → Anthropic's wire name. Unmapped names pass through.
+    pub fn to_provider_tool_name<'a>(&'a self, custom_name: &'a str) -> &'a str {
+        self.custom_to_provider
+            .get(custom_name)
+            .map(String::as_str)
+            .unwrap_or(custom_name)
+    }
+
+    /// Anthropic's wire name → caller's name. Unmapped names pass through.
+    pub fn to_custom_tool_name<'a>(&'a self, provider_name: &'a str) -> &'a str {
+        self.provider_to_custom
+            .get(provider_name)
+            .map(String::as_str)
+            .unwrap_or(provider_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aimux_core::tool::{FunctionTool, ProviderTool};
+    use serde_json::json;
+
+    fn provider_tool(id: &str, name: &str) -> Tool {
+        Tool::Provider(ProviderTool {
+            id: id.to_string(),
+            name: name.to_string(),
+            args: json!({}),
+        })
+    }
+
+    #[test]
+    fn maps_renamed_provider_tool_both_ways() {
+        let tools = vec![provider_tool("anthropic.web_search_20250305", "mySearch")];
+        let mapping = ToolNameMapping::new(Some(&tools));
+
+        assert_eq!(mapping.to_custom_tool_name("web_search"), "mySearch");
+        assert_eq!(mapping.to_provider_tool_name("mySearch"), "web_search");
+    }
+
+    #[test]
+    fn unmapped_names_pass_through() {
+        let mapping = ToolNameMapping::new(None);
+        assert_eq!(mapping.to_custom_tool_name("web_search"), "web_search");
+        assert_eq!(mapping.to_provider_tool_name("get_weather"), "get_weather");
+    }
+
+    #[test]
+    fn function_tools_are_ignored() {
+        let tools = vec![Tool::Function(FunctionTool::new("web_search", json!({})))];
+        let mapping = ToolNameMapping::new(Some(&tools));
+        // A function tool named `web_search` must not hijack the provider name.
+        assert_eq!(mapping.to_custom_tool_name("web_search"), "web_search");
+    }
+
+    #[test]
+    fn all_code_execution_versions_share_one_provider_name() {
+        for id in [
+            "anthropic.code_execution_20250522",
+            "anthropic.code_execution_20250825",
+            "anthropic.code_execution_20260120",
+        ] {
+            let tools = vec![provider_tool(id, "runCode")];
+            let mapping = ToolNameMapping::new(Some(&tools));
+            assert_eq!(
+                mapping.to_custom_tool_name("code_execution"),
+                "runCode",
+                "{id} must map to the code_execution provider name"
+            );
+        }
+    }
+
+    /// Every provider tool id this crate can build a request for must also be
+    /// mappable, and to the same name the request body uses. The two tables are
+    /// written out separately, so without this they drift silently: a renamed
+    /// tool would round-trip under the wrong name.
+    #[test]
+    fn every_known_provider_tool_id_maps_to_its_request_name() {
+        use crate::anthropic::prepare_tools::prepare_provider_tool;
+        use std::collections::BTreeSet;
+
+        // Ids are recovered from the source rather than duplicated here, so a
+        // newly supported tool cannot be added without this test seeing it.
+        let src = include_str!("prepare_tools.rs");
+        let ids: BTreeSet<&str> = src
+            .match_indices("\"anthropic.")
+            .filter_map(|(i, _)| {
+                let rest = &src[i + 1..];
+                rest.find('"').map(|end| &rest[..end])
+            })
+            .collect();
+        assert!(
+            ids.len() > 10,
+            "expected to recover the id table, got {ids:?}"
+        );
+
+        for id in ids {
+            let mut betas = BTreeSet::new();
+            let Some(def) = prepare_provider_tool(id, &json!({}), &mut betas) else {
+                continue;
+            };
+            let request_name = def["name"].as_str().expect("provider tool has a name");
+            let tools = vec![provider_tool(id, "myCustomName")];
+            let mapping = ToolNameMapping::new(Some(&tools));
+            assert_eq!(
+                mapping.to_custom_tool_name(request_name),
+                "myCustomName",
+                "{id} is sent as `{request_name}` but is not in the name mapping"
+            );
+        }
+    }
+}

--- a/aimux-providers/src/anthropic/tool_name_mapping.rs
+++ b/aimux-providers/src/anthropic/tool_name_mapping.rs
@@ -61,6 +61,7 @@ pub struct ToolNameMapping {
 
 impl ToolNameMapping {
     /// Build the mapping from the tools passed on this call.
+    #[must_use]
     pub fn new(tools: Option<&[Tool]>) -> Self {
         let mut mapping = ToolNameMapping::default();
         for tool in tools.unwrap_or(&[]) {

--- a/aimux-providers/src/anthropic_aws/model.rs
+++ b/aimux-providers/src/anthropic_aws/model.rs
@@ -17,8 +17,9 @@ use aimux_core::options::CallOptions;
 use aimux_core::result::{GenerateResult, StreamResult};
 use aimux_provider_utils::RetryConfig;
 
-use crate::anthropic::convert::build_request_body;
+use crate::anthropic::convert::build_request_body_with_warnings;
 use crate::anthropic::stream::{BodyEncoding, anthropic_generate_core, anthropic_stream_core};
+use crate::anthropic::tool_name_mapping::ToolNameMapping;
 use crate::bedrock::sigv4::sign_request;
 
 use super::AnthropicAwsAuth;
@@ -156,7 +157,7 @@ impl LanguageModel for AnthropicAwsModel {
     }
 
     async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
-        let body = build_request_body(&self.model_id, options, false)?;
+        let req = build_request_body_with_warnings(&self.model_id, options, false)?;
         let endpoint = self.endpoint();
         let build_headers = self.make_header_builder(options.headers.as_ref());
         let retry_config = crate::openai::model::resolve_retry_config(
@@ -166,19 +167,20 @@ impl LanguageModel for AnthropicAwsModel {
         anthropic_generate_core(
             &endpoint,
             retry_config,
-            body,
-            Vec::new(),
+            req.body,
+            req.warnings,
             build_headers,
             BodyEncoding::Bytes,
             options.abort_signal.clone(),
             options.timeout.map(Into::into),
             options.recording_context.clone(),
+            &ToolNameMapping::new(options.tools.as_deref()),
         )
         .await
     }
 
     async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
-        let body = build_request_body(&self.model_id, options, true)?;
+        let req = build_request_body_with_warnings(&self.model_id, options, true)?;
         let endpoint = self.endpoint();
         let build_headers = self.make_header_builder(options.headers.as_ref());
         let retry_config = crate::openai::model::resolve_retry_config(
@@ -188,13 +190,14 @@ impl LanguageModel for AnthropicAwsModel {
         anthropic_stream_core(
             &endpoint,
             retry_config,
-            body,
-            Vec::new(),
+            req.body,
+            req.warnings,
             build_headers,
             BodyEncoding::Bytes,
             options.abort_signal.clone(),
             options.timeout.map(Into::into),
             options.recording_context.clone(),
+            ToolNameMapping::new(options.tools.as_deref()),
         )
         .await
     }

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -288,6 +288,13 @@ impl LanguageModel for BedrockModel {
             let mut tool_blocks: HashMap<usize, (String, String, String)> = HashMap::new();
             let mut final_usage: Usage = Usage::default();
             let mut final_finish_reason: Option<FinishReason> = None;
+            // Provider metadata accumulated for the Finish chunk from `metadata`
+            // and `messageStop` events (findings #26, #27). Mirrors the TS
+            // `providerMetadata` / `stopSequence` accumulation in
+            // `amazon-bedrock-chat-language-model.ts` (`doStream`).
+            let mut finish_meta: serde_json::Map<String, serde_json::Value> =
+                serde_json::Map::new();
+            let mut stop_sequence: Option<String> = None;
 
             for msg in &messages {
                 if msg.message_type != "event" {
@@ -482,12 +489,35 @@ impl LanguageModel for BedrockModel {
                             }
                             final_finish_reason = Some(map_finish_reason(reason));
                         }
+                        // #26: surface which stop sequence sentinel fired
+                        // (additionalModelResponseFields.delta.stop_sequence), if any.
+                        if let Some(seq) = payload
+                            .get("additionalModelResponseFields")
+                            .and_then(|f| f.get("delta"))
+                            .and_then(|d| d.get("stop_sequence"))
+                            .and_then(|v| v.as_str())
+                        {
+                            stop_sequence = Some(seq.to_string());
+                        }
                     }
                     "metadata" => {
                         if let Some(usage) = payload.get("usage") {
                             let bedrock_usage: super::types::BedrockUsage =
                                 serde_json::from_value(usage.clone()).unwrap_or_default();
                             final_usage = convert_usage(Some(&bedrock_usage));
+                        }
+                        // #27: surface guardrails trace, performanceConfig, and
+                        // serviceTier into the Finish chunk's provider_metadata
+                        // (mirrors TS `doStream` metadata handling).
+                        if let Some(trace) = payload.get("trace") {
+                            finish_meta.insert("trace".to_string(), trace.clone());
+                        }
+                        if let Some(pc) = payload.get("performanceConfig") {
+                            finish_meta
+                                .insert("performanceConfig".to_string(), pc.clone());
+                        }
+                        if let Some(st) = payload.get("serviceTier") {
+                            finish_meta.insert("serviceTier".to_string(), st.clone());
                         }
                     }
                     _ => {}
@@ -508,13 +538,32 @@ impl LanguageModel for BedrockModel {
             });
             }
 
+            // #26: merge the stop sentinel into the metadata payload, then build
+            // the Finish provider_metadata under both `amazonBedrock` and
+            // `bedrock` keys (mirrors the TS `doStream` flush handler).
+            if let Some(seq) = stop_sequence {
+                finish_meta.insert(
+                    "stopSequence".to_string(),
+                    serde_json::Value::String(seq),
+                );
+            }
+            let provider_metadata = if finish_meta.is_empty() {
+                None
+            } else {
+                let payload = serde_json::Value::Object(finish_meta);
+                Some(json!({
+                    "amazonBedrock": payload,
+                    "bedrock": payload,
+                }))
+            };
+
             yield Ok(StreamPart::Finish {
                 finish_reason: final_finish_reason.unwrap_or(FinishReason {
                     unified: FinishReasonUnified::Stop,
                     raw: None,
                 }),
                 usage: final_usage,
-                provider_metadata: None,
+                provider_metadata,
             });
         };
 

--- a/aimux-providers/src/cohere/model.rs
+++ b/aimux-providers/src/cohere/model.rs
@@ -188,10 +188,8 @@ impl LanguageModel for CohereModel {
         // Mirrors TS `cohere-chat-language-model.ts`: each citation becomes a
         // `{ type: 'source', sourceType: 'document', title, providerMetadata:
         // { cohere: { start, end, text, sources, citationType } } }` content
-        // item. The Rust `GenerateContent::Source` variant carries no
-        // `mediaType` / `providerMetadata`, so only `source_type` and `title`
-        // are preserved here; the rich per-citation metadata (start/end/text/
-        // sources/citationType) is dropped — a documented data-model gap.
+        // item. The per-citation metadata (start/end/text/sources/citationType)
+        // is preserved in `provider_metadata`.
         if let Some(citations) = &data.message.citations {
             for (i, citation) in citations.iter().enumerate() {
                 let title = citation
@@ -203,12 +201,31 @@ impl LanguageModel for CohereModel {
                     .and_then(|t| t.as_str())
                     .map(std::string::ToString::to_string)
                     .unwrap_or_else(|| "Document".to_string());
+
+                // Build `providerMetadata.cohere` from the citation's fields.
+                // Only present fields are included (matching TS, where `undefined`
+                // values are dropped); `citationType` mirrors the TS spread
+                // `...(citation.type && { citationType: citation.type })` and is
+                // included only when `citation.type` is a non-empty string.
+                let mut cohere_meta = serde_json::Map::new();
+                for field in ["start", "end", "text", "sources"] {
+                    if let Some(v) = citation.get(field) {
+                        cohere_meta.insert(field.to_string(), v.clone());
+                    }
+                }
+                if let Some(t) = citation
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                {
+                    cohere_meta.insert("citationType".to_string(), Value::String(t.to_string()));
+                }
                 content.push(GenerateContent::Source {
                     id: format!("citation-{i}"),
                     source_type: "document".to_string(),
                     url: None,
                     title: Some(title),
-                    provider_metadata: None,
+                    provider_metadata: Some(json!({ "cohere": cohere_meta })),
                 });
             }
         }

--- a/aimux-providers/src/google/convert.rs
+++ b/aimux-providers/src/google/convert.rs
@@ -165,9 +165,44 @@ fn convert_assistant_parts(content: &[ContentPart]) -> Vec<Value> {
     let mut parts = Vec::new();
     for part in content {
         match part {
-            ContentPart::Text { text, .. } => {
+            ContentPart::Text {
+                text,
+                provider_options,
+            } => {
                 if !text.is_empty() {
-                    parts.push(json!({ "text": text }));
+                    let mut p = json!({ "text": text });
+                    // Echo thoughtSignature from provider_options if present
+                    // (upstream convert-to-google-messages.ts:355-377).
+                    if let Some(sig) = provider_options
+                        .as_ref()
+                        .and_then(|o| o.get("google"))
+                        .and_then(|g| g.get("thoughtSignature"))
+                        .and_then(|v| v.as_str())
+                    {
+                        p["thoughtSignature"] = json!(sig);
+                    }
+                    parts.push(p);
+                }
+            }
+            ContentPart::Reasoning {
+                text,
+                signature,
+                provider_options,
+            } => {
+                if !text.is_empty() {
+                    let mut p = json!({ "text": text, "thought": true });
+                    // Prefer explicit signature field, then fall back to provider_options.
+                    if let Some(sig) = signature.as_ref() {
+                        p["thoughtSignature"] = json!(sig);
+                    } else if let Some(sig) = provider_options
+                        .as_ref()
+                        .and_then(|o| o.get("google"))
+                        .and_then(|g| g.get("thoughtSignature"))
+                        .and_then(|v| v.as_str())
+                    {
+                        p["thoughtSignature"] = json!(sig);
+                    }
+                    parts.push(p);
                 }
             }
             ContentPart::ToolCall {
@@ -194,9 +229,35 @@ fn convert_assistant_parts(content: &[ContentPart]) -> Vec<Value> {
                 }
                 parts.push(part_value);
             }
+            ContentPart::ToolResult {
+                tool_call_id: _,
+                tool_name: _,
+                result,
+                is_error: _,
+                preliminary: _,
+                dynamic: _,
+                provider_options,
+            } => {
+                // Provider-executed tool result in an assistant message —
+                // upstream convert-to-google-messages.ts:518-540.
+                // If it carries serverToolCallId + serverToolType, emit as
+                // a toolResponse; otherwise skip (upstream returns undefined).
+                if let Some(opts) = provider_options.as_ref().and_then(|o| o.get("google")) {
+                    let server_id = opts.get("serverToolCallId").and_then(|v| v.as_str());
+                    let server_type = opts.get("serverToolType").and_then(|v| v.as_str());
+                    if let (Some(sid), Some(st)) = (server_id, server_type) {
+                        parts.push(json!({
+                            "toolResponse": {
+                                "toolType": st,
+                                "response": result,
+                                "id": sid,
+                            }
+                        }));
+                    }
+                }
+            }
             _ => {
-                // Files / images in assistant messages aren't supported by
-                // the Rust data model in a meaningful way here; skip them.
+                // Files / images in assistant messages: skip.
             }
         }
     }

--- a/aimux-providers/src/google/model.rs
+++ b/aimux-providers/src/google/model.rs
@@ -394,7 +394,7 @@ impl LanguageModel for GoogleModel {
                                             }
                                         }
                                     } else {
-                                        let is_thought = part.get("thought").and_then(|v| v.as_bool()).unwrap_or(false);
+                                        let is_thought = part.get("thought").and_then(serde_json::Value::as_bool).unwrap_or(false);
                                         if is_thought {
                                             // Close any open text block before starting reasoning
                                             if let Some(id) = text_id.take() {
@@ -402,7 +402,7 @@ impl LanguageModel for GoogleModel {
                                             }
                                             // Start a reasoning block if not already active
                                             if reasoning_id.is_none() {
-                                                let id = format!("{}", block_counter);
+                                                let id = format!("{block_counter}");
                                                 block_counter += 1;
                                                 reasoning_id = Some(id.clone());
                                                 yield Ok(StreamPart::ReasoningStart {
@@ -423,7 +423,7 @@ impl LanguageModel for GoogleModel {
                                                 yield Ok(StreamPart::ReasoningEnd { id, provider_metadata: None });
                                             }
                                             if text_id.is_none() {
-                                                let id = format!("{}", block_counter);
+                                                let id = format!("{block_counter}");
                                                 block_counter += 1;
                                                 text_id = Some(id.clone());
                                                 yield Ok(StreamPart::TextStart { id, provider_metadata: thought_sig_meta.clone() });
@@ -578,7 +578,7 @@ impl LanguageModel for GoogleModel {
                                     }
                                     yield Ok(StreamPart::ToolResult {
                                         tool_call_id: id,
-                                        tool_name: format!("server:{}", tool_type),
+                                        tool_name: format!("server:{tool_type}"),
                                         result: response,
                                         is_error: None,
                                         preliminary: None,
@@ -744,7 +744,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                     let output = cer
                         .get("output")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
+                        .map(std::string::ToString::to_string)
                         .unwrap_or_default();
                     content.push(GenerateContent::ToolResult {
                         tool_call_id: call_id,
@@ -766,7 +766,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                 } else {
                     let is_thought = part
                         .get("thought")
-                        .and_then(|v| v.as_bool())
+                        .and_then(serde_json::Value::as_bool)
                         .unwrap_or(false);
                     if is_thought {
                         content.push(GenerateContent::Reasoning {
@@ -835,7 +835,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                 let thought_signature = part
                     .get("thoughtSignature")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                    .map(std::string::ToString::to_string);
                 let mut server_meta = json!({
                     "google": { "serverToolCallId": id, "serverToolType": tool_type }
                 });
@@ -857,7 +857,11 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                 let tool_type = tr.get("toolType").and_then(|v| v.as_str()).unwrap_or("");
                 let id = last_server_tool_call_id
                     .take()
-                    .or_else(|| tr.get("id").and_then(|v| v.as_str()).map(|s| s.to_string()))
+                    .or_else(|| {
+                        tr.get("id")
+                            .and_then(|v| v.as_str())
+                            .map(std::string::ToString::to_string)
+                    })
                     .unwrap_or_default();
                 let response = tr.get("response").cloned().unwrap_or(json!({}));
                 let mut server_meta = json!({
@@ -868,7 +872,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                 }
                 content.push(GenerateContent::ToolResult {
                     tool_call_id: id,
-                    tool_name: format!("server:{}", tool_type),
+                    tool_name: format!("server:{tool_type}"),
                     result: response,
                     is_error: None,
                     preliminary: None,

--- a/aimux-providers/src/google/model.rs
+++ b/aimux-providers/src/google/model.rs
@@ -10,8 +10,11 @@ use aimux_core::error::{AiMuxError, ApiCallError};
 use aimux_core::language_model::LanguageModel;
 use aimux_core::options::CallOptions;
 use aimux_core::result::{GenerateContent, GenerateResult, StreamResult};
+use aimux_core::shared::{FileBytes, FileData};
 use aimux_core::stream_part::StreamPart;
-use aimux_core::types::{FinishReason, FinishReasonUnified, ResponseMetadata, Usage};
+use aimux_core::types::{
+    FinishReason, FinishReasonUnified, ProviderMetadata, ResponseMetadata, Usage,
+};
 
 use aimux_provider_utils::response::{ErrorStructure, error_for_status};
 use aimux_provider_utils::{HttpBody, HttpMethod, HttpRequest, send_stream_timed, send_timed};
@@ -237,6 +240,7 @@ impl LanguageModel for GoogleModel {
 
             let mut sse_stream = sse_stream;
             let mut text_id: Option<String> = None;
+            let mut reasoning_id: Option<String> = None;
             let mut block_counter = 0usize;
             let mut final_usage: Usage = Usage::default();
             let mut final_finish_reason: Option<FinishReason> = None;
@@ -358,21 +362,67 @@ impl LanguageModel for GoogleModel {
                             candidate.content.as_ref().and_then(|c| c.parts.as_ref())
                         {
                             for part in parts {
+                                // thoughtSignature → provider_metadata (upstream :778-782)
+                                let thought_sig_meta: Option<Value> = part
+                                    .get("thoughtSignature")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| json!({ "google": { "thoughtSignature": s } }));
+
                                 // text part
                                 if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
-                                    if !text.is_empty() {
-                                        if text_id.is_none() {
-                                            let id = format!("{block_counter}");
-                                            block_counter += 1;
-                                            text_id = Some(id.clone());
-                                            yield Ok(StreamPart::TextStart { id, provider_metadata: None});
-                                        }
-                                        if let Some(id) = &text_id {
+                                    if text.is_empty() {
+                                        // Empty-text part may carry a thoughtSignature
+                                        // (upstream :784-794): emit as a zero-length
+                                        // text-delta with the signature metadata.
+                                        if let (Some(meta), Some(id)) = (&thought_sig_meta, &text_id) {
                                             yield Ok(StreamPart::TextDelta {
                                                 id: id.clone(),
-                                                delta: text.to_string(),
-                                                provider_metadata: None,
+                                                delta: String::new(),
+                                                provider_metadata: Some(meta.clone()),
                                             });
+                                        }
+                                    } else {
+                                        let is_thought = part.get("thought").and_then(|v| v.as_bool()).unwrap_or(false);
+                                        if is_thought {
+                                            // Close any open text block before starting reasoning
+                                            if let Some(id) = text_id.take() {
+                                                yield Ok(StreamPart::TextEnd { id, provider_metadata: None });
+                                            }
+                                            // Start a reasoning block if not already active
+                                            if reasoning_id.is_none() {
+                                                let id = format!("{}", block_counter);
+                                                block_counter += 1;
+                                                reasoning_id = Some(id.clone());
+                                                yield Ok(StreamPart::ReasoningStart {
+                                                    id,
+                                                    provider_metadata: thought_sig_meta.clone(),
+                                                });
+                                            }
+                                            if let Some(id) = &reasoning_id {
+                                                yield Ok(StreamPart::ReasoningDelta {
+                                                    id: id.clone(),
+                                                    delta: text.to_string(),
+                                                    provider_metadata: thought_sig_meta.clone(),
+                                                });
+                                            }
+                                        } else {
+                                            // Close any open reasoning block before starting text
+                                            if let Some(id) = reasoning_id.take() {
+                                                yield Ok(StreamPart::ReasoningEnd { id, provider_metadata: None });
+                                            }
+                                            if text_id.is_none() {
+                                                let id = format!("{}", block_counter);
+                                                block_counter += 1;
+                                                text_id = Some(id.clone());
+                                                yield Ok(StreamPart::TextStart { id, provider_metadata: thought_sig_meta.clone() });
+                                            }
+                                            if let Some(id) = &text_id {
+                                                yield Ok(StreamPart::TextDelta {
+                                                    id: id.clone(),
+                                                    delta: text.to_string(),
+                                                    provider_metadata: thought_sig_meta.clone(),
+                                                });
+                                            }
                                         }
                                     }
                                 } else if let Some(fc) = part.get("functionCall") {
@@ -416,7 +466,7 @@ impl LanguageModel for GoogleModel {
                                         provider_executed: None,
                                         dynamic: None,
                                         thought_signature,
-                                        provider_metadata: None,
+                                        provider_metadata: thought_sig_meta.clone(),
                                     });
                                     has_tool_calls = true;
                                 } else if let Some(ec) = part.get("executableCode") {
@@ -456,7 +506,7 @@ impl LanguageModel for GoogleModel {
                                             .unwrap_or_default();
                                         yield Ok(StreamPart::ToolResult {
                                             tool_call_id: call_id,
-                                            tool_name: String::new(),
+                                            tool_name: "code_execution".to_string(),
                                             result: json!({ "outcome": outcome, "output": output }),
                                             is_error: None,
                                             preliminary: None,
@@ -478,6 +528,12 @@ impl LanguageModel for GoogleModel {
                                     block_counter += 1;
                                     last_server_tool_call_id = Some(id.clone());
                                     let args = tc.get("args").cloned().unwrap_or(json!({}));
+                                    let mut server_meta = json!({
+                                        "google": { "serverToolCallId": id, "serverToolType": tool_type }
+                                    });
+                                    if let Some(s) = part.get("thoughtSignature").and_then(|v| v.as_str()) {
+                                        server_meta["google"]["thoughtSignature"] = json!(s);
+                                    }
                                     yield Ok(StreamPart::ToolCall {
                                         tool_call_id: id,
                                         tool_name: format!("server:{tool_type}"),
@@ -485,11 +541,12 @@ impl LanguageModel for GoogleModel {
                                         provider_executed: None,
                                         dynamic: None,
                                         thought_signature: None,
-                                        provider_metadata: None,
+                                        provider_metadata: Some(server_meta),
                                     });
                                     // provider-executed → does NOT set has_tool_calls
                                 } else if let Some(tr) = part.get("toolResponse") {
                                     // Server-side tool response.
+                                    let tool_type = tr.get("toolType").and_then(|v| v.as_str()).unwrap_or("");
                                     let id = last_server_tool_call_id
                                         .take()
                                         .or_else(|| {
@@ -501,23 +558,53 @@ impl LanguageModel for GoogleModel {
                                     block_counter += 1;
                                     let response =
                                         tr.get("response").cloned().unwrap_or(json!({}));
+                                    let mut server_meta = json!({
+                                        "google": { "serverToolCallId": id, "serverToolType": tool_type }
+                                    });
+                                    if let Some(s) = part.get("thoughtSignature").and_then(|v| v.as_str()) {
+                                        server_meta["google"]["thoughtSignature"] = json!(s);
+                                    }
                                     yield Ok(StreamPart::ToolResult {
                                         tool_call_id: id,
-                                        tool_name: String::new(),
+                                        tool_name: format!("server:{}", tool_type),
                                         result: response,
                                         is_error: None,
                                         preliminary: None,
                                         dynamic: None,
-                                        provider_metadata: None,
+                                        provider_metadata: Some(server_meta),
                                     });
+                                } else if let Some(inline) = part.get("inlineData") {
+                                    // File output — upstream :847-877.
+                                    // Close any open text/reasoning block before file.
+                                    if let Some(id) = text_id.take() {
+                                        yield Ok(StreamPart::TextEnd { id, provider_metadata: None });
+                                    }
+                                    if let Some(id) = reasoning_id.take() {
+                                        yield Ok(StreamPart::ReasoningEnd { id, provider_metadata: None });
+                                    }
+                                    if let (Some(data), Some(mime)) = (
+                                        inline.get("data").and_then(|v| v.as_str()),
+                                        inline.get("mimeType").and_then(|v| v.as_str()),
+                                    ) {
+                                        // part.thought === true → upstream emits 'reasoning-file';
+                                        // emit plain File (reasoning-file is a separate PR).
+                                        yield Ok(StreamPart::File {
+                                            data: FileData::Data { data: FileBytes::Base64(data.to_string()) },
+                                            media_type: mime.to_string(),
+                                            provider_metadata: thought_sig_meta.clone(),
+                                        });
+                                    }
                                 }
                             }
                         }
 
                         if let Some(reason) = candidate.finish_reason.as_deref() {
-                            // Close any open text segment.
+                            // Close any open text/reasoning segment.
                             if let Some(id) = text_id.take() {
                                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
+                            }
+                            if let Some(id) = reasoning_id.take() {
+                                yield Ok(StreamPart::ReasoningEnd { id, provider_metadata: None});
                             }
                             // Snapshot the finishReason-chunk metadata.
                             if let Some(sr) = &candidate.safety_ratings {
@@ -541,9 +628,12 @@ impl LanguageModel for GoogleModel {
                 }
             }
 
-            // Close any remaining open text segment.
+            // Close any remaining open text/reasoning segment.
             if let Some(id) = text_id.take() {
                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
+            }
+            if let Some(id) = reasoning_id.take() {
+                yield Ok(StreamPart::ReasoningEnd { id, provider_metadata: None});
             }
 
             let provider_metadata = Some(serde_json::json!({
@@ -599,16 +689,84 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
     let mut has_tool_calls = false;
     let mut source_id = 0usize;
 
+    // Associates code-execution results / server tool responses with
+    // their preceding call.
+    let mut last_code_execution_tool_call_id: Option<String> = None;
+    let mut last_server_tool_call_id: Option<String> = None;
+
     let parts = candidate.content.as_ref().and_then(|c| c.parts.as_ref());
 
     if let Some(parts) = parts {
         for part in parts {
-            if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
-                if !text.is_empty() {
-                    content.push(GenerateContent::Text {
-                        text: text.to_string(),
+            // thoughtSignature → provider_metadata (upstream :448-451)
+            let thought_sig_meta: Option<Value> = part
+                .get("thoughtSignature")
+                .and_then(|v| v.as_str())
+                .map(|s| json!({ "google": { "thoughtSignature": s } }));
+
+            // Branch order matches upstream (google-language-model.ts:420-534):
+            // executableCode → codeExecutionResult → text → functionCall
+            // → inlineData → toolCall → toolResponse
+            if let Some(ec) = part.get("executableCode") {
+                let has_code = ec
+                    .get("code")
+                    .and_then(|v| v.as_str())
+                    .map(|s| !s.is_empty())
+                    .unwrap_or(false);
+                if has_code {
+                    let id = format!("call-{}", content.len());
+                    last_code_execution_tool_call_id = Some(id.clone());
+                    content.push(GenerateContent::ToolCall {
+                        tool_call_id: id,
+                        tool_name: "code_execution".to_string(),
+                        input: ec.clone(),
+                        provider_executed: None,
+                        dynamic: None,
+                        thought_signature: None,
                         provider_metadata: None,
                     });
+                }
+            } else if let Some(cer) = part.get("codeExecutionResult") {
+                if let Some(call_id) = last_code_execution_tool_call_id.take() {
+                    let outcome = cer.get("outcome").cloned().unwrap_or(json!(null));
+                    let output = cer
+                        .get("output")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_default();
+                    content.push(GenerateContent::ToolResult {
+                        tool_call_id: call_id,
+                        tool_name: "code_execution".to_string(),
+                        result: json!({ "outcome": outcome, "output": output }),
+                        is_error: None,
+                        preliminary: None,
+                        dynamic: None,
+                        provider_metadata: None,
+                    });
+                }
+            } else if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                if text.is_empty() {
+                    // Empty-text part may carry a thoughtSignature to attach
+                    // to the preceding content item (upstream :454-458).
+                    if let (Some(meta), Some(last)) = (&thought_sig_meta, content.last_mut()) {
+                        set_provider_metadata(last, meta.clone());
+                    }
+                } else {
+                    let is_thought = part
+                        .get("thought")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if is_thought {
+                        content.push(GenerateContent::Reasoning {
+                            text: text.to_string(),
+                            provider_metadata: thought_sig_meta.clone(),
+                        });
+                    } else {
+                        content.push(GenerateContent::Text {
+                            text: text.to_string(),
+                            provider_metadata: thought_sig_meta.clone(),
+                        });
+                    }
                 }
             } else if let Some(fc) = part.get("functionCall") {
                 let name = fc
@@ -633,32 +791,25 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                     provider_executed: None,
                     dynamic: None,
                     thought_signature,
-                    provider_metadata: None,
+                    provider_metadata: thought_sig_meta.clone(),
                 });
                 has_tool_calls = true;
-            } else if let Some(ec) = part.get("executableCode") {
-                // Provider-executed code execution. Only emit when `code` is a
-                // non-empty string (matches TS `part.executableCode?.code`).
-                let has_code = ec
-                    .get("code")
-                    .and_then(|v| v.as_str())
-                    .map(|s| !s.is_empty())
-                    .unwrap_or(false);
-                if has_code {
-                    content.push(GenerateContent::ToolCall {
-                        tool_call_id: String::new(),
-                        tool_name: "code_execution".to_string(),
-                        input: ec.clone(),
-                        provider_executed: None,
-                        dynamic: None,
-                        thought_signature: None,
-                        provider_metadata: None,
+            } else if let Some(inline) = part.get("inlineData") {
+                // File output (e.g. gemini-2.5-flash-image) — upstream :478-490.
+                if let (Some(data), Some(mime)) = (
+                    inline.get("data").and_then(|v| v.as_str()),
+                    inline.get("mimeType").and_then(|v| v.as_str()),
+                ) {
+                    // part.thought === true → upstream emits 'reasoning-file';
+                    // emit plain File (reasoning-file is a separate PR).
+                    content.push(GenerateContent::File {
+                        data: FileData::Data {
+                            data: FileBytes::Base64(data.to_string()),
+                        },
+                        media_type: mime.to_string(),
+                        provider_metadata: thought_sig_meta.clone(),
                     });
-                    // provider-executed → does NOT set has_tool_calls
                 }
-            } else if part.get("codeExecutionResult").is_some() {
-                // No `GenerateContent::ToolResult` variant yet; the
-                // result-portion assertions live in `#[ignore]`'d tests.
             } else if let Some(tc) = part.get("toolCall") {
                 // Server-side tool call (provider-executed, Gemini 3).
                 let tool_type = tc.get("toolType").and_then(|v| v.as_str()).unwrap_or("");
@@ -667,19 +818,52 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
+                last_server_tool_call_id = Some(id.clone());
                 let input = tc.get("args").cloned().unwrap_or(json!({}));
+                let thought_signature = part
+                    .get("thoughtSignature")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let mut server_meta = json!({
+                    "google": { "serverToolCallId": id, "serverToolType": tool_type }
+                });
+                if let Some(s) = part.get("thoughtSignature").and_then(|v| v.as_str()) {
+                    server_meta["google"]["thoughtSignature"] = json!(s);
+                }
                 content.push(GenerateContent::ToolCall {
                     tool_call_id: id,
                     tool_name: format!("server:{tool_type}"),
                     input,
                     provider_executed: None,
                     dynamic: None,
-                    thought_signature: None,
-                    provider_metadata: None,
+                    thought_signature,
+                    provider_metadata: Some(server_meta),
                 });
                 // provider-executed → does NOT set has_tool_calls
-            } else if part.get("toolResponse").is_some() {
-                // No `GenerateContent::ToolResult` variant yet; skip.
+            } else if let Some(tr) = part.get("toolResponse") {
+                // Server-side tool response (upstream :512-533).
+                let tool_type = tr.get("toolType").and_then(|v| v.as_str()).unwrap_or("");
+                let id = last_server_tool_call_id
+                    .take()
+                    .or_else(|| tr.get("id").and_then(|v| v.as_str()).map(|s| s.to_string()))
+                    .unwrap_or_default();
+                let response = tr.get("response").cloned().unwrap_or(json!({}));
+                let mut server_meta = json!({
+                    "google": { "serverToolCallId": id, "serverToolType": tool_type }
+                });
+                if let Some(s) = part.get("thoughtSignature").and_then(|v| v.as_str()) {
+                    server_meta["google"]["thoughtSignature"] = json!(s);
+                }
+                content.push(GenerateContent::ToolResult {
+                    tool_call_id: id,
+                    tool_name: format!("server:{}", tool_type),
+                    result: response,
+                    is_error: None,
+                    preliminary: None,
+                    dynamic: None,
+                    provider_metadata: Some(server_meta),
+                });
+                last_server_tool_call_id = None;
             }
         }
     }
@@ -689,6 +873,33 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
     content.append(&mut sources);
 
     (content, has_tool_calls)
+}
+
+/// Set `provider_metadata` on any `GenerateContent` variant (used to attach
+/// a thoughtSignature from an empty-text part to the preceding item).
+fn set_provider_metadata(item: &mut GenerateContent, meta: ProviderMetadata) {
+    match item {
+        GenerateContent::Text {
+            provider_metadata, ..
+        }
+        | GenerateContent::Reasoning {
+            provider_metadata, ..
+        }
+        | GenerateContent::ToolCall {
+            provider_metadata, ..
+        }
+        | GenerateContent::File {
+            provider_metadata, ..
+        }
+        | GenerateContent::Source {
+            provider_metadata, ..
+        }
+        | GenerateContent::ToolResult {
+            provider_metadata, ..
+        } => {
+            *provider_metadata = Some(meta);
+        }
+    }
 }
 
 /// Parse a Google error JSON envelope into an `AiMuxError`. Used for

--- a/aimux-providers/src/google/model.rs
+++ b/aimux-providers/src/google/model.rs
@@ -373,13 +373,25 @@ impl LanguageModel for GoogleModel {
                                     if text.is_empty() {
                                         // Empty-text part may carry a thoughtSignature
                                         // (upstream :784-794): emit as a zero-length
-                                        // text-delta with the signature metadata.
-                                        if let (Some(meta), Some(id)) = (&thought_sig_meta, &text_id) {
-                                            yield Ok(StreamPart::TextDelta {
-                                                id: id.clone(),
-                                                delta: String::new(),
-                                                provider_metadata: Some(meta.clone()),
-                                            });
+                                        // delta with the signature metadata on
+                                        // whichever block is open — text or
+                                        // reasoning (mirrors the non-streaming
+                                        // path, which attaches to the last
+                                        // content item regardless of type).
+                                        if let Some(meta) = &thought_sig_meta {
+                                            if let Some(id) = &text_id {
+                                                yield Ok(StreamPart::TextDelta {
+                                                    id: id.clone(),
+                                                    delta: String::new(),
+                                                    provider_metadata: Some(meta.clone()),
+                                                });
+                                            } else if let Some(id) = &reasoning_id {
+                                                yield Ok(StreamPart::ReasoningDelta {
+                                                    id: id.clone(),
+                                                    delta: String::new(),
+                                                    provider_metadata: Some(meta.clone()),
+                                                });
+                                            }
                                         }
                                     } else {
                                         let is_thought = part.get("thought").and_then(|v| v.as_bool()).unwrap_or(false);

--- a/aimux-providers/src/huggingface/responses.rs
+++ b/aimux-providers/src/huggingface/responses.rs
@@ -288,7 +288,12 @@ impl LanguageModel for HuggingFaceResponsesModel {
                                                     .and_then(|v| v.as_str())
                                                     .unwrap_or("")
                                                     .to_string();
-                                                yield Ok(StreamPart::TextStart { id, provider_metadata: None});
+                                                yield Ok(StreamPart::TextStart {
+                                                    id: id.clone(),
+                                                    provider_metadata: Some(json!({
+                                                        "huggingface": { "itemId": id }
+                                                    })),
+                                                });
                                             }
                                         }
                                         "function_call" => {
@@ -1039,9 +1044,12 @@ fn build_generate_content(response: &Value) -> Vec<GenerateContent> {
                     .unwrap_or(&empty_vec);
                 for cp in content_parts {
                     let text = cp.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                    let item_id = part.get("id").and_then(|v| v.as_str()).unwrap_or("");
                     content.push(GenerateContent::Text {
                         text: text.to_string(),
-                        provider_metadata: None,
+                        provider_metadata: Some(json!({
+                            "huggingface": { "itemId": item_id }
+                        })),
                     });
 
                     // Process annotations → source parts.
@@ -1097,9 +1105,6 @@ fn build_generate_content(response: &Value) -> Vec<GenerateContent> {
                     thought_signature: None,
                     provider_metadata: None,
                 });
-                // Tool result — the Rust GenerateContent enum has no ToolResult
-                // variant, so it is omitted (the TS emits it as a separate
-                // content item).
             }
 
             "mcp_call" => {
@@ -1120,6 +1125,18 @@ fn build_generate_content(response: &Value) -> Vec<GenerateContent> {
                     thought_signature: None,
                     provider_metadata: None,
                 });
+
+                if let Some(output) = part.get("output").filter(|v| !v.is_null()) {
+                    content.push(GenerateContent::ToolResult {
+                        tool_call_id: id.to_string(),
+                        tool_name: name.to_string(),
+                        result: output.clone(),
+                        is_error: None,
+                        preliminary: None,
+                        dynamic: None,
+                        provider_metadata: None,
+                    });
+                }
             }
 
             "mcp_list_tools" => {
@@ -1134,6 +1151,18 @@ fn build_generate_content(response: &Value) -> Vec<GenerateContent> {
                     thought_signature: None,
                     provider_metadata: None,
                 });
+
+                if let Some(tools) = part.get("tools").filter(|v| !v.is_null()) {
+                    content.push(GenerateContent::ToolResult {
+                        tool_call_id: id.to_string(),
+                        tool_name: "list_tools".to_string(),
+                        result: json!({ "tools": tools }),
+                        is_error: None,
+                        preliminary: None,
+                        dynamic: None,
+                        provider_metadata: None,
+                    });
+                }
             }
 
             _ => {}

--- a/aimux-providers/src/mistral/model.rs
+++ b/aimux-providers/src/mistral/model.rs
@@ -265,6 +265,17 @@ impl LanguageModel for MistralModel {
         // Build content array.
         let mut content = Vec::new();
 
+        // Reasoning content (from thinking parts in array content).
+        // Pushed before text to match upstream ordering (reasoning → text).
+        if let Some(r) = extract_reasoning_content(&choice.message.content)
+            && !r.is_empty()
+        {
+            content.push(GenerateContent::Reasoning {
+                text: r,
+                provider_metadata: None,
+            });
+        }
+
         // Content can be a string (legacy) or an array of typed parts.
         if let Some(text) = extract_text_content(&choice.message.content)
             && !text.is_empty()

--- a/aimux-providers/src/openai/convert.rs
+++ b/aimux-providers/src/openai/convert.rs
@@ -661,10 +661,20 @@ fn convert_message_to_openai(
     // all plain text (without providerOptions), collapse to a string — matching
     // the Vercel AI SDK `openai-compatible` assistant conversion
     // (`content: toolCalls.length > 0 ? text || null : text`).
+    //
+    // Provider-executed tool results are dropped from assistant messages: the
+    // OpenAI chat wire format has no content part for them, and upstream's
+    // assistant branch handles only `text` and `tool-call`
+    // (convert-to-openai-chat-messages.ts:246-300). Emitting one produces a
+    // part type the API rejects.
     let content_parts: Vec<&ContentPart> = msg
         .content
         .iter()
-        .filter(|p| !matches!(p, ContentPart::Reasoning { .. }))
+        .filter(|p| match p {
+            ContentPart::Reasoning { .. } => false,
+            ContentPart::ToolResult { .. } => msg.role != Role::Assistant,
+            _ => true,
+        })
         .collect();
     let all_plain_text = content_parts.iter().all(|p| {
         matches!(
@@ -691,7 +701,10 @@ fn convert_message_to_openai(
             .iter()
             .enumerate()
             .map(|(i, part)| convert_part_to_openai(part, i))
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .filter(|p| !p.is_null())
+            .collect();
         json!({ "role": role, "content": parts })
     };
     if has_reasoning {
@@ -868,15 +881,10 @@ fn convert_part_to_openai(part: &ContentPart, index: usize) -> Result<Value, AiM
                 "arguments": input.to_string(),
             }
         })),
-        ContentPart::ToolResult {
-            tool_call_id,
-            result,
-            ..
-        } => Ok(json!({
-            "type": "tool_result",
-            "tool_call_id": tool_call_id,
-            "content": result,
-        })),
+        // Tool results reach the wire as a separate `role: "tool"` message
+        // (built by `convert_message_to_openai`), never as a content part —
+        // there is no such part type in the OpenAI chat format.
+        ContentPart::ToolResult { .. } => Ok(Value::Null),
     }
 }
 

--- a/aimux-providers/src/openai/model.rs
+++ b/aimux-providers/src/openai/model.rs
@@ -732,6 +732,30 @@ pub async fn execute_stream(
                             }
                         }
 
+                        // Annotations / citations (URL citations → Source).
+                        if let Some(annotations) = choice.delta.annotations {
+                            for (i, ann) in annotations.iter().enumerate() {
+                                if ann.get("type").and_then(|v| v.as_str())
+                                    == Some("url_citation")
+                                    && let Some(uc) = ann.get("url_citation")
+                                {
+                                    yield Ok(StreamPart::Source {
+                                        id: format!("annotation-{}", i),
+                                        source_type: "url".to_string(),
+                                        url: uc
+                                            .get("url")
+                                            .and_then(|v| v.as_str())
+                                            .map(|s| s.to_string()),
+                                        title: uc
+                                            .get("title")
+                                            .and_then(|v| v.as_str())
+                                            .map(|s| s.to_string()),
+                                        provider_metadata: None,
+                                    });
+                                }
+                            }
+                        }
+
                         // Finish reason.
                         if let Some(reason) = choice.finish_reason {
                             // Close any open reasoning segment.

--- a/aimux-providers/src/openai/model.rs
+++ b/aimux-providers/src/openai/model.rs
@@ -740,16 +740,16 @@ pub async fn execute_stream(
                                     && let Some(uc) = ann.get("url_citation")
                                 {
                                     yield Ok(StreamPart::Source {
-                                        id: format!("annotation-{}", i),
+                                        id: format!("annotation-{i}"),
                                         source_type: "url".to_string(),
                                         url: uc
                                             .get("url")
                                             .and_then(|v| v.as_str())
-                                            .map(|s| s.to_string()),
+                                            .map(std::string::ToString::to_string),
                                         title: uc
                                             .get("title")
                                             .and_then(|v| v.as_str())
-                                            .map(|s| s.to_string()),
+                                            .map(std::string::ToString::to_string),
                                         provider_metadata: None,
                                     });
                                 }

--- a/aimux-providers/src/openai/responses/convert.rs
+++ b/aimux-providers/src/openai/responses/convert.rs
@@ -948,10 +948,18 @@ pub fn build_responses_request_body(
 /// - `output.total = output_tokens`
 /// - `output.text = output_tokens - reasoning_tokens`
 /// - `output.reasoning = reasoning_tokens`
+///
+/// `raw` is the untouched wire `usage` object; it is stored on `Usage.raw`
+/// (RFC-0015 P0-3). Re-serializing the typed struct instead would drop the
+/// `orchestration_*` counters and add explicit nulls, so the caller passes the
+/// original value through — matching the TS `raw: usage`.
 #[must_use]
-pub fn convert_responses_usage(usage: Option<&ResponsesUsage>) -> Usage {
+pub fn convert_responses_usage(usage: Option<&ResponsesUsage>, raw: Option<Value>) -> Usage {
     let Some(usage) = usage else {
-        return Usage::default();
+        return Usage {
+            raw,
+            ..Default::default()
+        };
     };
 
     let input_tokens = usage.input_tokens;
@@ -989,8 +997,7 @@ pub fn convert_responses_usage(usage: Option<&ResponsesUsage>) -> Usage {
             reasoning: Some(reasoning_tokens),
             ..Default::default()
         },
-        // RFC-0015 P0-3: keep the raw provider usage payload.
-        raw: Some(serde_json::to_value(usage).unwrap_or(serde_json::Value::Null)),
+        raw,
     }
 }
 

--- a/aimux-providers/src/openai/responses/responses_convert.rs
+++ b/aimux-providers/src/openai/responses/responses_convert.rs
@@ -338,6 +338,23 @@ enum SummaryStatus {
     Concluded,
 }
 
+/// Provider metadata for streamed reasoning parts, in the same shape the
+/// non-streaming path uses (`{ <provider_key>: { itemId,
+/// reasoningEncryptedContent? } }`) so `consume()` can propagate it into
+/// `response_messages` and the next turn's request conversion can read it
+/// back (`item_reference` when stored, `encrypted_content` when not).
+fn reasoning_stream_metadata(
+    provider_key: &str,
+    item_id: &str,
+    encrypted_content: Option<&str>,
+) -> Value {
+    let mut inner = json!({ "itemId": item_id });
+    if let Some(enc) = encrypted_content {
+        inner["reasoningEncryptedContent"] = json!(enc);
+    }
+    json!({ (provider_key): inner })
+}
+
 /// Generate a unique source ID for streaming annotation sources.
 ///
 /// Uses a process-wide atomic counter — consistent with the xAI Responses
@@ -572,6 +589,15 @@ where
                                             .get("encrypted_content")
                                             .and_then(|v| v.as_str())
                                             .map(std::string::ToString::to_string);
+                                        // Carry itemId + encrypted_content in
+                                        // provider_metadata (same shape as the
+                                        // non-streaming path) so reasoning can
+                                        // be echoed back on the next turn.
+                                        let meta = reasoning_stream_metadata(
+                                            &provider_key,
+                                            &id,
+                                            encrypted.as_deref(),
+                                        );
                                         active_reasoning.insert(
                                             id.clone(),
                                             ReasoningState {
@@ -584,7 +610,7 @@ where
                                         );
                                         yield Ok(StreamPart::ReasoningStart {
                                             id: format!("{id}:0"),
-                                            provider_metadata: None,
+                                            provider_metadata: Some(meta),
                                         });
                                     }
                                     _ => {}
@@ -643,6 +669,11 @@ where
                             if summary_index > 0
                                 && let Some(state) = active_reasoning.get_mut(&item_id)
                             {
+                                let meta = reasoning_stream_metadata(
+                                    &provider_key,
+                                    &item_id,
+                                    state.encrypted_content.as_deref(),
+                                );
                                 // Conclude all 'can-conclude' parts.
                                 let to_conclude: Vec<usize> = state
                                     .summary_parts
@@ -654,18 +685,16 @@ where
                                     state.summary_parts.insert(idx, SummaryStatus::Concluded);
                                     yield Ok(StreamPart::ReasoningEnd {
                                         id: format!("{item_id}:{idx}"),
-                                        provider_metadata: None,
+                                        provider_metadata: Some(meta.clone()),
                                     });
                                 }
                                 state
                                     .summary_parts
                                     .insert(summary_index, SummaryStatus::Active);
-                                let encrypted = state.encrypted_content.clone();
                                 yield Ok(StreamPart::ReasoningStart {
                                     id: format!("{item_id}:{summary_index}"),
-                                    provider_metadata: None,
+                                    provider_metadata: Some(meta),
                                 });
-                                let _ = encrypted;
                             }
                         }
 
@@ -710,7 +739,11 @@ where
                                         .insert(summary_index, SummaryStatus::Concluded);
                                     yield Ok(StreamPart::ReasoningEnd {
                                         id: format!("{item_id}:{summary_index}"),
-                                        provider_metadata: None,
+                                        provider_metadata: Some(reasoning_stream_metadata(
+                                            &provider_key,
+                                            &item_id,
+                                            state.encrypted_content.as_deref(),
+                                        )),
                                     });
                                 } else {
                                     state
@@ -818,6 +851,11 @@ where
                                             .unwrap_or("")
                                             .to_string();
                                         if let Some(state) = active_reasoning.get_mut(&id) {
+                                            let meta = reasoning_stream_metadata(
+                                                &provider_key,
+                                                &id,
+                                                state.encrypted_content.as_deref(),
+                                            );
                                             // Conclude all active / can-conclude parts.
                                             let to_conclude: Vec<usize> = state
                                                 .summary_parts
@@ -834,7 +872,7 @@ where
                                                     .insert(idx, SummaryStatus::Concluded);
                                                 yield Ok(StreamPart::ReasoningEnd {
                                                     id: format!("{id}:{idx}"),
-                                                    provider_metadata: None,
+                                                    provider_metadata: Some(meta.clone()),
                                                 });
                                             }
                                         }

--- a/aimux-providers/src/openai/responses/responses_convert.rs
+++ b/aimux-providers/src/openai/responses/responses_convert.rs
@@ -134,7 +134,11 @@ pub fn build_responses_generate_result(
                             if !text.is_empty() {
                                 content.push(GenerateContent::Text {
                                     text,
-                                    provider_metadata: None,
+                                    provider_metadata: Some(json!({
+                                        (provider_key.clone()): {
+                                            "itemId": part.get("id").cloned().unwrap_or(Value::Null),
+                                        }
+                                    })),
                                 });
                             }
                         }
@@ -189,7 +193,11 @@ pub fn build_responses_generate_result(
                     provider_executed: None,
                     dynamic: None,
                     thought_signature: None,
-                    provider_metadata: None,
+                    provider_metadata: Some(json!({
+                        (provider_key.clone()): {
+                            "itemId": part.get("id").cloned().unwrap_or(Value::Null),
+                        }
+                    })),
                 });
             }
             Some("custom_tool_call") => {
@@ -214,16 +222,26 @@ pub fn build_responses_generate_result(
                     provider_executed: None,
                     dynamic: None,
                     thought_signature: None,
-                    provider_metadata: None,
+                    provider_metadata: Some(json!({
+                        (provider_key.clone()): {
+                            "itemId": part.get("id").cloned().unwrap_or(Value::Null),
+                        }
+                    })),
                 });
             }
             Some("reasoning") => {
                 let summary = part.get("summary").and_then(|v| v.as_array());
                 let parts: Vec<&Value> = summary.map(|s| s.iter().collect()).unwrap_or_default();
+                let reasoning_metadata = Some(json!({
+                    (provider_key.clone()): {
+                        "itemId": part.get("id").cloned().unwrap_or(Value::Null),
+                        "reasoningEncryptedContent": part.get("encrypted_content").cloned().unwrap_or(Value::Null),
+                    }
+                }));
                 if parts.is_empty() {
                     content.push(GenerateContent::Reasoning {
                         text: String::new(),
-                        provider_metadata: None,
+                        provider_metadata: reasoning_metadata.clone(),
                     });
                 } else {
                     for sp in parts {
@@ -234,7 +252,7 @@ pub fn build_responses_generate_result(
                             .to_string();
                         content.push(GenerateContent::Reasoning {
                             text,
-                            provider_metadata: None,
+                            provider_metadata: reasoning_metadata.clone(),
                         });
                     }
                 }
@@ -249,7 +267,10 @@ pub fn build_responses_generate_result(
         .and_then(|v| v.as_str());
     let finish_reason = map_responses_finish_reason(incomplete_reason, has_function_call);
 
-    let usage = convert_responses_usage(data.get("usage").and_then(parse_usage).as_ref());
+    let usage = convert_responses_usage(
+        data.get("usage").and_then(parse_usage).as_ref(),
+        data.get("usage").cloned(),
+    );
 
     // Provider metadata: { <provider_key>: { responseId, reasoningContext?, serviceTier? } }
     let mut pm = json!({ "responseId": data.get("id").cloned().unwrap_or(Value::Null) });
@@ -315,6 +336,18 @@ enum SummaryStatus {
     Active,
     CanConclude,
     Concluded,
+}
+
+/// Generate a unique source ID for streaming annotation sources.
+///
+/// Uses a process-wide atomic counter — consistent with the xAI Responses
+/// provider (`aimux-providers/src/xai/responses/mod.rs`). Upstream TS uses
+/// `generateId()` for the same purpose.
+fn generate_source_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("source-{}", n)
 }
 
 /// Build the streaming event reducer shared by the OpenAI and Azure providers.
@@ -390,6 +423,9 @@ where
 
         let mut has_function_call = false;
         let mut final_usage: Option<ResponsesUsage> = None;
+        let mut final_raw_usage: Option<Value> = None;
+        let mut final_service_tier: Option<String> = None;
+        let mut final_reasoning_context: Option<Value> = None;
         let mut final_finish_reason: Option<FinishReason> = None;
         let mut response_id: Option<String> = None;
         let mut stream_errored = false;
@@ -809,6 +845,28 @@ where
                             }
                         }
 
+                        // ── response.output_text.annotation.added → Source ─────────
+                        "response.output_text.annotation.added" => {
+                            if let Some(ann) = parsed.get("annotation")
+                                && ann.get("type").and_then(|v| v.as_str())
+                                    == Some("url_citation")
+                            {
+                                yield Ok(StreamPart::Source {
+                                    id: generate_source_id(),
+                                    source_type: "url".to_string(),
+                                    url: ann
+                                        .get("url")
+                                        .and_then(|v| v.as_str())
+                                        .map(|s| s.to_string()),
+                                    title: ann
+                                        .get("title")
+                                        .and_then(|v| v.as_str())
+                                        .map(|s| s.to_string()),
+                                    provider_metadata: None,
+                                });
+                            }
+                        }
+
                         // ── response.completed / response.incomplete → finish ────
                         "response.completed" | "response.incomplete" => {
                             if let Some(resp_obj) = parsed.get("response") {
@@ -822,6 +880,23 @@ where
                                 ));
                                 final_usage =
                                     resp_obj.get("usage").and_then(parse_usage);
+                                // Keep the raw wire usage object for `usage.raw`
+                                // (RFC-0015 P0-3) and capture the finish-time
+                                // provider metadata fields carried on the
+                                // terminal response object.
+                                final_raw_usage = resp_obj.get("usage").cloned();
+                                if let Some(st) = resp_obj
+                                    .get("service_tier")
+                                    .and_then(|v| v.as_str())
+                                {
+                                    final_service_tier = Some(st.to_string());
+                                }
+                                if let Some(reasoning) = resp_obj.get("reasoning")
+                                    && let Some(ctx) = reasoning.get("context")
+                                    && !ctx.is_null()
+                                {
+                                    final_reasoning_context = Some(ctx.clone());
+                                }
                             }
                         }
 
@@ -841,6 +916,15 @@ where
                                 });
                                 final_usage =
                                     resp_obj.get("usage").and_then(parse_usage);
+                                final_raw_usage = resp_obj.get("usage").cloned();
+                                // Upstream's `response.failed` arm carries
+                                // `reasoningContext` (but not `serviceTier`).
+                                if let Some(reasoning) = resp_obj.get("reasoning")
+                                    && let Some(ctx) = reasoning.get("context")
+                                    && !ctx.is_null()
+                                {
+                                    final_reasoning_context = Some(ctx.clone());
+                                }
                                 if !stream_errored
                                     && resp_obj.get("error").is_some()
                                 {
@@ -912,10 +996,18 @@ where
             }
         }
 
-        // Build provider metadata for the Finish part.
+        // Build provider metadata for the Finish part: { <provider_key>: {
+        // responseId, serviceTier?, reasoningContext? } }. Mirrors the TS
+        // flush() providerMetadata, which carries `service_tier` and
+        // `reasoning.context` from the terminal response object.
         let mut pm = json!({ "responseId": response_id.unwrap_or_default() });
+        if let Some(st) = final_service_tier {
+            pm["serviceTier"] = json!(st);
+        }
+        if let Some(ctx) = final_reasoning_context {
+            pm["reasoningContext"] = ctx;
+        }
         let provider_metadata = Some(json!({ provider_key: pm }));
-        let _ = &mut pm;
 
         yield Ok(StreamPart::Finish {
             finish_reason: if stream_errored {
@@ -936,7 +1028,7 @@ where
             usage: if stream_errored {
                 Usage::default()
             } else {
-                convert_responses_usage(final_usage.as_ref())
+                convert_responses_usage(final_usage.as_ref(), final_raw_usage)
             },
             provider_metadata,
         });

--- a/aimux-providers/src/openai/responses/responses_convert.rs
+++ b/aimux-providers/src/openai/responses/responses_convert.rs
@@ -364,7 +364,7 @@ fn generate_source_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("source-{}", n)
+    format!("source-{n}")
 }
 
 /// Build the streaming event reducer shared by the OpenAI and Azure providers.
@@ -895,11 +895,11 @@ where
                                     url: ann
                                         .get("url")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string()),
+                                        .map(std::string::ToString::to_string),
                                     title: ann
                                         .get("title")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string()),
+                                        .map(std::string::ToString::to_string),
                                     provider_metadata: None,
                                 });
                             }

--- a/aimux-providers/src/openai/types.rs
+++ b/aimux-providers/src/openai/types.rs
@@ -149,6 +149,9 @@ pub struct Delta {
     pub reasoning_content: Option<String>,
     #[serde(default)]
     pub tool_calls: Option<Vec<DeltaToolCall>>,
+    /// Annotations (e.g. URL citations) carried by a streaming delta.
+    #[serde(default)]
+    pub annotations: Option<Vec<Value>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/aimux-providers/src/vertex/anthropic_model.rs
+++ b/aimux-providers/src/vertex/anthropic_model.rs
@@ -23,7 +23,7 @@ use serde_json::{Value, json};
 use aimux_core::error::{AiMuxError, ApiCallError};
 use aimux_core::language_model::LanguageModel;
 use aimux_core::options::CallOptions;
-use aimux_core::result::{GenerateContent, GenerateResult, StreamResult};
+use aimux_core::result::{GenerateResult, StreamResult};
 use aimux_core::stream_part::StreamPart;
 use aimux_core::types::{FinishReason, FinishReasonUnified, ResponseMetadata, Usage};
 
@@ -33,7 +33,9 @@ use aimux_provider_utils::{
 };
 use aimux_stream::SseStream;
 
-use crate::anthropic::convert::{build_request_body, parse_stop_reason};
+use crate::anthropic::convert::{build_request_body_with_warnings, parse_stop_reason};
+use crate::anthropic::stream::stream_parts_for_result_block;
+use crate::anthropic::tool_name_mapping::ToolNameMapping;
 use crate::anthropic::types::{AnthropicResponse, ContentBlock, StreamEvent};
 
 use super::VertexAuth;
@@ -177,8 +179,8 @@ impl LanguageModel for VertexAnthropicModel {
     }
 
     async fn do_generate(&self, options: &CallOptions) -> Result<GenerateResult, AiMuxError> {
-        let anthropic_body = build_request_body(&self.model_id, options, false)?;
-        let body = self.wrap_raw_predict_body(anthropic_body);
+        let req = build_request_body_with_warnings(&self.model_id, options, false)?;
+        let body = self.wrap_raw_predict_body(req.body);
         let url = self.generate_endpoint();
         let headers = self.build_headers(options.headers.as_ref());
         let retry_config = crate::openai::model::resolve_retry_config(
@@ -206,51 +208,10 @@ impl LanguageModel for VertexAnthropicModel {
         let data: AnthropicResponse =
             serde_json::from_slice(&resp.body).map_err(AiMuxError::from)?;
 
-        let mut content = Vec::new();
-        for block in &data.content {
-            match block {
-                ContentBlock::Text { text } => {
-                    content.push(GenerateContent::Text {
-                        text: text.clone(),
-                        provider_metadata: None,
-                    });
-                }
-                ContentBlock::ToolUse { id, name, input } => {
-                    content.push(GenerateContent::ToolCall {
-                        tool_call_id: id.clone(),
-                        tool_name: name.clone(),
-                        input: input.clone(),
-                        provider_executed: None,
-                        dynamic: None,
-                        thought_signature: None,
-                        provider_metadata: None,
-                    });
-                }
-                ContentBlock::Thinking {
-                    thinking,
-                    signature,
-                } => {
-                    content.push(GenerateContent::Reasoning {
-                        text: thinking.clone(),
-                        provider_metadata: Some(serde_json::json!({
-                            "anthropic": { "signature": signature }
-                        })),
-                    });
-                }
-                ContentBlock::ServerToolUse { id, name, input } => {
-                    content.push(GenerateContent::ToolCall {
-                        tool_call_id: id.clone(),
-                        tool_name: name.clone(),
-                        input: input.clone(),
-                        provider_executed: None,
-                        dynamic: None,
-                        thought_signature: None,
-                        provider_metadata: None,
-                    });
-                }
-                _ => {}
-            }
-        }
+        let content = crate::anthropic::stream::parse_anthropic_content(
+            &data.content,
+            &ToolNameMapping::new(options.tools.as_deref()),
+        );
 
         let finish_reason = data
             .stop_reason
@@ -268,7 +229,7 @@ impl LanguageModel for VertexAnthropicModel {
             content,
             finish_reason,
             usage,
-            warnings: Vec::new(),
+            warnings: req.warnings,
             provider_metadata: None,
             response: ResponseMetadata {
                 id: Some(data.id),
@@ -281,8 +242,10 @@ impl LanguageModel for VertexAnthropicModel {
     }
 
     async fn do_stream(&self, options: &CallOptions) -> Result<StreamResult, AiMuxError> {
-        let anthropic_body = build_request_body(&self.model_id, options, true)?;
-        let body = self.wrap_raw_predict_body(anthropic_body);
+        let req = build_request_body_with_warnings(&self.model_id, options, true)?;
+        let body = self.wrap_raw_predict_body(req.body);
+        let warnings = req.warnings;
+        let tool_names = ToolNameMapping::new(options.tools.as_deref());
         let url = self.stream_endpoint();
         let headers = self.build_headers(options.headers.as_ref());
         let retry_config = crate::openai::model::resolve_retry_config(
@@ -312,13 +275,14 @@ impl LanguageModel for VertexAnthropicModel {
         let sse_stream = SseStream::new(resp.body);
 
         let stream = async_stream::stream! {
-            yield Ok(StreamPart::StreamStart { warnings: vec![] });
+            yield Ok(StreamPart::StreamStart { warnings });
 
             let mut sse = sse_stream;
             let mut blocks: HashMap<usize, BlockState> = HashMap::new();
             let mut final_usage = Usage::default();
             let mut final_finish_reason: Option<FinishReason> = None;
             let mut response_meta_emitted = false;
+            let mut mcp_tool_calls: HashMap<String, (String, String)> = HashMap::new();
 
             while let Some(event) = sse.next().await {
                 match event {
@@ -363,7 +327,55 @@ impl LanguageModel for VertexAnthropicModel {
                                             accumulated_json: String::new(),
                                         });
                                     }
-                                    _ => {}
+                                    ContentBlock::ServerToolUse { id, name, input } => {
+                                        yield Ok(StreamPart::ToolCall {
+                                            tool_call_id: id.clone(),
+                                            tool_name: tool_names
+                                                .to_custom_tool_name(&name)
+                                                .to_string(),
+                                            input: input.clone(),
+                                            provider_executed: Some(true),
+                                            dynamic: None,
+                                            thought_signature: None,
+                                            provider_metadata: None,
+                                        });
+                                    }
+                                    ContentBlock::McpToolUse { id, name, input, server_name } => {
+                                        mcp_tool_calls
+                                            .insert(id.clone(), (name.clone(), server_name.clone()));
+                                        yield Ok(StreamPart::ToolCall {
+                                            tool_call_id: id.clone(),
+                                            tool_name: name.clone(),
+                                            input: input.clone(),
+                                            provider_executed: Some(true),
+                                            dynamic: Some(true),
+                                            thought_signature: None,
+                                            provider_metadata: Some(json!({
+                                                "anthropic": {
+                                                    "type": "mcp-tool-use",
+                                                    "serverName": server_name,
+                                                }
+                                            })),
+                                        });
+                                    }
+                                    ContentBlock::RedactedThinking { data } => {
+                                        yield Ok(StreamPart::ReasoningStart {
+                                            id: index.to_string(),
+                                            provider_metadata: Some(json!({
+                                                "anthropic": { "redactedData": data }
+                                            })),
+                                        });
+                                        blocks.insert(index, BlockState::Thinking { started: true });
+                                    }
+                                    other => {
+                                        for part in stream_parts_for_result_block(
+                                            &other,
+                                            &tool_names,
+                                            &mcp_tool_calls,
+                                        ) {
+                                            yield Ok(part);
+                                        }
+                                    }
                                 }
                             }
                             Ok(StreamEvent::ContentBlockDelta { index, delta }) => {
@@ -482,10 +494,16 @@ impl LanguageModel for VertexAnthropicModel {
                                     final_finish_reason = Some(parse_stop_reason(&reason));
                                 }
                                 if let Some(u) = usage {
-                                    final_usage.output_tokens = aimux_core::types::TokenUsage {
-                                        total: u.output_tokens,
-                                        ..Default::default()
-                                    };
+                                    // Reuse the shared conversion so the output
+                                    // reasoning/text split (from
+                                    // output_tokens_details) is preserved, matching
+                                    // anthropic/stream.rs. Only the output side is
+                                    // applied — MessageDelta carries output tokens
+                                    // only, so input-side usage from MessageStart is
+                                    // kept intact.
+                                    final_usage.output_tokens =
+                                        crate::anthropic::usage::usage_from_anthropic(&u)
+                                            .output_tokens;
                                 }
                             }
                             Ok(StreamEvent::MessageStop) => break,

--- a/aimux-providers/src/vertex/model.rs
+++ b/aimux-providers/src/vertex/model.rs
@@ -641,7 +641,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                 let thought_signature = part
                     .get("thoughtSignature")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                    .map(std::string::ToString::to_string);
                 content.push(GenerateContent::ToolCall {
                     tool_call_id: id,
                     tool_name: name,

--- a/aimux-providers/src/vertex/model.rs
+++ b/aimux-providers/src/vertex/model.rs
@@ -211,6 +211,9 @@ impl LanguageModel for VertexModel {
         let provider_metadata = Some(serde_json::json!({
             "googleVertex": {
                 "promptFeedback": data.prompt_feedback,
+                "groundingMetadata": candidate.grounding_metadata,
+                "urlContextMetadata": candidate.url_context_metadata,
+                "safetyRatings": candidate.safety_ratings,
                 "usageMetadata": data.usage_metadata,
                 "finishMessage": candidate.finish_message,
             }
@@ -610,47 +613,52 @@ impl LanguageModel for VertexModel {
 fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent>, bool) {
     let mut content = Vec::new();
     let mut has_tool_calls = false;
+    let mut source_id = 0usize;
 
-    let Some(parts) = candidate.content.as_ref().and_then(|c| c.parts.as_ref()) else {
-        return (content, has_tool_calls);
-    };
+    let parts = candidate.content.as_ref().and_then(|c| c.parts.as_ref());
 
-    for part in parts {
-        if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
-            if !text.is_empty() {
-                content.push(GenerateContent::Text {
-                    text: text.to_string(),
+    if let Some(parts) = parts {
+        for part in parts {
+            if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    content.push(GenerateContent::Text {
+                        text: text.to_string(),
+                        provider_metadata: None,
+                    });
+                }
+            } else if let Some(fc) = part.get("functionCall") {
+                let name = fc
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let id = fc
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let input = fc.get("args").cloned().unwrap_or(json!({}));
+                let thought_signature = part
+                    .get("thoughtSignature")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                content.push(GenerateContent::ToolCall {
+                    tool_call_id: id,
+                    tool_name: name,
+                    input,
+                    provider_executed: None,
+                    dynamic: None,
+                    thought_signature,
                     provider_metadata: None,
                 });
+                has_tool_calls = true;
             }
-        } else if let Some(fc) = part.get("functionCall") {
-            let name = fc
-                .get("name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let id = fc
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let input = fc.get("args").cloned().unwrap_or(json!({}));
-            let thought_signature = part
-                .get("thoughtSignature")
-                .and_then(|v| v.as_str())
-                .map(std::string::ToString::to_string);
-            content.push(GenerateContent::ToolCall {
-                tool_call_id: id,
-                tool_name: name,
-                input,
-                provider_executed: None,
-                dynamic: None,
-                thought_signature,
-                provider_metadata: None,
-            });
-            has_tool_calls = true;
         }
     }
+
+    // Sources are appended after the parts (mirrors TS / google provider).
+    let mut sources = extract_sources(candidate.grounding_metadata.as_ref(), &mut source_id);
+    content.append(&mut sources);
 
     (content, has_tool_calls)
 }

--- a/aimux-providers/tests/anthropic_assistant_tool_result_test.rs
+++ b/aimux-providers/tests/anthropic_assistant_tool_result_test.rs
@@ -1,0 +1,574 @@
+//! Assistant-role `ContentPart::ToolResult` → Anthropic provider-executed
+//! result blocks.
+//!
+//! Anthropic only accepts a bare `tool_result` block inside a **user** message.
+//! On an **assistant** message the converter has to emit the typed
+//! provider-executed block (`web_search_tool_result`, `mcp_tool_result`, …)
+//! instead, or the follow-up request is rejected with HTTP 400.
+//!
+//! `generate_text` does not route provider-executed results into
+//! `response_messages` yet — that needs `provider_executed` on the variant to
+//! express upstream's `!part.providerExecuted` predicate, and ships with the
+//! type change. The guard is in place first so the path is protected before it
+//! opens; these tests construct the assistant prompt directly rather than
+//! going through a generate call.
+//!
+//! Mirrors the assistant `case 'tool-result'` branch of
+//! `reference/vercel-ai/anthropic/src/convert-to-anthropic-prompt.ts` (:871-1285).
+
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aimux_core::content::ContentPart;
+use aimux_core::language_model::LanguageModel;
+use aimux_core::language_model_message::{LanguageModelPrompt, LanguageModelPromptMessage};
+use aimux_core::message::Role;
+use aimux_core::options::CallOptions;
+use aimux_core::result::GenerateContent;
+use aimux_core::tool::{ProviderTool, Tool};
+use aimux_providers::anthropic::AnthropicConfig;
+use aimux_providers::anthropic::convert::build_request_body_with_warnings;
+use aimux_providers::anthropic::model::AnthropicModel;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn provider_tool(id: &str, name: &str) -> Tool {
+    Tool::Provider(ProviderTool {
+        id: id.to_string(),
+        name: name.to_string(),
+        args: json!({}),
+    })
+}
+
+fn tool_result(tool_call_id: &str, tool_name: &str, result: Value) -> ContentPart {
+    ContentPart::ToolResult {
+        tool_call_id: tool_call_id.to_string(),
+        tool_name: Some(tool_name.to_string()),
+        result,
+        is_error: None,
+        preliminary: None,
+        dynamic: None,
+        provider_options: None,
+    }
+}
+
+fn msg(role: Role, content: Vec<ContentPart>) -> LanguageModelPromptMessage {
+    LanguageModelPromptMessage {
+        role,
+        content,
+        provider_options: None,
+    }
+}
+
+/// Build the request body for `prompt` + `tools` and return
+/// `(assistant content blocks, warning messages)`.
+fn convert(prompt: LanguageModelPrompt, tools: Vec<Tool>) -> (Vec<Value>, Vec<String>) {
+    let mut options = CallOptions::new(prompt);
+    if !tools.is_empty() {
+        options.tools = Some(tools);
+    }
+    let req = build_request_body_with_warnings("claude-sonnet-4-5", &options, false).unwrap();
+    let messages = req.body["messages"].as_array().cloned().unwrap_or_default();
+    let blocks = messages
+        .iter()
+        .filter(|m| m["role"] == "assistant")
+        .flat_map(|m| m["content"].as_array().cloned().unwrap_or_default())
+        .collect();
+    let warnings = req
+        .warnings
+        .iter()
+        .map(|w| serde_json::to_string(w).unwrap())
+        .collect();
+    (blocks, warnings)
+}
+
+// ── provider-executed result blocks ─────────────────────────────────────────
+
+#[test]
+fn assistant_web_search_result_becomes_web_search_tool_result() {
+    let (blocks, warnings) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "web_search",
+                json!([{
+                    "url": "https://example.com",
+                    "title": "Example",
+                    "pageAge": "3 days",
+                    "encryptedContent": "enc-1",
+                    "type": "web_search_result",
+                }]),
+            )],
+        )],
+        vec![provider_tool("anthropic.web_search_20250305", "web_search")],
+    );
+
+    assert_eq!(
+        blocks,
+        vec![json!({
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_1",
+            "content": [{
+                "url": "https://example.com",
+                "title": "Example",
+                "page_age": "3 days",
+                "encrypted_content": "enc-1",
+                "type": "web_search_result",
+            }],
+        })]
+    );
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+/// A renamed provider tool must still resolve to the provider block type.
+#[test]
+fn renamed_web_search_tool_still_resolves_to_provider_block() {
+    let (blocks, _) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result("srvtoolu_1", "mySearch", json!([]))],
+        )],
+        vec![provider_tool("anthropic.web_search_20250305", "mySearch")],
+    );
+
+    assert_eq!(blocks[0]["type"], "web_search_tool_result");
+}
+
+#[test]
+fn assistant_web_search_error_becomes_error_content() {
+    let (blocks, _) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "web_search",
+                json!({
+                    "type": "web_search_tool_result_error",
+                    "errorCode": "max_uses_exceeded",
+                }),
+            )],
+        )],
+        vec![provider_tool("anthropic.web_search_20250305", "web_search")],
+    );
+
+    assert_eq!(
+        blocks[0]["content"],
+        json!({
+            "type": "web_search_tool_result_error",
+            "error_code": "max_uses_exceeded",
+        })
+    );
+}
+
+#[test]
+fn assistant_mcp_result_becomes_mcp_tool_result() {
+    let mcp_call = ContentPart::ToolCall {
+        tool_call_id: "mcptoolu_1".to_string(),
+        tool_name: "echo".to_string(),
+        input: json!({ "text": "hi" }),
+        thought_signature: None,
+        provider_options: Some(json!({
+            "anthropic": { "type": "mcp-tool-use", "serverName": "my-server" }
+        })),
+    };
+
+    let (blocks, warnings) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![
+                mcp_call,
+                tool_result(
+                    "mcptoolu_1",
+                    "echo",
+                    json!([{ "type": "text", "text": "hi" }]),
+                ),
+            ],
+        )],
+        vec![],
+    );
+
+    assert_eq!(blocks[0]["type"], "tool_use");
+    assert_eq!(
+        blocks[1],
+        json!({
+            "type": "mcp_tool_result",
+            "tool_use_id": "mcptoolu_1",
+            "is_error": false,
+            "content": [{ "type": "text", "text": "hi" }],
+        })
+    );
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+#[test]
+fn assistant_code_execution_result_becomes_code_execution_tool_result() {
+    let (blocks, warnings) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "code_execution",
+                json!({
+                    "type": "code_execution_result",
+                    "stdout": "42\n",
+                    "stderr": "",
+                    "return_code": 0,
+                    "content": [],
+                }),
+            )],
+        )],
+        vec![provider_tool(
+            "anthropic.code_execution_20250522",
+            "code_execution",
+        )],
+    );
+
+    assert_eq!(
+        blocks,
+        vec![json!({
+            "type": "code_execution_tool_result",
+            "tool_use_id": "srvtoolu_1",
+            "content": {
+                "type": "code_execution_result",
+                "stdout": "42\n",
+                "stderr": "",
+                "return_code": 0,
+                "content": [],
+            },
+        })]
+    );
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+/// The bash subtool reports through the `code_execution` tool name but needs
+/// its own block type.
+#[test]
+fn assistant_bash_code_execution_result_uses_bash_block() {
+    let (blocks, _) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "code_execution",
+                json!({
+                    "type": "bash_code_execution_result",
+                    "stdout": "ok",
+                    "stderr": "",
+                    "return_code": 0,
+                    "content": [],
+                }),
+            )],
+        )],
+        vec![provider_tool(
+            "anthropic.code_execution_20250825",
+            "code_execution",
+        )],
+    );
+
+    assert_eq!(blocks[0]["type"], "bash_code_execution_tool_result");
+    assert_eq!(blocks[0]["content"]["type"], "bash_code_execution_result");
+}
+
+#[test]
+fn assistant_advisor_result_becomes_advisor_tool_result() {
+    let (blocks, _) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "advisor",
+                json!({
+                    "type": "advisor_result",
+                    "text": "consider X",
+                    "stopReason": "end_turn",
+                }),
+            )],
+        )],
+        vec![provider_tool("anthropic.advisor_20260301", "advisor")],
+    );
+
+    assert_eq!(
+        blocks,
+        vec![json!({
+            "type": "advisor_tool_result",
+            "tool_use_id": "srvtoolu_1",
+            "content": {
+                "type": "advisor_result",
+                "text": "consider X",
+                "stop_reason": "end_turn",
+            },
+        })]
+    );
+}
+
+#[test]
+fn assistant_tool_search_result_becomes_tool_search_tool_result() {
+    let (blocks, _) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "tool_search_tool_regex",
+                json!([{ "type": "tool_reference", "toolName": "get_weather" }]),
+            )],
+        )],
+        vec![provider_tool(
+            "anthropic.tool_search_regex_20251119",
+            "tool_search_tool_regex",
+        )],
+    );
+
+    assert_eq!(
+        blocks,
+        vec![json!({
+            "type": "tool_search_tool_result",
+            "tool_use_id": "srvtoolu_1",
+            "content": {
+                "type": "tool_search_tool_search_result",
+                "tool_references": [{ "type": "tool_reference", "tool_name": "get_weather" }],
+            },
+        })]
+    );
+}
+
+#[test]
+fn assistant_web_fetch_result_becomes_web_fetch_tool_result() {
+    let (blocks, _) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "web_fetch",
+                json!({
+                    "type": "web_fetch_result",
+                    "url": "https://example.com",
+                    "retrievedAt": "2025-01-01T00:00:00Z",
+                    "content": {
+                        "type": "document",
+                        "title": "Example",
+                        "citations": { "enabled": true },
+                        "source": {
+                            "type": "text",
+                            "mediaType": "text/plain",
+                            "data": "hello",
+                        },
+                    },
+                }),
+            )],
+        )],
+        vec![provider_tool("anthropic.web_fetch_20250910", "web_fetch")],
+    );
+
+    assert_eq!(
+        blocks[0]["content"],
+        json!({
+            "type": "web_fetch_result",
+            "url": "https://example.com",
+            "retrieved_at": "2025-01-01T00:00:00Z",
+            "content": {
+                "type": "document",
+                "title": "Example",
+                "citations": { "enabled": true },
+                "source": { "type": "text", "media_type": "text/plain", "data": "hello" },
+            },
+        })
+    );
+}
+
+// ── the fix: unknown tools must not emit a bare `tool_result` ───────────────
+
+/// The core of the fix. A `tool_result` block inside an assistant message is a
+/// hard HTTP 400 from Anthropic, so an unrecognised provider-executed result
+/// must be dropped with a warning rather than emitted.
+#[test]
+fn unrecognized_assistant_tool_result_is_dropped_with_warning() {
+    let (blocks, warnings) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![
+                ContentPart::text("done"),
+                tool_result("call_1", "get_weather", json!({ "temp": 20 })),
+            ],
+        )],
+        vec![],
+    );
+
+    assert_eq!(blocks, vec![json!({ "type": "text", "text": "done" })]);
+    assert!(
+        blocks.iter().all(|b| b["type"] != "tool_result"),
+        "assistant messages must never carry a bare tool_result: {blocks:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w
+                .contains("provider executed tool result for tool get_weather is not supported")),
+        "expected an unsupported-tool warning, got {warnings:?}"
+    );
+}
+
+/// A `ToolResult` with no `tool_name` cannot be resolved either.
+#[test]
+fn assistant_tool_result_without_tool_name_is_dropped_with_warning() {
+    let (blocks, warnings) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![ContentPart::tool_result("call_1", json!({ "ok": true }))],
+        )],
+        vec![],
+    );
+
+    assert!(blocks.is_empty(), "expected no blocks, got {blocks:?}");
+    assert!(
+        warnings.iter().any(|w| w.contains("is not supported")),
+        "expected a warning, got {warnings:?}"
+    );
+}
+
+/// A `code_execution` result whose payload has no recognisable `type` is also
+/// dropped (upstream pushes the "not a valid code execution result" warning).
+#[test]
+fn invalid_code_execution_payload_is_dropped_with_warning() {
+    let (blocks, warnings) = convert(
+        vec![msg(
+            Role::Assistant,
+            vec![tool_result(
+                "srvtoolu_1",
+                "code_execution",
+                json!({ "stdout": "no type field" }),
+            )],
+        )],
+        vec![provider_tool(
+            "anthropic.code_execution_20250522",
+            "code_execution",
+        )],
+    );
+
+    assert!(blocks.is_empty(), "expected no blocks, got {blocks:?}");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("not a valid code execution result")),
+        "expected a code-execution warning, got {warnings:?}"
+    );
+}
+
+// ── regression: user/tool-role results keep the bare `tool_result` ──────────
+
+#[test]
+fn user_role_tool_result_still_emits_bare_tool_result() {
+    let mut options = CallOptions::new(vec![msg(
+        Role::User,
+        vec![tool_result("call_1", "get_weather", json!("sunny"))],
+    )]);
+    options.tools = Some(vec![provider_tool(
+        "anthropic.web_search_20250305",
+        "web_search",
+    )]);
+    let req = build_request_body_with_warnings("claude-sonnet-4-5", &options, false).unwrap();
+
+    assert_eq!(
+        req.body["messages"],
+        json!([{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "call_1",
+                "content": "sunny",
+            }],
+        }])
+    );
+}
+
+#[test]
+fn tool_role_tool_result_still_emits_bare_tool_result() {
+    let options = CallOptions::new(vec![msg(
+        Role::Tool,
+        vec![tool_result(
+            "call_1",
+            "web_search",
+            json!([{ "url": "https://example.com" }]),
+        )],
+    )]);
+    let req = build_request_body_with_warnings("claude-sonnet-4-5", &options, false).unwrap();
+
+    assert_eq!(req.body["messages"][0]["role"], "user");
+    assert_eq!(
+        req.body["messages"][0]["content"][0]["type"], "tool_result",
+        "tool-role results must keep the bare block: {}",
+        req.body["messages"][0]
+    );
+}
+
+// ── round-trip: response block → ToolResult → the same wire block ───────────
+
+/// The response side (`parse_anthropic_content`) camel-cases the payload; the
+/// prompt side has to snake-case it back. Feeding a parsed `ToolResult`
+/// straight back into the converter must reproduce the original wire block.
+#[tokio::test]
+async fn web_search_result_round_trips_through_a_generate_call() {
+    let wire_block = json!({
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_rt",
+        "content": [{
+            "url": "https://example.com",
+            "title": "Example",
+            "page_age": "3 days",
+            "encrypted_content": "enc-1",
+            "type": "web_search_result",
+        }],
+    });
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msg_rt",
+            "type": "message",
+            "role": "assistant",
+            "content": [wire_block],
+            "model": "claude-sonnet-4-5",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": { "input_tokens": 1, "output_tokens": 1 },
+        })))
+        .mount(&server)
+        .await;
+
+    let mut options = CallOptions::new(vec![msg(Role::User, vec![ContentPart::text("Hello")])]);
+    options.tools = Some(vec![provider_tool(
+        "anthropic.web_search_20250305",
+        "mySearch",
+    )]);
+    let model = AnthropicModel::new(
+        "claude-sonnet-4-5".to_string(),
+        AnthropicConfig::new("test-api-key").with_base_url(server.uri()),
+    );
+    let result = model.do_generate(&options).await.unwrap();
+
+    // Replay the parsed tool result on an assistant message.
+    let replayed: Vec<ContentPart> = result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::ToolResult {
+                tool_call_id,
+                tool_name,
+                result,
+                ..
+            } => Some(tool_result(tool_call_id, tool_name, result.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(replayed.len(), 1, "expected one parsed tool result");
+
+    let (blocks, warnings) = convert(
+        vec![msg(Role::Assistant, replayed)],
+        vec![provider_tool("anthropic.web_search_20250305", "mySearch")],
+    );
+
+    assert_eq!(blocks, vec![wire_block]);
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}

--- a/aimux-providers/tests/anthropic_provider_tools_test.rs
+++ b/aimux-providers/tests/anthropic_provider_tools_test.rs
@@ -27,9 +27,9 @@
 //!    `tools: [{ type: 'provider', id: 'anthropic.web_search_20250305', ... }]`.
 //!    Until `CallOptions.tools` is extended to support provider tools (or a
 //!    separate field is added), these tests cannot be run.
-//! 2. **`GenerateContent` lacks server-tool variants** �?response parsing for
-//!    `server_tool_use`, `web_search_tool_result`, `code_execution_tool_result`,
-//!    `advisor_tool_result`, etc. requires new `GenerateContent` variants.
+//! 2. ~~**`GenerateContent` lacks server-tool variants**~~ �?resolved. The
+//!    result blocks are surfaced as `GenerateContent::ToolResult`, and
+//!    `web_search` hits additionally become `Source` items.
 //! 3. **`build_request_body` doesn't read `providerOptions.anthropic.mcpServers`
 //!    / `container` / `thinking`** �?tests that pass these through
 //!    `CallOptions.provider_options` compile and run but will fail on
@@ -610,13 +610,34 @@ mod web_search_tool {
             "web_search",
             json!({ "maxUses": 1 }),
         )]);
-        let _result = model.do_generate(&options).await.unwrap();
+        let result = model.do_generate(&options).await.unwrap();
 
         // TS expects content to contain:
         // 1. tool-result (isError: true, errorCode: 'max_uses_exceeded')
         // 2. text
-        // The error result block is decoded but not yet surfaced as a
-        // GenerateContent variant; the turn still parses successfully.
+        let tool_result = result
+            .content
+            .iter()
+            .find_map(|c| match c {
+                GenerateContent::ToolResult {
+                    result, is_error, ..
+                } => Some((result, is_error)),
+                _ => None,
+            })
+            .expect("the error result block must be surfaced");
+        assert_eq!(*tool_result.1, Some(true));
+        assert_eq!(
+            tool_result.0["errorCode"],
+            json!("max_uses_exceeded"),
+            "`error_code` is re-keyed to `errorCode`"
+        );
+        assert!(
+            result
+                .content
+                .iter()
+                .any(|c| matches!(c, GenerateContent::Text { .. })),
+            "the trailing text must still be surfaced"
+        );
     }
 
     /// TS: "should work alongside regular client-side tools" (L3695)

--- a/aimux-providers/tests/bedrock_reasoning_test.rs
+++ b/aimux-providers/tests/bedrock_reasoning_test.rs
@@ -195,7 +195,7 @@ fn reasoning_signatures(parts: &[StreamPart]) -> Vec<String> {
                 .get("amazonBedrock")
                 .and_then(|b| b.get("signature"))
                 .and_then(|s| s.as_str())
-                .map(|s| s.to_string()),
+                .map(std::string::ToString::to_string),
             _ => None,
         })
         .collect()

--- a/aimux-providers/tests/bedrock_reasoning_test.rs
+++ b/aimux-providers/tests/bedrock_reasoning_test.rs
@@ -16,23 +16,6 @@
 //! - `convert-to-amazon-bedrock-chat-messages.test.ts` — the reasoning
 //!   `it(...)` cases (prompt-side replay of signed/unsigned reasoning).
 //!
-//! ## TDD status
-//!
-//! Bedrock reasoning is not yet implemented on the Rust side:
-//! - **Request-side enabling** — `build_request_body` does not translate
-//!   `providerOptions.bedrock.reasoningConfig` into
-//!   `additionalModelRequestFields.thinking` (nor bump `inferenceConfig.maxTokens`
-//!   by `budgetTokens`). The request-body tests below are therefore expected to
-//!   **fail (red)** until that lands.
-//! - **Response-side extraction** — `extract_content` (non-streaming) and the
-//!   `do_stream` event loop ignore `reasoningContent` blocks, so no
-//!   `GenerateContent::Reasoning` / `StreamPart::Reasoning*` is ever emitted.
-//!   Those tests are also expected to **fail (red)**.
-//! - **Prompt-side replay** (`convert_prompt_to_bedrock`) — already implemented
-//!   for *signed* reasoning (it emits `reasoningContent.reasoningText`). Those
-//!   convert tests pass today (green). Unsigned reasoning is omitted, matching
-//!   the TS behaviour.
-//!
 //! Tests that require a data model the Rust crate does not expose are marked
 //! `#[ignore]` with an inline reason:
 //! - **Redacted reasoning replay** — `ContentPart::Reasoning` has no
@@ -41,13 +24,6 @@
 //! - **Foreign-provider reasoning replay** — `ContentPart::Reasoning.signature`
 //!   is provider-agnostic; the converter cannot distinguish an `anthropic`
 //!   signature (which must be dropped) from a `bedrock` one (which is kept).
-//!
-//! Another data-model gap: `StreamPart::ReasoningDelta { id, delta,
-//! provider_metadata }` carries no
-//! `provider_metadata`, so the thinking-block `signature` that the TS stream
-//! attaches to the final (empty) reasoning delta cannot be asserted here. The
-//! streaming tests assert the reasoning *text* deltas and the start/end markers
-//! instead; a comment marks the dropped signature assertion.
 
 use std::collections::HashMap;
 
@@ -190,6 +166,36 @@ fn reasoning_deltas(parts: &[StreamPart]) -> Vec<String> {
         .iter()
         .filter_map(|p| match p {
             StreamPart::ReasoningDelta { delta, .. } => Some(delta.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Reasoning deltas that carry actual text, i.e. excluding the zero-length
+/// deltas that only transport a `signature` / `redactedData` in
+/// `provider_metadata` (upstream emits those with `delta: ''`).
+fn reasoning_text_deltas(parts: &[StreamPart]) -> Vec<String> {
+    reasoning_deltas(parts)
+        .into_iter()
+        .filter(|d| !d.is_empty())
+        .collect()
+}
+
+/// The `signature` values carried on reasoning-block ends, in emission order.
+/// The signature arrives on a trailing text-less delta and is attached to the
+/// concluding `ReasoningEnd`.
+fn reasoning_signatures(parts: &[StreamPart]) -> Vec<String> {
+    parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::ReasoningEnd {
+                provider_metadata: Some(pm),
+                ..
+            } => pm
+                .get("amazonBedrock")
+                .and_then(|b| b.get("signature"))
+                .and_then(|s| s.as_str())
+                .map(|s| s.to_string()),
             _ => None,
         })
         .collect()
@@ -631,9 +637,8 @@ async fn bedrock_stream_reasoning_and_text() {
             "contentBlockDelta",
             json!({ "contentBlockIndex": 0, "delta": { "reasoningContent": { "text": "" } } }),
         ),
-        // Signature-only delta — TS emits a reasoning-delta with delta="" and
-        // providerMetadata.signature. `StreamPart::ReasoningDelta` has no
-        // provider_metadata field, so the signature cannot be asserted here.
+        // Signature-only delta — emitted as a reasoning-delta with delta=""
+        // carrying providerMetadata.signature, matching TS.
         (
             "event",
             "contentBlockDelta",
@@ -717,7 +722,7 @@ async fn bedrock_stream_reasoning_and_text() {
     // Reasoning block (id "0"): start, non-empty text deltas, end.
     assert!(has_reasoning_start(&parts), "expected a ReasoningStart");
     assert_eq!(
-        reasoning_deltas(&parts),
+        reasoning_text_deltas(&parts),
         vec![
             "Let me count the r",
             "'s in \"",
@@ -796,8 +801,8 @@ async fn bedrock_stream_reasoning_text_deltas() {
             "contentBlockDelta",
             json!({ "contentBlockIndex": 0, "delta": { "reasoningContent": { "text": " about this problem..." } } }),
         ),
-        // Signature-only delta — TS emits a reasoning-delta with delta="" and
-        // providerMetadata.signature. Not representable on the Rust delta part.
+        // Signature-only delta — emitted as a reasoning-delta with delta=""
+        // carrying providerMetadata.signature, matching TS.
         (
             "event",
             "contentBlockDelta",
@@ -825,12 +830,15 @@ async fn bedrock_stream_reasoning_text_deltas() {
 
     assert!(has_reasoning_start(&parts), "expected a ReasoningStart");
     assert_eq!(
-        reasoning_deltas(&parts),
+        reasoning_text_deltas(&parts),
         vec!["I am thinking", " about this problem..."]
     );
+    assert_eq!(
+        reasoning_signatures(&parts),
+        vec!["abc123signature"],
+        "the thinking-block signature must reach the caller"
+    );
     assert!(has_reasoning_end(&parts), "expected a ReasoningEnd");
-    // NOTE: signature "abc123signature" on the final empty reasoning delta is
-    // not assertable (StreamPart::ReasoningDelta has no provider_metadata).
 
     assert_eq!(
         text_deltas(&parts),

--- a/aimux-providers/tests/data_loss_regression_test.rs
+++ b/aimux-providers/tests/data_loss_regression_test.rs
@@ -1,0 +1,1598 @@
+//! Precise-assertion regression tests for the `fix/stop-dropping-response-data`
+//! branch (PR1 findings 1–35: "provider returned data, aimux silently dropped it").
+//!
+//! # Why this file exists
+//!
+//! The pre-existing cassette replay suite (`cassette_full_test.rs` &c.) only
+//! asserts weak conditions such as "text is non-empty". Every one of the 35
+//! data-loss bugs survived that suite unchanged, because dropping a field never
+//! makes the text empty. These tests therefore assert **exact values** taken
+//! from the real recorded cassettes: a URL, a base64 prefix, a signature, a
+//! `retrievedAt` timestamp. If a field is dropped again, the equality fails.
+//!
+//! # Conventions
+//!
+//! - Every test is named `finding_N_...` so it maps back to
+//!   `reference/PR1-FINDINGS.md`.
+//! - Response bodies come from the checked-in cassettes under
+//!   `tests/cassettes/<provider>/`; no new fixtures are invented. The cassette
+//!   is loaded from disk, mounted verbatim on a `wiremock` server, and the
+//!   provider is pointed at that server.
+//! - Assertions compare against literals copied out of the cassette, not
+//!   against re-reads of the cassette (a re-read would pass even if both the
+//!   producer and the assertion regressed together).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use futures::StreamExt;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path as path_matcher, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aimux_core::content::ContentPart;
+use aimux_core::language_model::LanguageModel;
+use aimux_core::language_model_message::{LanguageModelPrompt, LanguageModelPromptMessage};
+use aimux_core::message::Role;
+use aimux_core::options::CallOptions;
+use aimux_core::result::{GenerateContent, StreamResult};
+use aimux_core::shared::{FileBytes, FileData};
+use aimux_core::stream_part::StreamPart;
+use aimux_core::tool::{ProviderTool, Tool};
+
+use aimux_providers::anthropic::AnthropicConfig;
+use aimux_providers::anthropic::model::AnthropicModel;
+use aimux_providers::bedrock::{BedrockAuth, BedrockConfig, BedrockModel, event_stream};
+use aimux_providers::{
+    CohereConfig, CohereProvider, GoogleConfig, GoogleProvider, MistralConfig, MistralProvider,
+    OpenAIConfig, OpenAIProvider,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cassette loading
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A cassette's recorded exchange, reduced to what a mock needs.
+struct Cassette {
+    /// `request.path`, percent-decoded (Bedrock records `%3A` for `:`).
+    request_path: String,
+    status: u16,
+    /// `response.body` verbatim (a raw JSON / SSE string).
+    body: String,
+}
+
+/// Load one cassette by `<provider>/<file>.json` relative to `tests/cassettes`.
+///
+/// Panics loudly on any problem — a missing or malformed fixture is a broken
+/// test, not a runtime condition.
+fn cassette(rel: &str) -> Cassette {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/cassettes");
+    p.push(rel);
+    let text = fs::read_to_string(&p)
+        .unwrap_or_else(|e| panic!("cannot read cassette {}: {e}", p.display()));
+    let v: Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("invalid JSON in cassette {}: {e}", p.display()));
+
+    let request_path = v["request"]["path"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{rel}: missing request.path"))
+        .replace("%3A", ":");
+    let status = v["response"]["status"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("{rel}: missing response.status")) as u16;
+    let body = v["response"]["body"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{rel}: response.body must be a raw string"))
+        .to_string();
+
+    Cassette {
+        request_path,
+        status,
+        body,
+    }
+}
+
+/// Mount a cassette's response on `server` at its recorded path.
+async fn mount(server: &MockServer, c: &Cassette) {
+    Mock::given(method("POST"))
+        .and(path_matcher(c.request_path.clone()))
+        .respond_with(
+            ResponseTemplate::new(c.status)
+                .insert_header("content-type", "application/json")
+                .set_body_string(c.body.clone()),
+        )
+        .mount(server)
+        .await;
+}
+
+/// The parsed JSON of a cassette's response body (used to lift real payloads
+/// into synthetic streaming frames — the *values* still come from the wire).
+fn cassette_json(rel: &str) -> Value {
+    serde_json::from_str(&cassette(rel).body)
+        .unwrap_or_else(|e| panic!("{rel}: response.body is not JSON: {e}"))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Shared helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn user_prompt(text: &str) -> LanguageModelPrompt {
+    vec![LanguageModelPromptMessage {
+        role: Role::User,
+        content: vec![ContentPart::text(text)],
+        ..Default::default()
+    }]
+}
+
+fn opts() -> CallOptions {
+    CallOptions::new(user_prompt("Hello"))
+}
+
+fn opts_with_tools(tools: Vec<Tool>) -> CallOptions {
+    let mut o = opts();
+    o.tools = Some(tools);
+    o
+}
+
+fn provider_tool(id: &str, name: &str) -> Tool {
+    Tool::Provider(ProviderTool {
+        id: id.to_string(),
+        name: name.to_string(),
+        args: json!({}),
+    })
+}
+
+async fn collect(result: StreamResult) -> Vec<StreamPart> {
+    let mut parts = Vec::new();
+    let mut stream = result.stream;
+    while let Some(p) = stream.next().await {
+        parts.push(p.expect("stream part must be Ok"));
+    }
+    parts
+}
+
+/// The base64 payload of a `GenerateContent::File`, or panic.
+fn file_base64(c: &GenerateContent) -> &str {
+    match c {
+        GenerateContent::File {
+            data: FileData::Data {
+                data: FileBytes::Base64(s),
+            },
+            ..
+        } => s,
+        other => panic!("expected File with base64 data, got {other:?}"),
+    }
+}
+
+fn files(content: &[GenerateContent]) -> Vec<&GenerateContent> {
+    content
+        .iter()
+        .filter(|c| matches!(c, GenerateContent::File { .. }))
+        .collect()
+}
+
+fn texts(content: &[GenerateContent]) -> Vec<&str> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn reasonings(content: &[GenerateContent]) -> Vec<(&str, Option<&Value>)> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::Reasoning {
+                text,
+                provider_metadata,
+            } => Some((text.as_str(), provider_metadata.as_ref())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `(tool_call_id, tool_name, input, provider_executed, dynamic, thought_signature, metadata)`
+type ToolCallView<'a> = (
+    &'a str,
+    &'a str,
+    &'a Value,
+    Option<bool>,
+    Option<bool>,
+    Option<&'a str>,
+    Option<&'a Value>,
+);
+
+fn tool_calls(content: &[GenerateContent]) -> Vec<ToolCallView<'_>> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::ToolCall {
+                tool_call_id,
+                tool_name,
+                input,
+                provider_executed,
+                dynamic,
+                thought_signature,
+                provider_metadata,
+            } => Some((
+                tool_call_id.as_str(),
+                tool_name.as_str(),
+                input,
+                *provider_executed,
+                *dynamic,
+                thought_signature.as_deref(),
+                provider_metadata.as_ref(),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `(tool_call_id, tool_name, result, is_error, dynamic, metadata)`
+type ToolResultView<'a> = (
+    &'a str,
+    &'a str,
+    &'a Value,
+    Option<bool>,
+    Option<bool>,
+    Option<&'a Value>,
+);
+
+fn tool_results(content: &[GenerateContent]) -> Vec<ToolResultView<'_>> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::ToolResult {
+                tool_call_id,
+                tool_name,
+                result,
+                is_error,
+                dynamic,
+                provider_metadata,
+                ..
+            } => Some((
+                tool_call_id.as_str(),
+                tool_name.as_str(),
+                result,
+                *is_error,
+                *dynamic,
+                provider_metadata.as_ref(),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `(id, source_type, url, title, metadata)`
+type SourceView<'a> = (
+    &'a str,
+    &'a str,
+    Option<&'a str>,
+    Option<&'a str>,
+    Option<&'a Value>,
+);
+
+fn sources(content: &[GenerateContent]) -> Vec<SourceView<'_>> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::Source {
+                id,
+                source_type,
+                url,
+                title,
+                provider_metadata,
+            } => Some((
+                id.as_str(),
+                source_type.as_str(),
+                url.as_deref(),
+                title.as_deref(),
+                provider_metadata.as_ref(),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 1 — Gemini `inlineData` never read (generate + stream)
+//
+// Cassettes: gemini/nano_banana_image_generation_smoke.json,
+//            gemini/test_google_image_and_text_output.json
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// PNG magic bytes, base64-encoded: every image in the two Gemini image
+/// cassettes starts with this. Asserting the prefix (rather than "non-empty")
+/// proves the *actual* bytes survived rather than some placeholder.
+const PNG_BASE64_PREFIX: &str = "iVBORw0KGgoAAAANSUhEUgAA";
+
+/// The exact base64 length recorded in `nano_banana_image_generation_smoke`.
+const NANO_BANANA_BASE64_LEN: usize = 258_820;
+
+fn google_at(uri: &str) -> GoogleProvider {
+    GoogleProvider::new(GoogleConfig::new("test-api-key").with_base_url(format!("{uri}/v1beta")))
+}
+
+#[tokio::test]
+async fn finding_1_gemini_inline_data_surfaces_as_file() {
+    let c = cassette("gemini/nano_banana_image_generation_smoke.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = google_at(&server.uri())
+        .model("gemini-2.5-flash-image")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let f = files(&result.content);
+    assert_eq!(f.len(), 1, "exactly one inlineData part → one File");
+    match f[0] {
+        GenerateContent::File { media_type, .. } => {
+            assert_eq!(media_type, "image/png");
+        }
+        other => panic!("expected File, got {other:?}"),
+    }
+    let b64 = file_base64(f[0]);
+    assert!(
+        b64.starts_with(PNG_BASE64_PREFIX),
+        "image bytes must be the recorded PNG, got prefix {:?}",
+        &b64[..b64.len().min(32)]
+    );
+    assert_eq!(
+        b64.len(),
+        NANO_BANANA_BASE64_LEN,
+        "the whole base64 payload must survive, not a truncated head"
+    );
+}
+
+#[tokio::test]
+async fn finding_1_gemini_image_and_text_output_both_survive() {
+    let c = cassette("gemini/test_google_image_and_text_output.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = google_at(&server.uri())
+        .model("gemini-2.5-flash-image")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    // Text part first, then the inlineData part — order matters, upstream
+    // walks `parts` in order.
+    assert_eq!(result.content.len(), 2, "one text + one file");
+    assert!(
+        matches!(result.content[0], GenerateContent::Text { .. }),
+        "text part comes first"
+    );
+    assert!(
+        matches!(result.content[1], GenerateContent::File { .. }),
+        "inlineData part comes second"
+    );
+
+    let t = texts(&result.content);
+    assert_eq!(t.len(), 1);
+    assert!(
+        t[0].starts_with("Once, in a hidden cenote, lived an axolotl named Pip"),
+        "recorded story text must survive verbatim, got {:?}",
+        &t[0][..t[0].len().min(60)]
+    );
+
+    let f = files(&result.content);
+    assert_eq!(f.len(), 1);
+    match f[0] {
+        GenerateContent::File { media_type, .. } => assert_eq!(media_type, "image/png"),
+        other => panic!("expected File, got {other:?}"),
+    }
+    let b64 = file_base64(f[0]);
+    assert!(b64.starts_with(PNG_BASE64_PREFIX));
+    assert_eq!(b64.len(), 2_580_504);
+}
+
+/// The streaming path had the same hole. The chunk is built from the cassette's
+/// own `parts` array so the bytes are the recorded ones.
+#[tokio::test]
+async fn finding_1_gemini_inline_data_streams_as_file_part() {
+    let body = cassette_json("gemini/nano_banana_image_generation_smoke.json");
+    let candidate = &body["candidates"][0];
+    let sse = format!(
+        "data: {}\n\n",
+        json!({ "candidates": [{ "content": candidate["content"].clone(), "finishReason": "STOP" }] })
+    );
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path_matcher(
+            "/v1beta/models/gemini-2.5-flash-image:streamGenerateContent",
+        ))
+        .and(query_param("alt", "sse"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse),
+        )
+        .mount(&server)
+        .await;
+
+    let parts = collect(
+        google_at(&server.uri())
+            .model("gemini-2.5-flash-image")
+            .do_stream(&opts())
+            .await
+            .expect("do_stream should succeed"),
+    )
+    .await;
+
+    let file_parts: Vec<_> = parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::File {
+                data:
+                    FileData::Data {
+                        data: FileBytes::Base64(b64),
+                    },
+                media_type,
+                ..
+            } => Some((b64.as_str(), media_type.as_str())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(file_parts.len(), 1, "expected one StreamPart::File");
+    assert_eq!(file_parts[0].1, "image/png");
+    assert!(file_parts[0].0.starts_with(PNG_BASE64_PREFIX));
+    assert_eq!(file_parts[0].0.len(), NANO_BANANA_BASE64_LEN);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 3 — Gemini `part.thought` never read (thinking merged into the answer)
+// Finding 5 — Gemini `thoughtSignature` dropped
+//
+// Cassette: gemini/test_google_model_thinking_part.json
+//   parts[0] = { text: "**A Safe Street-Crossing Guide…", thought: true }
+//   parts[1] = { text: "Crossing the street safely…", thoughtSignature: "Eqoe…" }
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// First 16 chars of the real `thoughtSignature` on parts[1].
+const GEMINI_THOUGHT_SIG_PREFIX: &str = "EqoeCqceAdHtim+c";
+const GEMINI_THOUGHT_SIG_LEN: usize = 5180;
+
+#[tokio::test]
+async fn finding_3_gemini_thought_part_becomes_reasoning_not_text() {
+    let c = cassette("gemini/test_google_model_thinking_part.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = google_at(&server.uri())
+        .model("gemini-3-pro-preview")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let r = reasonings(&result.content);
+    assert_eq!(r.len(), 1, "the `thought: true` part is the only reasoning");
+    assert!(
+        r[0].0
+            .starts_with("**A Safe Street-Crossing Guide: My Thought Process**"),
+        "reasoning must be the thought part verbatim, got {:?}",
+        &r[0].0[..r[0].0.len().min(60)]
+    );
+    assert_eq!(
+        r[0].0.chars().count(),
+        2238,
+        "the full thought text, not a fragment"
+    );
+
+    let t = texts(&result.content);
+    assert_eq!(t.len(), 1, "only the non-thought part is answer text");
+    assert!(
+        t[0].starts_with("Crossing the street safely is a fundamental skill"),
+        "answer text must be the non-thought part"
+    );
+    // The regression this guards: the thought text used to be concatenated
+    // into the answer.
+    assert!(
+        !t[0].contains("My Thought Process"),
+        "the thinking must NOT leak into the answer text"
+    );
+    assert_eq!(t[0].chars().count(), 3017);
+}
+
+#[tokio::test]
+async fn finding_5_gemini_thought_signature_reaches_provider_metadata() {
+    let c = cassette("gemini/test_google_model_thinking_part.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = google_at(&server.uri())
+        .model("gemini-3-pro-preview")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    // The signature rides on the *text* part in this cassette.
+    let sig = result
+        .content
+        .iter()
+        .find_map(|c| match c {
+            GenerateContent::Text {
+                provider_metadata: Some(m),
+                ..
+            } => m["google"]["thoughtSignature"].as_str(),
+            _ => None,
+        })
+        .expect("text part must carry providerMetadata.google.thoughtSignature");
+    assert!(
+        sig.starts_with(GEMINI_THOUGHT_SIG_PREFIX),
+        "thoughtSignature must be the recorded one, got {:?}",
+        &sig[..sig.len().min(24)]
+    );
+    assert_eq!(
+        sig.len(),
+        GEMINI_THOUGHT_SIG_LEN,
+        "the signature must be echoed back byte-for-byte (truncation breaks the next turn)"
+    );
+}
+
+/// `thoughtSignature` on a `functionCall` part must reach
+/// `ToolCall.thought_signature` — that is the field the follow-up turn echoes.
+#[tokio::test]
+async fn finding_5_gemini_function_call_thought_signature_round_trips() {
+    let c = cassette("gemini/two_arg_rewrites_chain_blocking_0.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = google_at(&server.uri())
+        .model("gemini-2.5-flash")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let calls = tool_calls(&result.content);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].1, "add");
+    assert_eq!(calls[0].2, &json!({ "x": 1, "y": 1 }));
+    assert_eq!(
+        calls[0].5,
+        Some("signature_REDACTED_1"),
+        "the functionCall thoughtSignature must land on ToolCall.thought_signature"
+    );
+    assert_eq!(
+        calls[0].6.expect("providerMetadata")["google"]["thoughtSignature"],
+        json!("signature_REDACTED_1")
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 12 — Gemini `codeExecutionResult` dropped; tool_call_id was empty
+//
+// Cassette: gemini/test_code_execution.json
+//   codeExecutionResult = { id: "h0mwtrhs", outcome: "OUTCOME_OK",
+//                           output: "Current day in Utrecht: Tuesday, May 05, 2026\n" }
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn finding_12_gemini_code_execution_result_surfaced_with_matching_call_id() {
+    let c = cassette("gemini/test_code_execution.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = google_at(&server.uri())
+        .model("gemini-3-flash-preview")
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "google.code_execution",
+            "code_execution",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let calls = tool_calls(&result.content);
+    let results = tool_results(&result.content);
+    assert_eq!(calls.len(), 2, "two executableCode parts");
+    assert_eq!(results.len(), 2, "two codeExecutionResult parts");
+
+    // Exact values from the cassette's first result.
+    assert_eq!(results[0].1, "code_execution");
+    assert_eq!(
+        results[0].2,
+        &json!({
+            "outcome": "OUTCOME_OK",
+            "output": "Current day in Utrecht: Tuesday, May 05, 2026\n"
+        }),
+        "the recorded outcome AND output must both survive"
+    );
+    assert_eq!(
+        results[1].2,
+        &json!({ "outcome": "OUTCOME_OK", "output": "2026-05-05 20:40:33.367937\n" })
+    );
+
+    // The regression: `tool_call_id` used to be the empty string, so a client
+    // could not pair the result with its call.
+    assert!(
+        !results[0].0.is_empty(),
+        "ToolResult.tool_call_id must not be empty"
+    );
+    assert_eq!(
+        results[0].0, calls[0].0,
+        "result must carry the id of the executableCode call it answers"
+    );
+    assert_eq!(results[1].0, calls[1].0);
+    assert_ne!(
+        calls[0].0, calls[1].0,
+        "the two code-execution calls need distinct ids"
+    );
+
+    // The executableCode payload itself is preserved on the call.
+    assert_eq!(calls[0].2["language"], json!("PYTHON"));
+    assert_eq!(calls[0].2["id"], json!("h0mwtrhs"));
+    assert!(
+        calls[0].2["code"]
+            .as_str()
+            .expect("code")
+            .contains("Europe/Amsterdam"),
+        "the executed source must survive verbatim"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 14 — grounding sources never extracted
+//
+// Cassette: gemini/test_google_model_web_search_tool.json
+//   groundingMetadata.groundingChunks[].web.{title,uri}
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn finding_14_gemini_grounding_chunks_become_sources() {
+    let c = cassette("gemini/test_google_model_web_search_tool.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = google_at(&server.uri())
+        .model("gemini-2.5-pro")
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "google.google_search",
+            "google_search",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let s = sources(&result.content);
+    assert_eq!(s.len(), 3, "three groundingChunks → three sources");
+
+    // Exact url + title of the first chunk.
+    assert_eq!(s[0].1, "url");
+    assert_eq!(
+        s[0].2,
+        Some("https://www.google.com/search?q=weather+in+San Francisco, CA,+US")
+    );
+    assert_eq!(
+        s[0].3,
+        Some("Weather information for San Francisco, CA, US")
+    );
+
+    assert_eq!(s[1].3, Some("weather.gov"));
+    assert!(
+        s[1].2
+            .expect("url")
+            .starts_with("https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQF_uqo2G5Goeww8iF1L"),
+        "the redirect URL must survive intact, got {:?}",
+        s[1].2
+    );
+    assert_eq!(s[2].3, Some("wunderground.com"));
+
+    // Source ids must be distinct, otherwise callers cannot key on them.
+    assert_ne!(s[0].0, s[1].0);
+    assert_ne!(s[1].0, s[2].0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 2 — Anthropic `_ => {}` swallowed every server-tool result block
+//
+// Cassettes under tests/cassettes/anthropic/. `parse_anthropic_content` now
+// maps each block to a `GenerateContent::ToolResult` whose payload is
+// camel-cased to match the upstream contract.
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn anthropic_at(uri: &str) -> AnthropicModel {
+    AnthropicModel::new(
+        "claude-sonnet-4-0".to_string(),
+        AnthropicConfig::new("test-api-key").with_base_url(uri.to_string()),
+    )
+}
+
+#[tokio::test]
+async fn finding_2_anthropic_web_search_result_mapped_and_sources_emitted() {
+    let c = cassette("anthropic/test_pause_turn_web_search_vcr_1.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "anthropic.web_search_20250305",
+            "web_search",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let results = tool_results(&result.content);
+    let first = results
+        .iter()
+        .find(|(id, ..)| *id == "srvtoolu_01RGq5wiPsxhz5Wk3Nj1w2JU")
+        .expect("the first web_search_tool_result block must surface");
+    assert_eq!(first.1, "web_search");
+    let arr = first.2.as_array().expect("success payload is an array");
+    assert_eq!(arr.len(), 10, "all ten recorded results, not just the head");
+
+    // Exact fields of the first recorded search hit, in the camelCase shape.
+    assert_eq!(
+        arr[0]["url"],
+        json!("https://www.iqair.com/us/usa/california/san-francisco")
+    );
+    assert_eq!(
+        arr[0]["title"],
+        json!("San Francisco Air Quality Index (AQI) and USA Air Pollution | IQAir")
+    );
+    assert_eq!(arr[0]["type"], json!("web_search_result"));
+    assert_eq!(
+        arr[0]["pageAge"],
+        json!(null),
+        "`page_age` is re-keyed to `pageAge` (null here, but present)"
+    );
+    assert!(
+        arr[0]["encryptedContent"]
+            .as_str()
+            .expect("encryptedContent")
+            .starts_with("EqAHCioIDBgCIiQ5MGZjMWI5Mi1iYzIyLTQzNTMtYWExZi1i"),
+        "`encrypted_content` is re-keyed to `encryptedContent` and kept verbatim"
+    );
+
+    // The headline of the fix: each result also becomes a Source, which is the
+    // only way its URL reaches `result.sources`.
+    let s = sources(&result.content);
+    assert!(
+        s.iter().any(|(_, st, url, title, _)| {
+            *st == "url"
+                && *url == Some("https://www.iqair.com/us/usa/california/san-francisco")
+                && *title
+                    == Some("San Francisco Air Quality Index (AQI) and USA Air Pollution | IQAir")
+        }),
+        "the first hit must appear as a Source; got {:?}",
+        s.iter().map(|x| x.2).collect::<Vec<_>>()
+    );
+    assert!(
+        s.len() >= 10,
+        "every web_search_result becomes a Source, got {}",
+        s.len()
+    );
+    // Each Source carries `page_age` re-keyed to `pageAge`, and nothing else,
+    // under the anthropic key. The expected values are spelled out rather than
+    // read back out of `meta`: deriving them from the same object would make the
+    // assertion agree with whatever the code produced, including a renamed key.
+    // (`get("pageAge").is_some()` is no good either — a missing key and a
+    // recorded `null` both read back as `Some(Value::Null)`.)
+    let by_url: BTreeMap<&str, &Value> = s
+        .iter()
+        .filter_map(|(_, _, url, _, m)| Some(((*url)?, (*m)?)))
+        .collect();
+    for (url, expected_page_age) in [
+        (
+            "https://www.iqair.com/us/usa/california/san-francisco",
+            json!(null),
+        ),
+        (
+            "https://www.aqi.in/us/dashboard/united-states/california/san-francisco",
+            json!("3 weeks ago"),
+        ),
+    ] {
+        assert_eq!(
+            by_url.get(url).copied(),
+            Some(&json!({ "anthropic": { "pageAge": expected_page_age } })),
+            "source {url}: providerMetadata must hold exactly anthropic.pageAge"
+        );
+    }
+
+    // The server_tool_use call itself is surfaced so it round-trips.
+    let calls = tool_calls(&result.content);
+    assert!(
+        calls.iter().any(|(id, name, input, ..)| {
+            *id == "srvtoolu_01Co4g1amCdYwEhUNBpoQEgp"
+                && *name == "web_search"
+                && input["query"] == json!("latest news events San Francisco this week")
+        }),
+        "the server_tool_use block must surface as a ToolCall"
+    );
+}
+
+/// A renamed provider tool must be reported under the caller's name.
+#[tokio::test]
+async fn finding_2_anthropic_web_search_result_uses_the_callers_tool_name() {
+    let c = cassette("anthropic/test_pause_turn_web_search_vcr_1.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "anthropic.web_search_20250305",
+            "mySearch",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let results = tool_results(&result.content);
+    assert!(!results.is_empty());
+    assert!(
+        results.iter().all(|(_, name, ..)| *name == "mySearch"),
+        "wire name `web_search` must be mapped back to the caller's `mySearch`"
+    );
+}
+
+#[tokio::test]
+async fn finding_2_anthropic_web_fetch_result_mapped() {
+    let c = cassette("anthropic/test_anthropic_web_fetch_tool.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "anthropic.web_fetch_20250910",
+            "web_fetch",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let results = tool_results(&result.content);
+    assert_eq!(results.len(), 1, "one web_fetch_tool_result block");
+    let (id, name, payload, is_error, _, _) = results[0];
+    assert_eq!(id, "srvtoolu_01So85wNUocinTvFfgKCfQeb");
+    assert_eq!(name, "web_fetch");
+    assert_eq!(is_error, None);
+
+    assert_eq!(payload["type"], json!("web_fetch_result"));
+    assert_eq!(payload["url"], json!("https://ai.pydantic.dev"));
+    assert_eq!(
+        payload["retrievedAt"],
+        json!("2025-11-14T23:34:21.151000+00:00"),
+        "`retrieved_at` is re-keyed to `retrievedAt` with the recorded timestamp"
+    );
+    assert_eq!(payload["content"]["type"], json!("document"));
+    assert_eq!(payload["content"]["title"], json!("Pydantic AI"));
+    assert_eq!(payload["content"]["source"]["type"], json!("text"));
+    assert_eq!(
+        payload["content"]["source"]["mediaType"],
+        json!("text/plain"),
+        "`media_type` is re-keyed to `mediaType`"
+    );
+    assert!(
+        payload["content"]["source"]["data"]
+            .as_str()
+            .expect("fetched document body")
+            .starts_with("Pydantic AI\nGenAI Agent Framework, the Pydantic way"),
+        "the fetched page body must survive verbatim"
+    );
+
+    // The server_tool_use call that produced it.
+    let calls = tool_calls(&result.content);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "srvtoolu_01So85wNUocinTvFfgKCfQeb");
+    assert_eq!(calls[0].2, &json!({ "url": "https://ai.pydantic.dev" }));
+
+    // The thinking block on the same response keeps its signature.
+    let r = reasonings(&result.content);
+    assert_eq!(r.len(), 1);
+    assert!(
+        r[0].1.expect("thinking metadata")["anthropic"]["signature"]
+            .as_str()
+            .expect("signature")
+            .starts_with("EsIDCkYICRgCKkAKi/j4a8lGN12CjyS27ZXcPkXHGyTbn1vJENJz"),
+        "the thinking signature must survive for the next turn"
+    );
+}
+
+#[tokio::test]
+async fn finding_2_anthropic_bash_code_execution_result_passed_through() {
+    let c = cassette("anthropic/test_anthropic_code_execution_files_multi_turn_1.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "anthropic.code_execution_20250825",
+            "code_execution",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let results = tool_results(&result.content);
+    assert_eq!(results.len(), 1);
+    let (id, name, payload, ..) = results[0];
+    assert_eq!(id, "srvtoolu_01P9KoHAS2PSorMZSSjLfQ5N");
+    assert_eq!(name, "code_execution");
+    // `bash_code_execution_tool_result` is passed through unmapped upstream.
+    assert_eq!(payload["type"], json!("bash_code_execution_result"));
+    assert_eq!(
+        payload["stdout"],
+        json!("Sum of value column: 100.0\n"),
+        "the computed answer lives only in stdout"
+    );
+    assert_eq!(payload["stderr"], json!(""));
+    assert_eq!(payload["return_code"], json!(0));
+    assert_eq!(payload["content"], json!([]));
+
+    // The result must be paired with its call id.
+    let calls = tool_calls(&result.content);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, id, "call and result share the tool_use_id");
+    assert_eq!(calls[0].1, "bash_code_execution");
+}
+
+#[tokio::test]
+async fn finding_2_anthropic_tool_search_result_lists_tool_references() {
+    let c = cassette("anthropic/test_anthropic_native_tool_search.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    // Rename the bm25 tool so the mapping (and `tool_search_provider_name`)
+    // resolves to the bm25 variant rather than the regex default.
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "anthropic.tool_search_bm25_20251119",
+            "findTools",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let results = tool_results(&result.content);
+    assert_eq!(results.len(), 1);
+    let (id, name, payload, is_error, ..) = results[0];
+    assert_eq!(id, "srvtoolu_01AFqvRopGELemw8jFcntaRt");
+    assert_eq!(
+        name, "findTools",
+        "bm25 wire name maps back to the caller's tool name"
+    );
+    assert_eq!(is_error, None);
+
+    // Success collapses to the tool-reference array, camel-cased.
+    assert_eq!(
+        payload,
+        &json!([
+            { "type": "tool_reference", "toolName": "get_exchange_rate" },
+            { "type": "tool_reference", "toolName": "mortgage_calculator" },
+        ]),
+        "both discovered tools must survive, with `tool_name` → `toolName`"
+    );
+
+    // The client-executed tool_use that follows is untouched.
+    let calls = tool_calls(&result.content);
+    assert!(
+        calls.iter().any(|(id, name, input, ..)| {
+            *id == "toolu_01WYuJPXi77h8uRRgi6F7owo"
+                && *name == "get_exchange_rate"
+                && input["from_currency"] == json!("USD")
+                && input["to_currency"] == json!("EUR")
+        }),
+        "the follow-up tool_use must still surface"
+    );
+}
+
+#[tokio::test]
+async fn finding_2_anthropic_advisor_result_keeps_text_and_stop_reason() {
+    let c = cassette("anthropic/test_anthropic_advisor_tool.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts_with_tools(vec![provider_tool(
+            "anthropic.advisor_20260301",
+            "advisor",
+        )]))
+        .await
+        .expect("do_generate should succeed");
+
+    let results = tool_results(&result.content);
+    assert_eq!(results.len(), 1);
+    let (id, name, payload, is_error, ..) = results[0];
+    assert_eq!(id, "srvtoolu_01HjzmxWnLPCkNoLmrowWNBc");
+    assert_eq!(name, "advisor");
+    assert_eq!(is_error, None);
+    assert_eq!(
+        payload,
+        &json!({
+            "type": "advisor_result",
+            "text": "4.\n\n(You're right--it's trivial. Ship it.)",
+            "stopReason": "end_turn",
+        }),
+        "advisor text and `stop_reason` → `stopReason` must both survive"
+    );
+}
+
+#[tokio::test]
+async fn finding_2_anthropic_mcp_tool_use_and_result_are_dynamic_and_named() {
+    let c = cassette("anthropic/test_anthropic_mcp_servers.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    // mcp_tool_use → provider-executed + dynamic + serverName metadata.
+    let calls = tool_calls(&result.content);
+    assert_eq!(calls.len(), 1);
+    let (id, name, input, provider_executed, dynamic, _, meta) = calls[0];
+    assert_eq!(id, "mcptoolu_01SAss3KEwASziHZoMR6HcZU");
+    assert_eq!(name, "ask_question");
+    assert_eq!(input["repoName"], json!("pydantic/pydantic-ai"));
+    assert_eq!(provider_executed, Some(true));
+    assert_eq!(dynamic, Some(true));
+    assert_eq!(
+        meta.expect("mcp_tool_use metadata")["anthropic"],
+        json!({ "type": "mcp-tool-use", "serverName": "deepwiki" })
+    );
+
+    // mcp_tool_result inherits the name and server of the call it answers.
+    let results = tool_results(&result.content);
+    assert_eq!(results.len(), 1);
+    let (rid, rname, payload, is_error, rdynamic, rmeta) = results[0];
+    assert_eq!(rid, "mcptoolu_01SAss3KEwASziHZoMR6HcZU");
+    assert_eq!(
+        rname, "ask_question",
+        "the result inherits the mcp_tool_use name"
+    );
+    assert_eq!(is_error, Some(false), "`is_error: false` must be preserved");
+    assert_eq!(rdynamic, Some(true));
+    assert_eq!(
+        rmeta.expect("mcp_tool_result metadata")["anthropic"],
+        json!({ "type": "mcp-tool-use", "serverName": "deepwiki" })
+    );
+    assert!(
+        payload[0]["text"]
+            .as_str()
+            .expect("mcp payload text")
+            .starts_with("Pydantic AI is a Python agent framework designed to simplify"),
+        "the MCP answer body must survive verbatim"
+    );
+}
+
+#[tokio::test]
+async fn finding_2_anthropic_redacted_thinking_surfaced_as_reasoning() {
+    let c = cassette("anthropic/test_anthropic_model_thinking_part_redacted.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = anthropic_at(&server.uri())
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let r = reasonings(&result.content);
+    assert_eq!(r.len(), 1, "the redacted_thinking block must surface");
+    assert_eq!(r[0].0, "", "redacted thinking has no plaintext");
+    let data = r[0].1.expect("redacted metadata")["anthropic"]["redactedData"]
+        .as_str()
+        .expect("redactedData");
+    assert!(
+        data.starts_with("EvgFCkYIBxgCKkBmxKtCnM3xlr1zpw0Ik4FY0bnznKLdj7THnWO4shd9"),
+        "the opaque redacted payload must be preserved byte-for-byte"
+    );
+    assert_eq!(data.len(), 1020);
+
+    // The visible answer is unaffected.
+    let t = texts(&result.content);
+    assert_eq!(t.len(), 1);
+    assert!(t[0].starts_with("I notice that your message appears to contain a command"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 25 — Cohere per-citation metadata
+//
+// Cassette: cohere/test_tool_choice_matrix[auto-cohere]_1.json
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn finding_25_cohere_citation_metadata_preserved_field_by_field() {
+    let c = cassette("cohere/test_tool_choice_matrix[auto-cohere]_1.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let provider = CohereProvider::new(
+        CohereConfig::new("test-key").with_base_url(format!("{}/v2", server.uri())),
+    );
+    let result = provider
+        .model("command-r-plus")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let s = sources(&result.content);
+    assert_eq!(s.len(), 2, "two citations → two sources");
+
+    let expected_tool_source = json!([{
+        "id": "get_weather_9gpb31r7h7mj:0",
+        "type": "tool",
+        "tool_output": { "content": "Sunny, 22C in Paris" },
+    }]);
+
+    // Citation 0 — every field, not just "metadata is Some".
+    assert_eq!(s[0].1, "document");
+    let m0 = &s[0].4.expect("citation 0 metadata")["cohere"];
+    assert_eq!(m0["start"], json!(34));
+    assert_eq!(m0["end"], json!(39));
+    assert_eq!(m0["text"], json!("sunny"));
+    assert_eq!(m0["citationType"], json!("TEXT_CONTENT"));
+    assert_eq!(
+        m0["sources"], expected_tool_source,
+        "the citation's source array (including tool_output) must survive intact"
+    );
+
+    // Citation 1.
+    let m1 = &s[1].4.expect("citation 1 metadata")["cohere"];
+    assert_eq!(m1["start"], json!(44));
+    assert_eq!(m1["end"], json!(48));
+    assert_eq!(m1["text"], json!("22C."));
+    assert_eq!(m1["citationType"], json!("TEXT_CONTENT"));
+    assert_eq!(m1["sources"], expected_tool_source);
+
+    // The answer text the citations point into.
+    assert_eq!(
+        texts(&result.content),
+        vec!["The weather in Paris is currently sunny and 22C."]
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 13 — Mistral thinking parts dropped on the non-streaming path
+//
+// Cassette: mistral/test_reasoning_wire_contract[mistral-small-thinking-high].json
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn finding_13_mistral_thinking_parts_become_reasoning_in_generate() {
+    let c = cassette("mistral/test_reasoning_wire_contract[mistral-small-thinking-high].json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let provider = MistralProvider::new(
+        MistralConfig::new("test-key").with_base_url(format!("{}/v1", server.uri())),
+    );
+    let result = provider
+        .model("mistral-small-latest")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    // Reasoning was previously reachable only via the streaming path.
+    let r = reasonings(&result.content);
+    assert_eq!(r.len(), 1, "the `thinking` content part must surface");
+    assert_eq!(
+        r[0].0,
+        "The user is asking for the result of 2+2. The instruction is to reply \
+         with just the number, so I should respond with \"4\".",
+        "the thinking text must survive verbatim"
+    );
+
+    // The visible answer is the plain `text` part only.
+    assert_eq!(texts(&result.content), vec!["4"]);
+
+    // Ordering: reasoning precedes text (upstream contract).
+    assert!(matches!(
+        result.content[0],
+        GenerateContent::Reasoning { .. }
+    ));
+    assert!(matches!(result.content[1], GenerateContent::Text { .. }));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 4 / 19 — OpenAI Responses: reasoning `encrypted_content` + `itemId`
+// Finding 30    — url_citation annotations
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn openai_responses_at(uri: &str, model: &str) -> impl LanguageModel {
+    OpenAIProvider::new(OpenAIConfig::new("test-key").with_base_url(format!("{uri}/v1")))
+        .responses_model(model)
+}
+
+#[tokio::test]
+async fn finding_4_openai_responses_reasoning_carries_item_id_and_encrypted_content() {
+    let c = cassette("openai/test_openai_responses_model_web_search_tool_with_invalid_region.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = openai_responses_at(&server.uri(), "gpt-5")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let r = reasonings(&result.content);
+    assert_eq!(
+        r.len(),
+        2,
+        "the cassette has two `reasoning` output items (both summary-less)"
+    );
+
+    let m0 = r[0].1.expect("reasoning 0 metadata");
+    assert_eq!(
+        m0["openai"]["itemId"],
+        json!("rs_0b4f29854724a3120068c4ab0be6a08191b495f9009b885649"),
+        "itemId identifies the reasoning item on the follow-up turn"
+    );
+    let enc = m0["openai"]["reasoningEncryptedContent"]
+        .as_str()
+        .expect("reasoningEncryptedContent must be a string, not null");
+    assert!(
+        enc.starts_with("gAAAAABoxKsml4Y3hqqolEa8BSvPr6mIoOyAbWRJz9FeLHoqX03v4b6K"),
+        "the encrypted reasoning blob must be preserved verbatim"
+    );
+    assert_eq!(
+        enc.len(),
+        2508,
+        "truncating the blob would break reasoning continuity across turns"
+    );
+
+    // Both reasoning items are distinct; neither is a placeholder.
+    let m1 = r[1].1.expect("reasoning 1 metadata");
+    assert_ne!(m1["openai"]["itemId"], m0["openai"]["itemId"]);
+    assert!(m1["openai"]["reasoningEncryptedContent"].is_string());
+}
+
+#[tokio::test]
+async fn finding_30_openai_responses_url_citation_annotation_becomes_source() {
+    let c = cassette("openai/test_openai_include_raw_annotations_non_streaming.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = openai_responses_at(&server.uri(), "gpt-5.2")
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let s = sources(&result.content);
+    assert_eq!(s.len(), 1, "one url_citation annotation → one Source");
+    assert_eq!(s[0].1, "url");
+    assert_eq!(
+        s[0].2,
+        Some("https://www.britannica.com/place/Mount-Columbia?utm_source=openai"),
+        "the citation URL (query string included) must survive"
+    );
+    assert_eq!(
+        s[0].3,
+        Some("Mount Columbia | mountain, Alberta, Canada | Britannica")
+    );
+
+    // The cited text itself is still present.
+    let t = texts(&result.content);
+    assert_eq!(t.len(), 1);
+    assert!(t[0].starts_with("The tallest mountain in Alberta is **Mount Columbia**"));
+    // The message item id rides on the text part (finding 19).
+    let item_id = result
+        .content
+        .iter()
+        .find_map(|c| match c {
+            GenerateContent::Text {
+                provider_metadata: Some(m),
+                ..
+            } => m["openai"]["itemId"].as_str(),
+            _ => None,
+        })
+        .expect("text part must carry providerMetadata.openai.itemId");
+    assert_eq!(
+        item_id,
+        "msg_057daac88567bde400696c45fc489c81909c927a966ee61535"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Finding 10 / 27 — Bedrock reasoning signature + metadata passthrough
+//
+// The recorded Bedrock cassettes are non-streaming JSON; the streaming frames
+// below carry the *same recorded payloads* (signature, performanceConfig,
+// serviceTier, guardrail trace) through the AWS event-stream codec.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const BEDROCK_MODEL: &str = "us.anthropic.claude-sonnet-4-20250514-v1:0";
+
+fn bedrock_at(uri: &str, model: &str) -> BedrockModel {
+    BedrockModel::new(
+        model.to_string(),
+        BedrockConfig {
+            base_url: uri.to_string(),
+            auth: BedrockAuth::BearerToken("test-token".to_string()),
+            retry_config: aimux_provider_utils::RetryConfig::default(),
+            api_key_source: None,
+        },
+    )
+}
+
+/// The real signature recorded in
+/// `bedrock/test_bedrock_model_thinking_part_anthropic.json`.
+fn bedrock_recorded_reasoning() -> (String, String) {
+    let body = cassette_json("bedrock/test_bedrock_model_thinking_part_anthropic.json");
+    let rt = &body["output"]["message"]["content"][0]["reasoningContent"]["reasoningText"];
+    (
+        rt["signature"].as_str().expect("signature").to_string(),
+        rt["text"].as_str().expect("text").to_string(),
+    )
+}
+
+#[tokio::test]
+async fn finding_10_bedrock_generate_reasoning_signature_in_provider_metadata() {
+    let c = cassette("bedrock/test_bedrock_model_thinking_part_anthropic.json");
+    let server = MockServer::start().await;
+    mount(&server, &c).await;
+
+    let result = bedrock_at(&server.uri(), BEDROCK_MODEL)
+        .do_generate(&opts())
+        .await
+        .expect("do_generate should succeed");
+
+    let r = reasonings(&result.content);
+    assert_eq!(r.len(), 1);
+    assert!(
+        r[0].0
+            .starts_with("This is a straightforward question about crossing the street safely."),
+        "the reasoning text must survive"
+    );
+    let m = r[0].1.expect("reasoning metadata");
+    let sig = m["amazonBedrock"]["signature"]
+        .as_str()
+        .expect("amazonBedrock.signature");
+    assert!(
+        sig.starts_with("Eu4CCkgIBxABGAIqQCc4A+JUj/DJn5X49FRHzzGDqrWoZCEii+cINeYRllo7"),
+        "the recorded signature must be echoed back, got {:?}",
+        &sig[..sig.len().min(24)]
+    );
+    assert_eq!(sig.len(), 496, "the signature must not be truncated");
+    assert_eq!(
+        m["bedrock"]["signature"], m["amazonBedrock"]["signature"],
+        "the signature is mirrored under both provider keys"
+    );
+
+    // The visible answer is separate from the reasoning.
+    let t = texts(&result.content);
+    assert_eq!(t.len(), 1);
+    assert!(t[0].starts_with("Here are the basic steps for crossing the street safely:"));
+}
+
+fn encode_events(events: &[(&str, &str, Value)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for (mt, et, payload) in events {
+        buf.extend_from_slice(&event_stream::encode_message(mt, et, &payload.to_string()));
+    }
+    buf
+}
+
+async fn bedrock_stream_parts(model: &str, events: &[(&str, &str, Value)]) -> Vec<StreamPart> {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path_matcher(format!("/model/{model}/converse-stream")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/vnd.amazon.eventstream")
+                .set_body_bytes(encode_events(events)),
+        )
+        .mount(&server)
+        .await;
+
+    collect(
+        bedrock_at(&server.uri(), model)
+            .do_stream(&opts())
+            .await
+            .expect("do_stream should succeed"),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn finding_10_bedrock_stream_reasoning_signature_emitted_as_metadata_delta() {
+    let (signature, text) = bedrock_recorded_reasoning();
+
+    let parts = bedrock_stream_parts(
+        BEDROCK_MODEL,
+        &[
+            ("event", "messageStart", json!({ "role": "assistant" })),
+            (
+                "event",
+                "contentBlockDelta",
+                json!({
+                    "contentBlockIndex": 0,
+                    "delta": { "reasoningContent": { "text": text } }
+                }),
+            ),
+            (
+                "event",
+                "contentBlockDelta",
+                json!({
+                    "contentBlockIndex": 0,
+                    "delta": { "reasoningContent": { "signature": signature } }
+                }),
+            ),
+            ("event", "messageStop", json!({ "stopReason": "end_turn" })),
+        ],
+    )
+    .await;
+
+    // The text delta.
+    let text_deltas: Vec<&str> = parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::ReasoningDelta { delta, .. } if !delta.is_empty() => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(text_deltas.len(), 1);
+    assert!(text_deltas[0].starts_with("This is a straightforward question"));
+
+    // The signature arrives on a trailing text-less delta and is attached to
+    // the concluding ReasoningEnd (dual-key, same shape as the non-streaming
+    // path) — it used to be dropped entirely.
+    let end_meta = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::ReasoningEnd {
+                provider_metadata: Some(m),
+                ..
+            } => Some(m),
+            _ => None,
+        })
+        .expect("the ReasoningEnd must carry the signature");
+    assert_eq!(end_meta["amazonBedrock"]["signature"], json!(signature));
+    assert_eq!(end_meta["bedrock"]["signature"], json!(signature));
+}
+
+#[tokio::test]
+async fn finding_27_bedrock_stream_performance_config_and_service_tier_reach_finish() {
+    // Real recorded values.
+    let perf =
+        cassette_json("bedrock/test_bedrock_model_performance_config.json")["performanceConfig"]
+            .clone();
+    let tier = cassette_json("bedrock/test_bedrock_model_service_tier.json")["serviceTier"].clone();
+    assert_eq!(perf, json!({ "latency": "optimized" }));
+    assert_eq!(tier, json!({ "type": "flex" }));
+
+    let parts = bedrock_stream_parts(
+        BEDROCK_MODEL,
+        &[
+            ("event", "messageStart", json!({ "role": "assistant" })),
+            (
+                "event",
+                "contentBlockDelta",
+                json!({ "contentBlockIndex": 0, "delta": { "text": "Paris." } }),
+            ),
+            ("event", "messageStop", json!({ "stopReason": "end_turn" })),
+            (
+                "event",
+                "metadata",
+                json!({
+                    "usage": { "inputTokens": 13, "outputTokens": 67, "totalTokens": 80 },
+                    "performanceConfig": perf,
+                    "serviceTier": tier,
+                }),
+            ),
+        ],
+    )
+    .await;
+
+    let meta = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::Finish {
+                provider_metadata, ..
+            } => provider_metadata.as_ref(),
+            _ => None,
+        })
+        .expect("Finish must carry provider_metadata");
+    assert_eq!(
+        meta["amazonBedrock"]["performanceConfig"],
+        json!({ "latency": "optimized" })
+    );
+    assert_eq!(
+        meta["amazonBedrock"]["serviceTier"],
+        json!({ "type": "flex" })
+    );
+    assert_eq!(
+        meta["bedrock"], meta["amazonBedrock"],
+        "both provider keys carry the same payload"
+    );
+}
+
+#[tokio::test]
+async fn finding_27_bedrock_stream_guardrail_trace_reaches_finish() {
+    let trace = cassette_json("bedrock/test_bedrock_model_guardrail_config.json")["trace"].clone();
+    // Guard against the cassette silently losing its guardrail block.
+    assert_eq!(trace["guardrail"]["actionReason"], json!("No action."));
+
+    let parts = bedrock_stream_parts(
+        "us.amazon.nova-micro-v1:0",
+        &[
+            ("event", "messageStart", json!({ "role": "assistant" })),
+            (
+                "event",
+                "contentBlockDelta",
+                json!({ "contentBlockIndex": 0, "delta": { "text": "Paris." } }),
+            ),
+            ("event", "messageStop", json!({ "stopReason": "end_turn" })),
+            (
+                "event",
+                "metadata",
+                json!({
+                    "usage": { "inputTokens": 13, "outputTokens": 67, "totalTokens": 80 },
+                    "trace": trace,
+                }),
+            ),
+        ],
+    )
+    .await;
+
+    let meta = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::Finish {
+                provider_metadata, ..
+            } => provider_metadata.as_ref(),
+            _ => None,
+        })
+        .expect("Finish must carry provider_metadata");
+
+    let guardrail = &meta["amazonBedrock"]["trace"]["guardrail"];
+    assert_eq!(guardrail["actionReason"], json!("No action."));
+    let assessment = &guardrail["inputAssessment"]["xbgw7g293v7o"];
+    assert_eq!(
+        assessment["appliedGuardrailDetails"]["guardrailId"],
+        json!("xbgw7g293v7o")
+    );
+    assert_eq!(
+        assessment["appliedGuardrailDetails"]["guardrailArn"],
+        json!("arn:aws:bedrock:us-east-1:353014496775:guardrail/xbgw7g293v7o")
+    );
+    assert_eq!(
+        assessment["invocationMetrics"]["guardrailProcessingLatency"],
+        json!(397),
+        "nested metrics must not be flattened away"
+    );
+    assert_eq!(meta["bedrock"]["trace"], meta["amazonBedrock"]["trace"]);
+}
+
+#[tokio::test]
+async fn finding_26_bedrock_stream_stop_sequence_reaches_finish() {
+    let parts = bedrock_stream_parts(
+        BEDROCK_MODEL,
+        &[
+            ("event", "messageStart", json!({ "role": "assistant" })),
+            (
+                "event",
+                "contentBlockDelta",
+                json!({ "contentBlockIndex": 0, "delta": { "text": "Hello, World!" } }),
+            ),
+            (
+                "event",
+                "messageStop",
+                json!({
+                    "stopReason": "stop_sequence",
+                    "additionalModelResponseFields": { "delta": { "stop_sequence": "STOP" } }
+                }),
+            ),
+            (
+                "event",
+                "metadata",
+                json!({ "usage": { "inputTokens": 4, "outputTokens": 30, "totalTokens": 34 } }),
+            ),
+        ],
+    )
+    .await;
+
+    let meta = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::Finish {
+                provider_metadata, ..
+            } => provider_metadata.as_ref(),
+            _ => None,
+        })
+        .expect("Finish must carry provider_metadata");
+    assert_eq!(meta["amazonBedrock"]["stopSequence"], json!("STOP"));
+    assert_eq!(meta["bedrock"]["stopSequence"], json!("STOP"));
+}

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -1231,6 +1231,63 @@ mod do_stream {
         );
     }
 
+    // ── empty-text thoughtSignature while a reasoning block is open ───────────
+    // Regression: the signature used to be silently dropped unless a *text*
+    // block was open. Gemini thinking models emit the signature on an
+    // empty-text part right after the thought text — while the reasoning
+    // block is the open one.
+
+    #[tokio::test]
+    async fn should_stream_empty_text_signature_onto_open_reasoning_block() {
+        let server = MockServer::start().await;
+        let body = sse_body(&[
+            &sse_event(
+                r#"{"candidates":[{"content":{"parts":[{"text":"Thinking hard","thought":true}],"role":"model"},"index":0}],"responseId":"resp-3"}"#,
+            ),
+            &sse_event(
+                r#"{"candidates":[{"content":{"parts":[{"text":"","thoughtSignature":"sig-on-empty-text"}],"role":"model"},"index":0}],"responseId":"resp-3"}"#,
+            ),
+            &sse_event(
+                r#"{"candidates":[{"content":{"parts":[{"text":"The answer"}],"role":"model"},"finishReason":"STOP","index":0}],"responseId":"resp-3"}"#,
+            ),
+        ]);
+        mock_sse_response(&server, "gemini-2.5-pro", &body).await;
+
+        let config = GoogleConfig::new("test-api-key").with_base_url(server.uri());
+        let provider = GoogleProvider::new(config);
+        let model = provider.model("gemini-2.5-pro");
+
+        let result = model
+            .do_stream(&default_options(test_prompt()))
+            .await
+            .expect("do_stream should succeed");
+        let parts = collect_stream(result).await;
+
+        // The reasoning block opens with id "0" and receives the thought text.
+        let reasoning_delta = parts.iter().find(
+            |p| matches!(p, StreamPart::ReasoningDelta { delta, .. } if delta == "Thinking hard"),
+        );
+        assert!(
+            reasoning_delta.is_some(),
+            "thought text should stream as ReasoningDelta"
+        );
+
+        // The signature on the empty-text part must attach to the open
+        // reasoning block as a zero-length ReasoningDelta — not be dropped.
+        let sig_delta = parts.iter().find(|p| {
+            matches!(p, StreamPart::ReasoningDelta { id, delta, provider_metadata }
+                if id == "0"
+                && delta.is_empty()
+                && provider_metadata.as_ref().and_then(|m| m["google"]["thoughtSignature"].as_str())
+                    == Some("sig-on-empty-text"))
+        });
+        assert!(
+            sig_delta.is_some(),
+            "empty-text thoughtSignature must ride the open reasoning block, got {:?}",
+            parts
+        );
+    }
+
     // ── should expose usage from the final chunk ──────────────────────────────
 
     #[tokio::test]

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -1283,8 +1283,7 @@ mod do_stream {
         });
         assert!(
             sig_delta.is_some(),
-            "empty-text thoughtSignature must ride the open reasoning block, got {:?}",
-            parts
+            "empty-text thoughtSignature must ride the open reasoning block, got {parts:?}"
         );
     }
 

--- a/aimux-providers/tests/google_provider_tools_test.rs
+++ b/aimux-providers/tests/google_provider_tools_test.rs
@@ -209,6 +209,43 @@ fn gen_tool_calls(content: &[GenerateContent]) -> Vec<(String, String, Value)> {
         .collect()
 }
 
+/// Extract `(tool_call_id, tool_name, result)` from `GenerateContent::ToolResult`.
+fn gen_tool_results(content: &[GenerateContent]) -> Vec<(String, String, Value)> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::ToolResult {
+                tool_call_id,
+                tool_name,
+                result,
+                ..
+            } => Some((tool_call_id.clone(), tool_name.clone(), result.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The `provider_metadata` of the `GenerateContent::ToolCall` / `ToolResult`
+/// whose `tool_name` is `name`.
+fn gen_server_metadata(content: &[GenerateContent], name: &str) -> Vec<Value> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            GenerateContent::ToolCall {
+                tool_name,
+                provider_metadata,
+                ..
+            }
+            | GenerateContent::ToolResult {
+                tool_name,
+                provider_metadata,
+                ..
+            } if tool_name == name => provider_metadata.clone(),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Extract `(id, source_type, url, title)` from `GenerateContent::Source`.
 ///
 /// NOTE: `GenerateContent::Source` has no `filename` / `media_type` fields —
@@ -1109,17 +1146,17 @@ mod do_generate {
             has_call,
             "expected a code_execution tool-call, got {calls:?}"
         );
-        // NOTE: TS also asserts a tool-result content item { outcome, output }
-        // with providerExecuted=true — not expressible until GenerateContent
-        // gains a ToolResult variant (see `code_execution_tool_result_content`).
+        // The tool-result half of the TS assertion lives in
+        // `code_execution_tool_result_content` below.
     }
 
     /// TS: "should handle code execution tool calls" — the `tool-result` portion.
     ///
-    /// `GenerateContent` has no `ToolResult` variant and `ToolCall` has no
-    /// `provider_executed` flag, so the full TS assertion cannot be expressed.
+    /// `GenerateContent::ToolResult` now exists, so the TS assertion is
+    /// expressible: the `codeExecutionResult` part becomes a `ToolResult`
+    /// named `code_execution` carrying `{ outcome, output }`, paired with the
+    /// id of the `executableCode` call it answers.
     #[tokio::test]
-    #[ignore = "GenerateContent has no ToolResult variant; ToolCall lacks provider_executed"]
     async fn code_execution_tool_result_content() {
         let server = MockServer::start().await;
         mock_json_response(
@@ -1149,12 +1186,34 @@ mod do_generate {
             .await
             .expect("do_generate should succeed");
 
-        // Once GenerateContent::ToolResult exists, assert:
-        //   a ToolResult { tool_name: "code_execution",
-        //                  output: { "outcome": "OUTCOME_OK", "output": "2" } }
-        // and the ToolCall carries provider_executed: true.
-        let _ = result;
-        panic!("placeholder until GenerateContent::ToolResult exists");
+        let calls = gen_tool_calls(&result.content);
+        assert_eq!(calls.len(), 1, "one executableCode part → one tool-call");
+        assert_eq!(calls[0].1, "code_execution");
+        assert_eq!(
+            calls[0].2,
+            json!({ "language": "PYTHON", "code": "print(1+1)" })
+        );
+
+        let results = gen_tool_results(&result.content);
+        assert_eq!(
+            results.len(),
+            1,
+            "one codeExecutionResult part → one tool-result"
+        );
+        assert_eq!(results[0].1, "code_execution");
+        assert_eq!(
+            results[0].2,
+            json!({ "outcome": "OUTCOME_OK", "output": "2" }),
+            "the TS `{{ outcome, output }}` result shape"
+        );
+        assert_eq!(
+            results[0].0, calls[0].0,
+            "the result must carry the id of the call it answers"
+        );
+        assert!(
+            !results[0].0.is_empty(),
+            "tool_call_id must not be the empty string"
+        );
     }
 
     #[tokio::test]
@@ -1358,12 +1417,12 @@ mod do_generate {
     // ── server-side toolCall / toolResponse parts ─────────────────────────────
     //
     // Gemini 3 can return `toolCall` + `toolResponse` parts for provider tools
-    // (e.g. GOOGLE_SEARCH_WEB). These are not parsed by the Rust port yet.
-    // `GenerateContent::ToolCall` also lacks the TS `dynamic` / `providerExecuted`
-    // / per-call `providerMetadata` fields, and there is no `ToolResult` variant.
+    // (e.g. GOOGLE_SEARCH_WEB). Both are parsed now: the call becomes a
+    // `ToolCall` named `server:<toolType>` and the response a `ToolResult` with
+    // the same name, each carrying
+    // `providerMetadata.google.{serverToolCallId,serverToolType,thoughtSignature}`.
 
     #[tokio::test]
-    #[ignore = "server-side toolCall/toolResponse parts need ToolCall dynamic/providerMetadata fields and a ToolResult variant"]
     async fn handle_server_side_tool_call_and_tool_response_parts() {
         // TS: "should handle server-side toolCall and toolResponse parts (tool combination)"
         let server = MockServer::start().await;
@@ -1413,13 +1472,50 @@ mod do_generate {
             c,
             GenerateContent::Text { text, .. } if text == "The weather in San Francisco is sunny."
         )));
-        // Server tool call with toolName "server:GOOGLE_SEARCH_WEB" (red).
-        assert!(
-            gen_tool_calls(&result.content)
-                .iter()
-                .any(|(_, name, _)| name == "server:GOOGLE_SEARCH_WEB"),
-            "expected a server-side tool-call"
+
+        // Server tool call with toolName "server:GOOGLE_SEARCH_WEB".
+        let calls = gen_tool_calls(&result.content);
+        assert_eq!(calls.len(), 1, "one toolCall part → one tool-call");
+        assert_eq!(calls[0].0, "server-call-1", "the server-assigned id");
+        assert_eq!(calls[0].1, "server:GOOGLE_SEARCH_WEB");
+        assert_eq!(calls[0].2, json!({ "query": "San Francisco weather" }));
+
+        // The matching toolResponse part.
+        let results = gen_tool_results(&result.content);
+        assert_eq!(results.len(), 1, "one toolResponse part → one tool-result");
+        assert_eq!(
+            results[0].0, "server-call-1",
+            "the result is paired with its call"
         );
+        assert_eq!(results[0].1, "server:GOOGLE_SEARCH_WEB");
+        assert_eq!(
+            results[0].2,
+            json!({ "results": [{ "title": "Weather in SF" }] }),
+            "the server tool's response payload must survive verbatim"
+        );
+
+        // Per-part providerMetadata: server ids/types plus the thoughtSignature
+        // (which must be echoed back on the follow-up turn).
+        let meta = gen_server_metadata(&result.content, "server:GOOGLE_SEARCH_WEB");
+        assert_eq!(meta.len(), 2, "both the call and the result carry metadata");
+        assert_eq!(
+            meta[0]["google"],
+            json!({
+                "serverToolCallId": "server-call-1",
+                "serverToolType": "GOOGLE_SEARCH_WEB",
+                "thoughtSignature": "sig-abc",
+            })
+        );
+        assert_eq!(
+            meta[1]["google"],
+            json!({
+                "serverToolCallId": "server-call-1",
+                "serverToolType": "GOOGLE_SEARCH_WEB",
+                "thoughtSignature": "sig-def",
+            })
+        );
+
+        // Provider-executed tools do NOT flip the finish reason to tool-calls.
         assert_eq!(
             result.finish_reason.unified,
             aimux_core::types::FinishReasonUnified::Stop
@@ -1870,12 +1966,10 @@ mod do_stream {
 
     /// TS: "should stream server-side toolCall and toolResponse parts (tool combination)".
     ///
-    /// Server-side `toolCall`/`toolResponse` parts need `ToolCall` dynamic /
-    /// providerMetadata fields and a `ToolResult` variant to fully express; the
-    /// core assertion (server tool call + result streamed) is kept but ignored
-    /// until those land.
+    /// Both parts are streamed now: `StreamPart::ToolCall` /
+    /// `StreamPart::ToolResult` named `server:<toolType>`, each carrying
+    /// `providerMetadata.google.{serverToolCallId,serverToolType,thoughtSignature}`.
     #[tokio::test]
-    #[ignore = "server-side toolCall/toolResponse streaming needs ToolCall dynamic/providerMetadata fields and a ToolResult tool_name"]
     async fn stream_server_side_tool_call_and_tool_response_parts() {
         let server = MockServer::start().await;
         mock_sse_response(
@@ -1926,12 +2020,82 @@ mod do_stream {
             .expect("do_stream should succeed");
         let parts = collect_stream(result).await;
 
-        assert!(
-            stream_tool_calls(&parts)
-                .iter()
-                .any(|(_, name, _)| name == "server:GOOGLE_SEARCH_WEB"),
-            "expected a server-side tool-call in the stream"
+        let calls = stream_tool_calls(&parts);
+        assert_eq!(calls.len(), 1, "one toolCall part → one streamed tool-call");
+        assert_eq!(calls[0].0, "server-call-1");
+        assert_eq!(calls[0].1, "server:GOOGLE_SEARCH_WEB");
+        assert_eq!(calls[0].2, json!({ "query": "San Francisco weather" }));
+
+        let results = stream_tool_results(&parts);
+        assert_eq!(
+            results.len(),
+            1,
+            "one toolResponse part → one streamed tool-result"
         );
+        assert_eq!(
+            results[0].0, "server-call-1",
+            "the streamed result is paired with its call"
+        );
+        assert_eq!(
+            results[0].1,
+            json!({ "results": [{ "title": "Weather in SF" }] }),
+            "the server tool's response payload must survive verbatim"
+        );
+
+        // Per-part providerMetadata (ids/types + the thoughtSignature that must
+        // be echoed back on the follow-up turn).
+        let meta: Vec<Value> = parts
+            .iter()
+            .filter_map(|p| match p {
+                StreamPart::ToolCall {
+                    tool_name,
+                    provider_metadata,
+                    ..
+                }
+                | StreamPart::ToolResult {
+                    tool_name,
+                    provider_metadata,
+                    ..
+                } if tool_name == "server:GOOGLE_SEARCH_WEB" => provider_metadata.clone(),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(meta.len(), 2, "both the call and the result carry metadata");
+        assert_eq!(
+            meta[0]["google"],
+            json!({
+                "serverToolCallId": "server-call-1",
+                "serverToolType": "GOOGLE_SEARCH_WEB",
+                "thoughtSignature": "sig-abc",
+            })
+        );
+        assert_eq!(
+            meta[1]["google"],
+            json!({
+                "serverToolCallId": "server-call-1",
+                "serverToolType": "GOOGLE_SEARCH_WEB",
+                "thoughtSignature": "sig-def",
+            })
+        );
+
+        // The trailing text is still streamed, and the finish reason is Stop
+        // (provider-executed tools do not flip it to tool-calls).
+        let text: String = parts
+            .iter()
+            .filter_map(|p| match p {
+                StreamPart::TextDelta { delta, .. } => Some(delta.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "The weather in San Francisco is sunny.");
+        let finish = parts
+            .iter()
+            .find_map(|p| match p {
+                StreamPart::Finish { finish_reason, .. } => Some(finish_reason),
+                _ => None,
+            })
+            .expect("finish part");
+        assert_eq!(finish.unified, aimux_core::types::FinishReasonUnified::Stop);
     }
 
     // ── streaming source events ───────────────────────────────────────────────

--- a/aimux-providers/tests/huggingface_responses_test.rs
+++ b/aimux-providers/tests/huggingface_responses_test.rs
@@ -555,19 +555,19 @@ async fn should_handle_mcp_tools_with_annotations() {
             assert_eq!(tool_call_id, "mcp_search_test");
             assert_eq!(tool_name, "search");
         }
-        other => panic!("expected ToolResult at [1], got {:?}", other),
+        other => panic!("expected ToolResult at [1], got {other:?}"),
     }
     match &result.content[2] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Based on the search results."),
-        other => panic!("expected Text at [2], got {:?}", other),
+        other => panic!("expected Text at [2], got {other:?}"),
     }
     match &result.content[3] {
         GenerateContent::Source { id, .. } => assert_eq!(id, "id-0"),
-        other => panic!("expected Source at [3], got {:?}", other),
+        other => panic!("expected Source at [3], got {other:?}"),
     }
     match &result.content[4] {
         GenerateContent::Source { id, .. } => assert_eq!(id, "id-1"),
-        other => panic!("expected Source at [4], got {:?}", other),
+        other => panic!("expected Source at [4], got {other:?}"),
     }
 }
 

--- a/aimux-providers/tests/huggingface_responses_test.rs
+++ b/aimux-providers/tests/huggingface_responses_test.rs
@@ -529,10 +529,10 @@ async fn should_handle_mcp_tools_with_annotations() {
         .await
         .expect("should succeed");
 
-    // content: tool-call, text, source, source
-    // (Rust GenerateContent has no ToolResult variant — the TS tool-result is
-    // omitted.)
-    assert_eq!(result.content.len(), 4);
+    // content: tool-call, tool-result, text, source, source — the `mcp_call`
+    // carries an `output`, which is surfaced as the paired ToolResult (the TS
+    // emits it as a separate content item too).
+    assert_eq!(result.content.len(), 5);
     match &result.content[0] {
         GenerateContent::ToolCall {
             tool_call_id,
@@ -547,16 +547,27 @@ async fn should_handle_mcp_tools_with_annotations() {
         other => panic!("expected ToolCall at [0], got {other:?}"),
     }
     match &result.content[1] {
-        GenerateContent::Text { text, .. } => assert_eq!(text, "Based on the search results."),
-        other => panic!("expected Text at [1], got {other:?}"),
+        GenerateContent::ToolResult {
+            tool_call_id,
+            tool_name,
+            ..
+        } => {
+            assert_eq!(tool_call_id, "mcp_search_test");
+            assert_eq!(tool_name, "search");
+        }
+        other => panic!("expected ToolResult at [1], got {:?}", other),
     }
     match &result.content[2] {
-        GenerateContent::Source { id, .. } => assert_eq!(id, "id-0"),
-        other => panic!("expected Source at [2], got {other:?}"),
+        GenerateContent::Text { text, .. } => assert_eq!(text, "Based on the search results."),
+        other => panic!("expected Text at [2], got {:?}", other),
     }
     match &result.content[3] {
+        GenerateContent::Source { id, .. } => assert_eq!(id, "id-0"),
+        other => panic!("expected Source at [3], got {:?}", other),
+    }
+    match &result.content[4] {
         GenerateContent::Source { id, .. } => assert_eq!(id, "id-1"),
-        other => panic!("expected Source at [3], got {other:?}"),
+        other => panic!("expected Source at [4], got {:?}", other),
     }
 }
 
@@ -1067,7 +1078,8 @@ async fn should_handle_function_call_tool_responses() {
         .await
         .expect("should succeed");
 
-    // content: tool-call, text (Rust has no ToolResult in GenerateContent)
+    // content: tool-call, text — a client-executed `function_call` carries no
+    // output, so there is no paired ToolResult.
     assert_eq!(result.content.len(), 2);
     match &result.content[0] {
         GenerateContent::ToolCall {

--- a/aimux-providers/tests/mistral_model_test.rs
+++ b/aimux-providers/tests/mistral_model_test.rs
@@ -995,9 +995,10 @@ async fn should_extract_content_when_message_content_is_object() {
     }
 }
 
-/// TS: "should preserve ordering of mixed thinking and text" — the Rust
-/// `GenerateContent` enum has no reasoning variant, so thinking parts are
-/// skipped and only text parts are surfaced.
+/// TS: "should preserve ordering of mixed thinking and text".
+///
+/// Thinking parts become a `Reasoning` item, pushed ahead of the text to match
+/// the upstream ordering; the text parts are joined as before.
 #[tokio::test]
 async fn should_extract_text_from_mixed_thinking_and_text() {
     let server = MockServer::start().await;
@@ -1035,14 +1036,22 @@ async fn should_extract_text_from_mixed_thinking_and_text() {
         .await
         .expect("should succeed");
 
-    // The Rust `GenerateContent` enum has no reasoning variant; the impl joins
-    // all text parts into a single Text content (thinking parts are skipped).
-    assert_eq!(result.content.len(), 1);
+    // Reasoning first, then the joined text.
+    assert_eq!(result.content.len(), 2);
     match &result.content[0] {
+        GenerateContent::Reasoning { text, .. } => {
+            assert_eq!(
+                text, "First thought.Second thought.",
+                "both thinking parts must survive, in order"
+            );
+        }
+        other => panic!("expected Reasoning at [0], got {:?}", other),
+    }
+    match &result.content[1] {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "Partial answer.Final answer.");
         }
-        other => panic!("expected Text, got {other:?}"),
+        other => panic!("expected Text at [1], got {other:?}"),
     }
 }
 

--- a/aimux-providers/tests/mistral_model_test.rs
+++ b/aimux-providers/tests/mistral_model_test.rs
@@ -1045,7 +1045,7 @@ async fn should_extract_text_from_mixed_thinking_and_text() {
                 "both thinking parts must survive, in order"
             );
         }
-        other => panic!("expected Reasoning at [0], got {:?}", other),
+        other => panic!("expected Reasoning at [0], got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Text { text, .. } => {

--- a/aimux-providers/tests/openai_responses_test.rs
+++ b/aimux-providers/tests/openai_responses_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK OpenAI Responses API tests.
+//! Rust translations of the AI SDK OpenAI Responses API tests.
 //!
 //! Sources (TS -> Rust):
 //! - `packages/openai/src/responses/openai-responses-language-model.test.ts`
@@ -1289,7 +1289,7 @@ mod do_stream {
                     json!("enc-blob-123")
                 );
             }
-            other => panic!("ReasoningStart must carry metadata, got {:?}", other),
+            other => panic!("ReasoningStart must carry metadata, got {other:?}"),
         }
 
         let end = parts
@@ -1309,7 +1309,7 @@ mod do_stream {
                     "encrypted_content must ride ReasoningEnd so consume() can round-trip it"
                 );
             }
-            other => panic!("ReasoningEnd must carry metadata, got {:?}", other),
+            other => panic!("ReasoningEnd must carry metadata, got {other:?}"),
         }
     }
 
@@ -1359,10 +1359,7 @@ mod do_stream {
                     json!("enc-no-summary")
                 );
             }
-            other => panic!(
-                "ReasoningEnd must carry metadata even without summary, got {:?}",
-                other
-            ),
+            other => panic!("ReasoningEnd must carry metadata even without summary, got {other:?}"),
         }
     }
 

--- a/aimux-providers/tests/openai_responses_test.rs
+++ b/aimux-providers/tests/openai_responses_test.rs
@@ -1237,6 +1237,135 @@ mod do_stream {
         }
     }
 
+    // -- should carry encrypted reasoning content in stream metadata --
+
+    /// Regression: the streaming reducer captured `encrypted_content` into
+    /// state and then discarded it (`let _ = encrypted;`) — every
+    /// ReasoningEnd carried `provider_metadata: None`, so encrypted
+    /// reasoning could not cross a turn with store=false.
+    #[tokio::test]
+    async fn should_stream_reasoning_encrypted_content_in_metadata() {
+        let server = MockServer::start().await;
+        let chunks = sse_body(&[
+            &sse_event(
+                r#"{"type":"response.created","response":{"id":"resp_enc","created_at":1741269019,"model":"o3-mini-2025-01-31"}}"#,
+            ),
+            &sse_event(
+                r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","encrypted_content":"enc-blob-123"}}"#,
+            ),
+            &sse_event(
+                r#"{"type":"response.reasoning_summary_text.delta","item_id":"rs_1","summary_index":0,"delta":"thinking"}"#,
+            ),
+            &sse_event(
+                r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","encrypted_content":"enc-blob-123","summary":[{"type":"summary_text","text":"thinking"}]}}"#,
+            ),
+            &sse_event(
+                r#"{"type":"response.completed","response":{"id":"resp_enc","created_at":1741269019,"model":"o3-mini-2025-01-31","incomplete_details":null,"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":20,"output_tokens_details":{"reasoning_tokens":20}}}}"#,
+            ),
+        ]);
+        mock_sse_response(&server, &chunks).await;
+
+        let config = OpenAIConfig::new("test-key").with_base_url(server.uri());
+        let model = OpenAIProvider::new(config).responses_model("o3-mini");
+
+        let result = model
+            .do_stream(&default_options(test_prompt()))
+            .await
+            .expect("should succeed");
+        let parts = collect_stream(result).await;
+
+        let start = parts
+            .iter()
+            .find(|p| matches!(p, StreamPart::ReasoningStart { .. }))
+            .expect("ReasoningStart");
+        match start {
+            StreamPart::ReasoningStart {
+                provider_metadata: Some(m),
+                ..
+            } => {
+                assert_eq!(m["openai"]["itemId"], json!("rs_1"));
+                assert_eq!(
+                    m["openai"]["reasoningEncryptedContent"],
+                    json!("enc-blob-123")
+                );
+            }
+            other => panic!("ReasoningStart must carry metadata, got {:?}", other),
+        }
+
+        let end = parts
+            .iter()
+            .find(|p| matches!(p, StreamPart::ReasoningEnd { .. }))
+            .expect("ReasoningEnd");
+        match end {
+            StreamPart::ReasoningEnd {
+                id,
+                provider_metadata: Some(m),
+            } => {
+                assert_eq!(id, "rs_1:0");
+                assert_eq!(m["openai"]["itemId"], json!("rs_1"));
+                assert_eq!(
+                    m["openai"]["reasoningEncryptedContent"],
+                    json!("enc-blob-123"),
+                    "encrypted_content must ride ReasoningEnd so consume() can round-trip it"
+                );
+            }
+            other => panic!("ReasoningEnd must carry metadata, got {:?}", other),
+        }
+    }
+
+    /// Same path with no summary text at all: the ReasoningEnd must still
+    /// carry the metadata so `consume()` can keep the part in
+    /// response_messages.
+    #[tokio::test]
+    async fn should_stream_reasoning_encrypted_content_without_summary() {
+        let server = MockServer::start().await;
+        let chunks = sse_body(&[
+            &sse_event(
+                r#"{"type":"response.created","response":{"id":"resp_enc2","created_at":1741269019,"model":"o3-mini-2025-01-31"}}"#,
+            ),
+            &sse_event(
+                r#"{"type":"response.output_item.added","output_index":0,"item":{"id":"rs_9","type":"reasoning","encrypted_content":"enc-no-summary"}}"#,
+            ),
+            &sse_event(
+                r#"{"type":"response.output_item.done","output_index":0,"item":{"id":"rs_9","type":"reasoning","encrypted_content":"enc-no-summary","summary":[]}}"#,
+            ),
+            &sse_event(
+                r#"{"type":"response.completed","response":{"id":"resp_enc2","created_at":1741269019,"model":"o3-mini-2025-01-31","incomplete_details":null,"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":20,"output_tokens_details":{"reasoning_tokens":20}}}}"#,
+            ),
+        ]);
+        mock_sse_response(&server, &chunks).await;
+
+        let config = OpenAIConfig::new("test-key").with_base_url(server.uri());
+        let model = OpenAIProvider::new(config).responses_model("o3-mini");
+
+        let result = model
+            .do_stream(&default_options(test_prompt()))
+            .await
+            .expect("should succeed");
+        let parts = collect_stream(result).await;
+
+        let end = parts
+            .iter()
+            .find(|p| matches!(p, StreamPart::ReasoningEnd { .. }))
+            .expect("ReasoningEnd even without any summary text");
+        match end {
+            StreamPart::ReasoningEnd {
+                provider_metadata: Some(m),
+                ..
+            } => {
+                assert_eq!(m["openai"]["itemId"], json!("rs_9"));
+                assert_eq!(
+                    m["openai"]["reasoningEncryptedContent"],
+                    json!("enc-no-summary")
+                );
+            }
+            other => panic!(
+                "ReasoningEnd must carry metadata even without summary, got {:?}",
+                other
+            ),
+        }
+    }
+
     // -- should send finish reason for incomplete response --
 
     /// TS: "should send finish reason for incomplete response"


### PR DESCRIPTION
## Why this resubmits #101

#101 was closed as "already-merged" because its 4 commits appeared to be on master (a local fast-forward). They never actually landed on the upstream master: the current master diverged and contains none of this work — verifiable by content (`google/model.rs` has no `thought_sig_meta`/`set_provider_metadata`, `data_loss_regression_test.rs` does not exist, `anthropic/stream.rs` is 524 lines vs 1123 here).

The 4 original commits are rebased onto current master (`7a9d1e2`) **unchanged in intent**; two collisions with #131/#143 (which landed in parallel) were resolved in upstream's favor — details in [the rebase comment](https://github.com/arcships/aimux/pull/139#issuecomment-5302846029).

## Original #101 scope (rebased, unchanged)

- anthropic: surface server-tool results and stop sending illegal blocks
- google/vertex: surface inlineData, thoughts, signatures and grounding
- openai/bedrock/cohere/mistral/huggingface: keep response data providers already sent
- data_loss_regression_test.rs: exact-value assertions instead of "not empty"

## Review follow-ups from #101 (new commits)

1. **Gemini streaming empty-text `thoughtSignature` dropped while a reasoning block is open** — fixed. The signature now attaches to whichever block is open (text or reasoning) via a zero-length delta, mirroring the non-streaming `content.last_mut()` path. Regression test included.

2. **OpenAI Responses reasoning cross-turn** — the review asked for a wording fix and noted the end-to-end path lands with the provider-executed work, so this commit goes beyond what was asked; flagging that openly. The reason it became code: the streaming reducer was already parsing `encrypted_content` and then discarding it (`let _ = encrypted;`) — squarely this PR's "stop dropping parsed data" theme. **If you'd rather take cross-turn propagation together with the provider-executed work, say so and I'll split `8755602` + its tests into a separate PR.** The reducer captured `encrypted_content` and discarded it (`let _ = encrypted;`); every `ReasoningEnd` carried `provider_metadata: None`. Now `ReasoningStart`/`ReasoningEnd` carry `{ <provider_key>: { itemId, reasoningEncryptedContent? } }` (same shape as the non-streaming path; covers Azure via the shared reducer — xAI already did this), and `consume()` keeps a metadata-carrying reasoning part in `response_messages` even when no summary text was streamed. Three regression tests included.

## Out of scope (flagged for a follow-up issue)

Vertex **streaming** has no reasoning-block handling at all (thought text streams as plain text; text-part signatures are dropped) — a larger pre-existing gap, not regressed here.

## Verification

Pre-rebase (base `cf2cea5`):

- cargo check: clean
- cargo clippy -p aimux-core -p aimux-providers --all-targets: clean
- cargo fmt --all -- --check: clean
- google_model_test 25/25, openai_responses_test 79/79, data_loss_regression_test 30/30, m11_m12_m6_test 7/7

Post-rebase (base `7a9d1e2`): compile and the anthropic suites verified locally; full matrix on CI.
