### PR TITLE
fix(providers): vertex stream drops grounding/code-execution/server-tool results

### DIFF
--- a/aimux-providers/src/vertex/model.rs
+++ b/aimux-providers/src/vertex/model.rs
@@ -23,7 +23,9 @@ use aimux_provider_utils::{
 };
 use aimux_stream::SseStream;
 
-use crate::google::convert::{build_request_body, convert_usage, parse_finish_reason};
+use crate::google::convert::{
+    build_request_body, convert_usage, extract_sources, parse_finish_reason,
+};
 use crate::google::types::{Candidate, GenerateContentResponse, GoogleUsageMetadata, StreamChunk};
 
 use super::VertexAuth;
@@ -274,6 +276,26 @@ impl LanguageModel for VertexModel {
             let mut response_metadata_emitted = false;
             let mut stream_errored = false;
 
+            // Provider-metadata accumulators (mirrors TS `lastGroundingMetadata` /
+            // `lastUrlContextMetadata` + the finishReason-chunk snapshot). Same
+            // behaviour as the public Gemini API provider.
+            let mut last_grounding_metadata: Option<Value> = None;
+            let mut last_url_context_metadata: Option<Value> = None;
+            let mut last_prompt_feedback: Option<Value> = None;
+            let mut last_safety_ratings: Option<Value> = None;
+            let mut last_finish_message: Option<Value> = None;
+            let mut last_usage_metadata_value: Option<Value> = None;
+
+            // Source dedup across chunks (url sources only).
+            let mut emitted_source_urls: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            let mut source_id = 0usize;
+
+            // Associates code-execution results / server tool responses with
+            // their preceding call.
+            let mut last_code_execution_tool_call_id: Option<String> = None;
+            let mut last_server_tool_call_id: Option<String> = None;
+
             while let Some(event) = sse_stream.next().await {
                 if stream_errored {
                     break;
@@ -314,6 +336,10 @@ impl LanguageModel for VertexModel {
 
                         if let Some(usage) = &chunk.usage_metadata {
                             final_usage = convert_usage(usage);
+                            last_usage_metadata_value = serde_json::to_value(usage).ok();
+                        }
+                        if let Some(pf) = &chunk.prompt_feedback {
+                            last_prompt_feedback = Some(pf.clone());
                         }
 
                         let Some(candidates) = chunk.candidates else {
@@ -322,6 +348,37 @@ impl LanguageModel for VertexModel {
                         let Some(candidate) = candidates.into_iter().next() else {
                             continue;
                         };
+
+                        if let Some(gm) = &candidate.grounding_metadata {
+                            last_grounding_metadata = Some(gm.clone());
+                        }
+                        if let Some(ucm) = &candidate.url_context_metadata {
+                            last_url_context_metadata = Some(ucm.clone());
+                        }
+
+                        // Extract url sources from this chunk's grounding metadata
+                        // (deduplicated across chunks; document sources are not
+                        // emitted in the stream, matching TS).
+                        let chunk_sources =
+                            extract_sources(candidate.grounding_metadata.as_ref(), &mut source_id);
+                        for src in chunk_sources {
+                            if let GenerateContent::Source {
+                                url: Some(url),
+                                source_type,
+                                id,
+                                title,
+                                provider_metadata: None,
+                            } = src
+                                && emitted_source_urls.insert(url.clone()) {
+                                    yield Ok(StreamPart::Source {
+                                        id,
+                                        source_type,
+                                        url: Some(url),
+                                        title,
+                                        provider_metadata: None,
+                                    });
+                                }
+                        }
 
                         if let Some(parts) =
                             candidate.content.as_ref().and_then(|c| c.parts.as_ref())
@@ -385,6 +442,97 @@ impl LanguageModel for VertexModel {
                                         provider_metadata: None,
                                     });
                                     has_tool_calls = true;
+                                } else if let Some(ec) = part.get("executableCode") {
+                                    // Provider-executed code execution.
+                                    let has_code = ec
+                                        .get("code")
+                                        .and_then(|v| v.as_str())
+                                        .map(|s| !s.is_empty())
+                                        .unwrap_or(false);
+                                    if has_code {
+                                        let id = format!("call-{}", block_counter);
+                                        block_counter += 1;
+                                        last_code_execution_tool_call_id = Some(id.clone());
+                                        yield Ok(StreamPart::ToolCall {
+                                            tool_call_id: id,
+                                            tool_name: "code_execution".to_string(),
+                                            input: ec.clone(),
+                                            provider_executed: None,
+                                            dynamic: None,
+                                            thought_signature: None,
+                                            provider_metadata: None,
+                                        });
+                                        // provider-executed → does NOT set has_tool_calls
+                                    }
+                                } else if let Some(cer) = part.get("codeExecutionResult") {
+                                    // Result corresponds to the most recent
+                                    // executableCode part.
+                                    if let Some(call_id) =
+                                        last_code_execution_tool_call_id.take()
+                                    {
+                                        let outcome =
+                                            cer.get("outcome").cloned().unwrap_or(json!(null));
+                                        let output = cer
+                                            .get("output")
+                                            .and_then(|v| v.as_str())
+                                            .map(|s| s.to_string())
+                                            .unwrap_or_default();
+                                        yield Ok(StreamPart::ToolResult {
+                                            tool_call_id: call_id,
+                                            tool_name: String::new(),
+                                            result: json!({ "outcome": outcome, "output": output }),
+                                            is_error: None,
+                                            preliminary: None,
+                                            dynamic: None,
+                                            provider_metadata: None,
+                                        });
+                                    }
+                                } else if let Some(tc) = part.get("toolCall") {
+                                    // Server-side tool call (provider-executed).
+                                    let tool_type = tc
+                                        .get("toolType")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("");
+                                    let id = tc
+                                        .get("id")
+                                        .and_then(|v| v.as_str())
+                                        .map(|s| s.to_string())
+                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                    block_counter += 1;
+                                    last_server_tool_call_id = Some(id.clone());
+                                    let args = tc.get("args").cloned().unwrap_or(json!({}));
+                                    yield Ok(StreamPart::ToolCall {
+                                        tool_call_id: id,
+                                        tool_name: format!("server:{}", tool_type),
+                                        input: args,
+                                        provider_executed: None,
+                                        dynamic: None,
+                                        thought_signature: None,
+                                        provider_metadata: None,
+                                    });
+                                    // provider-executed → does NOT set has_tool_calls
+                                } else if let Some(tr) = part.get("toolResponse") {
+                                    // Server-side tool response.
+                                    let id = last_server_tool_call_id
+                                        .take()
+                                        .or_else(|| {
+                                            tr.get("id")
+                                                .and_then(|v| v.as_str())
+                                                .map(|s| s.to_string())
+                                        })
+                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                    block_counter += 1;
+                                    let response =
+                                        tr.get("response").cloned().unwrap_or(json!({}));
+                                    yield Ok(StreamPart::ToolResult {
+                                        tool_call_id: id,
+                                        tool_name: String::new(),
+                                        result: response,
+                                        is_error: None,
+                                        preliminary: None,
+                                        dynamic: None,
+                                        provider_metadata: None,
+                                    });
                                 }
                             }
                         }
@@ -392,6 +540,14 @@ impl LanguageModel for VertexModel {
                         if let Some(reason) = candidate.finish_reason.as_deref() {
                             if let Some(id) = text_id.take() {
                                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
+                            }
+                            // Snapshot the finishReason-chunk metadata.
+                            if let Some(sr) = &candidate.safety_ratings {
+                                last_safety_ratings =
+                                    Some(serde_json::to_value(sr).unwrap_or(Value::Null));
+                            }
+                            if let Some(fm) = &candidate.finish_message {
+                                last_finish_message = Some(json!(fm));
                             }
                             final_finish_reason =
                                 Some(parse_finish_reason(reason, has_tool_calls));
@@ -411,7 +567,16 @@ impl LanguageModel for VertexModel {
                 yield Ok(StreamPart::TextEnd { id, provider_metadata: None});
             }
 
-            let provider_metadata = Some(serde_json::json!({ "googleVertex": {} }));
+            let provider_metadata = Some(serde_json::json!({
+                "googleVertex": {
+                    "promptFeedback": last_prompt_feedback,
+                    "groundingMetadata": last_grounding_metadata,
+                    "urlContextMetadata": last_url_context_metadata,
+                    "safetyRatings": last_safety_ratings,
+                    "usageMetadata": last_usage_metadata_value,
+                    "finishMessage": last_finish_message,
+                }
+            }));
 
             yield Ok(StreamPart::Finish {
                 finish_reason: if stream_errored {

--- a/aimux-providers/tests/vertex_model_test.rs
+++ b/aimux-providers/tests/vertex_model_test.rs
@@ -1,4 +1,4 @@
-﻿//! Wiremock tests for the Google Vertex AI provider.
+//! Wiremock tests for the Google Vertex AI provider.
 //!
 //! Tests cover:
 //! - Non-streaming text generation (generateContent JSON response)
@@ -623,5 +623,457 @@ async fn vertex_generate_rate_limit() {
     assert!(
         matches!(result, Err(ref e) if e.status_code() == Some(429)),
         "expected RateLimited, got {result:?}"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// doStream — provider tool results & metadata (mirrors the google provider's
+// do_stream tests in google_provider_tools_test.rs; issue #141).
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// A single SSE chunk carrying `content.parts: [{ text }]`, optional
+/// `finishReason`, and optional `groundingMetadata` / `urlContextMetadata`.
+fn stream_chunk(
+    text: &str,
+    finish_reason: Option<&str>,
+    grounding: Option<Value>,
+    url_context: Option<Value>,
+) -> Value {
+    let mut candidate = json!({
+        "content": { "parts": [{ "text": text }], "role": "model" }
+    });
+    if let Some(r) = finish_reason {
+        candidate["finishReason"] = json!(r);
+    }
+    if let Some(g) = grounding {
+        candidate["groundingMetadata"] = g;
+    }
+    if let Some(u) = url_context {
+        candidate["urlContextMetadata"] = u;
+    }
+    json!({ "candidates": [candidate] })
+}
+
+/// Extract the `Finish` part's provider metadata from a collected stream.
+fn finish_provider_metadata(parts: &[StreamPart]) -> Option<Value> {
+    parts.iter().find_map(|p| match p {
+        StreamPart::Finish {
+            provider_metadata, ..
+        } => provider_metadata.clone(),
+        _ => None,
+    })
+}
+
+/// Collect `(tool_call_id, tool_name, input)` from streamed `ToolCall` parts.
+fn stream_tool_calls(parts: &[StreamPart]) -> Vec<(String, String, Value)> {
+    parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::ToolCall {
+                tool_call_id,
+                tool_name,
+                input,
+                ..
+            } => Some((tool_call_id.clone(), tool_name.clone(), input.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Collect `(tool_call_id, result)` from streamed `ToolResult` parts.
+fn stream_tool_results(parts: &[StreamPart]) -> Vec<(String, Value)> {
+    parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::ToolResult {
+                tool_call_id,
+                result,
+                ..
+            } => Some((tool_call_id.clone(), result.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Collect `(id, source_type, url, title)` from streamed `Source` parts.
+fn stream_sources(parts: &[StreamPart]) -> Vec<(String, String, Option<String>, Option<String>)> {
+    parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::Source {
+                id,
+                source_type,
+                url,
+                title,
+                ..
+            } => Some((id.clone(), source_type.clone(), url.clone(), title.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// TS: "should stream code execution tool calls and results" — the Vertex
+/// stream must not silently drop provider-executed code results (#141).
+#[tokio::test]
+async fn vertex_stream_code_execution_tool_calls_and_results() {
+    let server = MockServer::start().await;
+    mock_stream_content(
+        &server,
+        &sse_stream(&[
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "executableCode": { "language": "PYTHON", "code": "print(\"hello\")" } }]
+                    }
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "codeExecutionResult": { "outcome": "OUTCOME_OK", "output": "hello\n" } }]
+                    },
+                    "finishReason": "STOP"
+                }]
+            }),
+        ]),
+    )
+    .await;
+
+    let model = make_model(&server);
+    let result = model
+        .do_stream(&default_options(test_prompt()))
+        .await
+        .expect("do_stream should succeed");
+    let parts = collect_stream(result).await;
+
+    let calls = stream_tool_calls(&parts);
+    let has_call = calls.iter().any(|(_, name, input)| {
+        name == "code_execution"
+            && *input == json!({ "language": "PYTHON", "code": "print(\"hello\")" })
+    });
+    assert!(
+        has_call,
+        "expected a code_execution tool-call, got {:?}",
+        calls
+    );
+
+    // The ToolResult must reference the preceding executableCode call id.
+    let results = stream_tool_results(&parts);
+    let call_id = calls
+        .iter()
+        .find(|(_, name, _)| name == "code_execution")
+        .map(|(id, _, _)| id.clone())
+        .expect("code_execution call id");
+    let has_result = results.iter().any(|(id, output)| {
+        *id == call_id && *output == json!({ "outcome": "OUTCOME_OK", "output": "hello\n" })
+    });
+    assert!(
+        has_result,
+        "expected a code_execution tool-result, got {:?}",
+        results
+    );
+
+    // Provider-executed tool → Stop, not ToolCalls.
+    let finish = parts.iter().find_map(|p| match p {
+        StreamPart::Finish { finish_reason, .. } => Some(finish_reason.clone()),
+        _ => None,
+    });
+    assert_eq!(
+        finish.expect("finish part").unified,
+        FinishReasonUnified::Stop
+    );
+}
+
+/// TS: "should stream code execution result with missing output field".
+#[tokio::test]
+async fn vertex_stream_code_execution_result_missing_output() {
+    let server = MockServer::start().await;
+    mock_stream_content(
+        &server,
+        &sse_stream(&[
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "executableCode": {
+                            "language": "PYTHON",
+                            "code": "img = PIL.Image.open('input.png')\nimg.save('output.png')\n"
+                        } }]
+                    }
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "codeExecutionResult": { "outcome": "OUTCOME_OK" } }]
+                    },
+                    "finishReason": "STOP"
+                }]
+            }),
+        ]),
+    )
+    .await;
+
+    let model = make_model(&server);
+    let result = model
+        .do_stream(&default_options(test_prompt()))
+        .await
+        .expect("do_stream should succeed");
+    let parts = collect_stream(result).await;
+
+    assert!(
+        stream_tool_calls(&parts)
+            .iter()
+            .any(|(_, name, _)| name == "code_execution"),
+        "expected a code_execution tool-call"
+    );
+    // Missing output defaults to "".
+    let results = stream_tool_results(&parts);
+    let has_empty = results
+        .iter()
+        .any(|(_, output)| *output == json!({ "outcome": "OUTCOME_OK", "output": "" }));
+    assert!(
+        has_empty,
+        "expected a tool-result with empty output, got {:?}",
+        results
+    );
+}
+
+/// TS: "should stream server-side toolCall and toolResponse parts (tool
+/// combination)" — server tools are provider-executed and must be streamed.
+#[tokio::test]
+async fn vertex_stream_server_tool_call_and_response() {
+    let server = MockServer::start().await;
+    mock_stream_content(
+        &server,
+        &sse_stream(&[
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "toolCall": {
+                            "toolType": "GOOGLE_SEARCH_WEB",
+                            "args": { "query": "San Francisco weather" },
+                            "id": "server-call-1"
+                        }, "thoughtSignature": "sig-abc" }]
+                    }
+                }]
+            }),
+            json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [
+                            { "toolResponse": {
+                                "toolType": "GOOGLE_SEARCH_WEB",
+                                "response": { "results": [{ "title": "Weather in SF" }] },
+                                "id": "server-call-1"
+                            }, "thoughtSignature": "sig-def" },
+                            { "text": "The weather in San Francisco is sunny." }
+                        ]
+                    },
+                    "finishReason": "STOP"
+                }]
+            }),
+        ]),
+    )
+    .await;
+
+    let model = make_model(&server);
+    let result = model
+        .do_stream(&default_options(test_prompt()))
+        .await
+        .expect("do_stream should succeed");
+    let parts = collect_stream(result).await;
+
+    let calls = stream_tool_calls(&parts);
+    assert!(
+        calls
+            .iter()
+            .any(|(_, name, _)| name == "server:GOOGLE_SEARCH_WEB"),
+        "expected a server-side tool-call in the stream, got {:?}",
+        calls
+    );
+
+    let results = stream_tool_results(&parts);
+    assert!(
+        results.iter().any(|(id, output)| *id == "server-call-1"
+            && *output == json!({ "results": [{ "title": "Weather in SF" }] })),
+        "expected a server tool-response keyed to server-call-1, got {:?}",
+        results
+    );
+
+    // Provider-executed server tools → stop, not tool-calls.
+    let finish = parts.iter().find_map(|p| match p {
+        StreamPart::Finish { finish_reason, .. } => Some(finish_reason.clone()),
+        _ => None,
+    });
+    assert_eq!(
+        finish.expect("finish part").unified,
+        FinishReasonUnified::Stop
+    );
+}
+
+/// TS: "should stream source events" + "should deduplicate sources across
+/// chunks" — groundingMetadata is processed, not dropped.
+#[tokio::test]
+async fn vertex_stream_grounding_metadata_sources() {
+    let server = MockServer::start().await;
+    mock_stream_content(
+        &server,
+        &sse_stream(&[
+            stream_chunk(
+                "first chunk",
+                None,
+                Some(json!({
+                    "groundingChunks": [
+                        { "web": { "uri": "https://example.com", "title": "Example" } },
+                        { "web": { "uri": "https://unique.com", "title": "Unique" } }
+                    ]
+                })),
+                None,
+            ),
+            stream_chunk(
+                "second chunk",
+                None,
+                Some(json!({
+                    "groundingChunks": [
+                        { "web": { "uri": "https://example.com", "title": "Example Duplicate" } },
+                        { "web": { "uri": "https://another.com", "title": "Another" } }
+                    ]
+                })),
+                None,
+            ),
+            stream_chunk("final chunk", Some("STOP"), None, None),
+        ]),
+    )
+    .await;
+
+    let model = make_model(&server);
+    let result = model
+        .do_stream(&default_options(test_prompt()))
+        .await
+        .expect("do_stream should succeed");
+    let parts = collect_stream(result).await;
+
+    let sources = stream_sources(&parts);
+    // The duplicate https://example.com appears in two chunks but should be
+    // emitted only once (keeping the first title).
+    let example: Vec<_> = sources
+        .iter()
+        .filter(|(_, _, url, _)| url.as_deref() == Some("https://example.com"))
+        .collect();
+    assert_eq!(
+        example.len(),
+        1,
+        "duplicate source should be emitted once, got {:?}",
+        sources
+    );
+    assert_eq!(example[0].1, "url");
+    assert_eq!(example[0].3.as_deref(), Some("Example"));
+    assert_eq!(
+        sources.len(),
+        3,
+        "expected 3 deduplicated sources, got {:?}",
+        sources
+    );
+}
+
+/// TS: "should preserve grounding/url context metadata when it arrives before
+/// the finishReason chunk" — Finish provider_metadata is non-empty with all
+/// six fields under the `googleVertex` key.
+#[tokio::test]
+async fn vertex_stream_finish_provider_metadata() {
+    let server = MockServer::start().await;
+    mock_stream_content(
+        &server,
+        &sse_stream(&[
+            stream_chunk(
+                "hello",
+                None,
+                Some(json!({
+                    "webSearchQueries": ["super bowl 2026 halftime show"],
+                    "groundingChunks": [{
+                        "web": { "uri": "https://example.com/superbowl", "title": "Super Bowl 2026" }
+                    }]
+                })),
+                Some(json!({
+                    "urlMetadata": [{
+                        "retrievedUrl": "https://example.com/page",
+                        "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
+                    }]
+                })),
+            ),
+            {
+                let mut c = stream_chunk(" world", Some("STOP"), None, None);
+                c["usageMetadata"] = json!({
+                    "promptTokenCount": 38,
+                    "candidatesTokenCount": 1335,
+                    "totalTokenCount": 1890
+                });
+                c
+            },
+        ]),
+    )
+    .await;
+
+    let model = make_model(&server);
+    let result = model
+        .do_stream(&default_options(test_prompt()))
+        .await
+        .expect("do_stream should succeed");
+    let parts = collect_stream(result).await;
+
+    let pm = finish_provider_metadata(&parts).expect("finish part");
+    let vertex = &pm["googleVertex"];
+    assert!(
+        !vertex.is_null() && vertex.as_object().map(|o| !o.is_empty()).unwrap_or(false),
+        "googleVertex provider metadata should be non-empty, got {}",
+        pm
+    );
+    assert_eq!(
+        vertex["groundingMetadata"],
+        json!({
+            "webSearchQueries": ["super bowl 2026 halftime show"],
+            "groundingChunks": [{
+                "web": { "uri": "https://example.com/superbowl", "title": "Super Bowl 2026" }
+            }]
+        })
+    );
+    assert_eq!(
+        vertex["urlContextMetadata"],
+        json!({
+            "urlMetadata": [{
+                "retrievedUrl": "https://example.com/page",
+                "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
+            }]
+        })
+    );
+    // usageMetadata is the serialized GoogleUsageMetadata (includes null
+    // optional fields, mirroring the google provider).
+    assert_eq!(vertex["usageMetadata"]["promptTokenCount"], json!(38));
+    assert_eq!(vertex["usageMetadata"]["candidatesTokenCount"], json!(1335));
+    assert_eq!(vertex["usageMetadata"]["totalTokenCount"], json!(1890));
+    // All six keys are always present (null when absent), matching google.
+    for key in [
+        "promptFeedback",
+        "groundingMetadata",
+        "urlContextMetadata",
+        "safetyRatings",
+        "usageMetadata",
+        "finishMessage",
+    ] {
+        assert!(
+            vertex.get(key).is_some(),
+            "expected key `{key}` in googleVertex metadata, got {}",
+            pm
+        );
+    }
+
+    // Usage also lands on the Finish part itself.
+    let finish_usage = parts.iter().find_map(|p| match p {
+        StreamPart::Finish { usage, .. } => Some(usage.clone()),
+        _ => None,
+    });
+    assert_eq!(
+        finish_usage.expect("finish usage").input_tokens.total,
+        Some(38)
     );
 }

--- a/aimux-providers/tests/vertex_model_test.rs
+++ b/aimux-providers/tests/vertex_model_test.rs
@@ -985,24 +985,34 @@ async fn vertex_stream_finish_provider_metadata() {
     mock_stream_content(
         &server,
         &sse_stream(&[
-            stream_chunk(
-                "hello",
-                None,
-                Some(json!({
-                    "webSearchQueries": ["super bowl 2026 halftime show"],
-                    "groundingChunks": [{
-                        "web": { "uri": "https://example.com/superbowl", "title": "Super Bowl 2026" }
-                    }]
-                })),
+            {
+                let mut c = stream_chunk(
+                    "hello",
+                    None,
+                    Some(json!({
+                        "webSearchQueries": ["super bowl 2026 halftime show"],
+                        "groundingChunks": [{
+                            "web": { "uri": "https://example.com/superbowl", "title": "Super Bowl 2026" }
+                        }]
+                    })),
                 Some(json!({
                     "urlMetadata": [{
                         "retrievedUrl": "https://example.com/page",
                         "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
                     }]
                 })),
-            ),
+                );
+                // Carry a valued promptFeedback so the assertion below locks
+                // the captured value, not just key presence.
+                c["promptFeedback"] = json!({ "promptTokenCount": 12 });
+                c
+            },
             {
                 let mut c = stream_chunk(" world", Some("STOP"), None, None);
+                c["candidates"][0]["safetyRatings"] = json!([
+                    { "category": "HARM_CATEGORY_HARASSMENT", "probability": "NEGLIGIBLE" }
+                ]);
+                c["candidates"][0]["finishMessage"] = json!("natural stop");
                 c["usageMetadata"] = json!({
                     "promptTokenCount": 38,
                     "candidatesTokenCount": 1335,
@@ -1066,6 +1076,14 @@ async fn vertex_stream_finish_provider_metadata() {
             pm
         );
     }
+    // …and the three snapshot fields carry their captured values, not just
+    // key presence (locks the capture code, not the key scaffold).
+    assert_eq!(vertex["promptFeedback"], json!({ "promptTokenCount": 12 }));
+    assert_eq!(
+        vertex["safetyRatings"],
+        json!([{ "category": "HARM_CATEGORY_HARASSMENT", "probability": "NEGLIGIBLE" }])
+    );
+    assert_eq!(vertex["finishMessage"], json!("natural stop"));
 
     // Usage also lands on the Finish part itself.
     let finish_usage = parts.iter().find_map(|p| match p {


### PR DESCRIPTION
Fixes #141（自 #121 拆出的功能缺失部分）

## 修复

vertex 流式循环此前只处理 text/functionCall，从 google/model.rs 忠实移植五块（StreamPart 语义完全对齐，metadata 键保持 `googleVertex`）：

1. `groundingMetadata` → Source 事件 + 跨 chunk URL 去重（首见保留、title 首胜）
2. `urlContextMetadata` 累积
3. `executableCode`/`codeExecutionResult` → ToolCall + ToolResult（take() 关联）
4. server `toolCall`/`toolResponse` → provider-executed ToolCall/ToolResult
5. Finish provider_metadata 六键快照（promptFeedback/grounding/urlContext/safetyRatings/usageMetadata/finishMessage）

## 测试

vertex_model_test 新增 5 用例（codeExecutionResult 不丢、缺 output 默认空、server tool、grounding 去重、Finish metadata 全值断言——值断言经 Round 2 评审确认可捕获回归）。vertex 20 / google 80+40 / fmt+clippy 全绿。

## 评审

两轮独立评审：Round 1 忠实度逐行对照通过（2 低危），Round 1-① 已修复，Round 2 CLEAN。
**范围外跟进**：vertex 非流式路径（extract_content_from_candidate）同样缺 grounding/codeExecution——建议后续单独 issue。