### PR TITLE
fix(kotlin): make the nextPart timeout sentinel reachable (retryable contract)

### DIFF
--- a/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Model.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Model.kt
@@ -193,10 +193,15 @@ internal object FFI {
  * Frees the FFI-allocated [AimuxCError.message] and [AimuxCError.error_value]
  * exactly once each (fromC itself is a pure mapping and never frees).
  */
-internal fun throwFromC(err: AimuxCError): Nothing {
-    val ex = AimuxException.fromC(err)
+/** Free the FFI-allocated error strings, per the RFC-0028 D5 release contract. */
+internal fun consumeErrorStrings(err: AimuxCError) {
     FFI.lib.aimux_free_string(err.message)
     FFI.lib.aimux_free_string(err.error_value)
+}
+
+internal fun throwFromC(err: AimuxCError): Nothing {
+    val ex = AimuxException.fromC(err)
+    consumeErrorStrings(err)
     throw ex
 }
 

--- a/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Multimodal.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Multimodal.kt
@@ -285,7 +285,11 @@ class TranscriptionSession internal constructor(handle: Long) : Closeable {
      *                  indefinitely.
      * @return the part JSON.
      * @throws AimuxTranscriptionEndedException   the stream finished normally.
-     * @throws AimuxTranscriptionTimeoutException no part in time (retryable).
+     * @throws AimuxTranscriptionTimeoutException no part arrived in time —
+     *                  **retryable**: the session stays live, call again
+     *                  (RFC-0028: `AIMUX_E_TIMEOUT`). This is NOT an
+     *                  [AimuxException] / [TimeoutError]; catch the sentinel
+     *                  explicitly.
      * @throws AimuxException                     the stream failed.
      */
     fun nextPart(timeoutMs: Long): String {
@@ -298,9 +302,13 @@ class TranscriptionSession internal constructor(handle: Long) : Closeable {
             return s
         }
         if (err.code == AIMUX_E_TIMEOUT) {
-            // throwFromC consumes (frees) the message strings, then we swap
-            // in the retryable sentinel.
-            throwFromC(err)
+            // Consume (free) the FFI-allocated message strings exactly as
+            // throwFromC would (RFC-0028 D5: the timeout path must consume
+            // the error strings to avoid leaking) — but swap the generic
+            // TimeoutError for the retryable session sentinel: the session
+            // is still live and nextPart may be called again.
+            FFI.lib.aimux_free_string(err.message)
+            FFI.lib.aimux_free_string(err.error_value)
             throw AimuxTranscriptionTimeoutException()
         }
         if (err.code == AIMUX_OK) {
@@ -313,7 +321,13 @@ class TranscriptionSession internal constructor(handle: Long) : Closeable {
     class AimuxTranscriptionEndedException :
         RuntimeException("transcription stream ended")
 
-    /** No transcription part arrived within the timeout (retryable). */
+    /**
+     * No transcription part arrived within the timeout — **retryable**: the
+     * session stays live, call [nextPart] again (RFC-0028). Deliberately not
+     * an [AimuxException]: a timeout is not a stream failure, so generic
+     * engine-error handling must not swallow it — same shape as the Go / Java
+     * / Swift / Flutter sentinels.
+     */
     class AimuxTranscriptionTimeoutException :
         RuntimeException("transcription part timeout")
 }

--- a/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Multimodal.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/arcships/aimux/Multimodal.kt
@@ -307,8 +307,7 @@ class TranscriptionSession internal constructor(handle: Long) : Closeable {
             // the error strings to avoid leaking) — but swap the generic
             // TimeoutError for the retryable session sentinel: the session
             // is still live and nextPart may be called again.
-            FFI.lib.aimux_free_string(err.message)
-            FFI.lib.aimux_free_string(err.error_value)
+            consumeErrorStrings(err)
             throw AimuxTranscriptionTimeoutException()
         }
         if (err.code == AIMUX_OK) {

--- a/bindings/kotlin/src/test/kotlin/ai/arcships/aimux/TranscriptionSessionTest.kt
+++ b/bindings/kotlin/src/test/kotlin/ai/arcships/aimux/TranscriptionSessionTest.kt
@@ -1,0 +1,117 @@
+package ai.arcships.aimux
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TranscriptionSession nextPart tests (issue #116).
+//
+// The realtime transcription session streams over a WebSocket
+// (`ws://{base}/realtime?intent=transcription`). We point an OpenAI realtime
+// transcription model at a **stalling** TCP server — it accepts connections
+// but never completes the WebSocket handshake — so the session's connect
+// hangs and no part ever arrives. nextPart(timeoutMs) then hits its wait
+// bound and the FFI returns NULL + AIMUX_E_TIMEOUT, which the binding must
+// surface as the catchable retryable sentinel
+// TranscriptionSession.AimuxTranscriptionTimeoutException — not as the
+// generic TimeoutError (AimuxException), which a sentinel-catch could never
+// intercept.
+//
+// Requires the native library (same as the other E2E tests); no real network
+// access — everything stays on 127.0.0.1.
+// ─────────────────────────────────────────────────────────────────────────────
+
+class TranscriptionSessionTest {
+
+    /** Accepted-but-stalled sockets; held open so the WS handshake hangs. */
+    private val accepted = java.util.concurrent.CopyOnWriteArrayList<Socket>()
+
+    private lateinit var server: ServerSocket
+    private lateinit var acceptThread: Thread
+
+    @BeforeEach
+    fun setUp() {
+        server = ServerSocket(0, 8, InetAddress.getByName("127.0.0.1"))
+        acceptThread = Thread {
+            while (!server.isClosed) {
+                try {
+                    accepted.add(server.accept())
+                } catch (_: java.io.IOException) {
+                    return@Thread
+                }
+            }
+        }
+        acceptThread.isDaemon = true
+        acceptThread.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        runCatching { server.close() }
+        accepted.forEach { runCatching { it.close() } }
+    }
+
+    private val baseUrl: String
+        get() = "http://127.0.0.1:${server.localPort}"
+
+    @Test
+    fun `nextPart timeout throws the retryable AimuxTranscriptionTimeoutException and the session stays live`() {
+        TranscriptionModel.openai("sk-test", "gpt-realtime-whisper", baseUrl).use { model ->
+            model.startStream().use { session ->
+                // The WS handshake to the stalling server never completes, so
+                // no part arrives within the wait bound: the documented
+                // sentinel must be thrown (previously dead code — the
+                // throwFromC(TimeoutError) before it never returned).
+                val ex = catchSentinel { session.nextPart(150) }
+                assertThat(ex).isNotNull
+                assertThat(ex).isInstanceOf(RuntimeException::class.java)
+
+                // It must NOT be the generic engine TimeoutError: callers
+                // catching the sentinel per the KDoc need it to match, and a
+                // TimeoutError catch-all is not how "session still live,
+                // call again" is expressed (RFC-0028 AIMUX_E_TIMEOUT).
+                assertThat(ex).isNotInstanceOf(TimeoutError::class.java)
+                assertThat(ex).isNotInstanceOf(AimuxException::class.java)
+
+                // Retryable: after a timeout the session is still alive — a
+                // second pull again yields the sentinel, not a stream-failure
+                // or invalid-handle error.
+                val second = catchSentinel { session.nextPart(150) }
+                assertThat(second).isNotNull
+            }
+        }
+    }
+
+    @Test
+    fun `nextPart maps non-timeout failures to the typed AimuxException hierarchy`() {
+        // `whisper-1` is not a realtime model: do_stream rejects it before
+        // connecting (UnsupportedFunctionality), which surfaces on the first
+        // nextPart as a typed engine error — never as the timeout sentinel.
+        TranscriptionModel.openai("sk-test", "whisper-1", baseUrl).use { model ->
+            model.startStream().use { session ->
+                val ex = try {
+                    session.nextPart(2_000)
+                    null
+                } catch (e: AimuxException) {
+                    e
+                }
+                assertThat(ex).isInstanceOf(UnsupportedFunctionalityError::class.java)
+                assertThat(ex!!.code).isEqualTo(AIMUX_E_UNSUPPORTED_FUNCTIONALITY)
+            }
+        }
+    }
+
+    /** Run [block], returning the timeout sentinel if it was thrown. */
+    private inline fun catchSentinel(block: () -> Unit): TranscriptionSession.AimuxTranscriptionTimeoutException? =
+        try {
+            block()
+            null
+        } catch (e: TranscriptionSession.AimuxTranscriptionTimeoutException) {
+            e
+        }
+}

--- a/docs/api/kotlin.md
+++ b/docs/api/kotlin.md
@@ -142,6 +142,48 @@ println(result.usage?.inputTokens?.total)
 `TypedModel` is `Closeable` (use `use { }`); engine errors surface as
 typed `AimuxException` subclasses (see [Errors](#errors)).
 
+## Streaming Transcription (STT)
+
+Realtime transcription models (e.g. OpenAI `gpt-realtime-whisper`) support
+streaming sessions (RFC-0028): push audio chunks, then pull transcription
+parts. `TranscriptionModel.startStream` returns a `TranscriptionSession`
+(`Closeable`):
+
+```kotlin
+TranscriptionModel.openai("sk-...", "gpt-realtime-whisper").use { model ->
+    model.startStream().use { session ->
+        session.pushAudio(chunk)          // blocking (backpressure)
+        session.inputDone()               // end-of-audio (idempotent)
+        while (true) {
+            try {
+                val part = session.nextPart(timeoutMs = 500)
+                println(part)             // JSON TranscriptionStreamPart
+            } catch (e: TranscriptionSession.AimuxTranscriptionEndedException) {
+                break                     // stream finished normally
+            } catch (e: TranscriptionSession.AimuxTranscriptionTimeoutException) {
+                // No part within timeoutMs — retryable: the session stays
+                // live, just call nextPart again.
+            }
+        }
+    }
+}
+```
+
+`nextPart(timeoutMs)`: `timeoutMs > 0` waits at most that long; `0` polls
+immediately; `< 0` waits indefinitely. Outcomes:
+
+| Exception | Meaning |
+|-----------|---------|
+| returns a `String` | the next part (JSON `TranscriptionStreamPart`) |
+| `AimuxTranscriptionEndedException` | the stream finished normally |
+| `AimuxTranscriptionTimeoutException` | no part in time — **retryable**, the session stays live |
+| `AimuxException` subclasses | the stream failed (typed hierarchy) |
+
+The timeout sentinel is deliberately **not** an `AimuxException` / `TimeoutError`
+— a timeout is not a stream failure, so catch it explicitly (same shape as the
+Go / Java / Swift / Flutter bindings). `close()` aborts and releases the
+session (idempotent).
+
 ## Types
 
 `bindings/kotlin/src/main/kotlin/aimux/Types.kt` declares the typed model
@@ -154,7 +196,8 @@ surface: `Role`, `FinishReasonUnified`, `ReasoningEffort`, `TokenUsage`,
 
 ## Coverage
 
-Full multimodal surface — text generation, streaming, embedding, TTS, STT,
-image, video, rerank, search, and file upload (`Multimodal.kt` +
-`MultimodalTypes.kt`), verified by mock-server end-to-end tests (no real
-network). See the [coverage matrix](../API.md#feature-coverage).
+Full multimodal surface — text generation, streaming, embedding, TTS, STT
+(incl. streaming `TranscriptionSession`), image, video, rerank, search, and
+file upload (`Multimodal.kt` + `MultimodalTypes.kt`), verified by
+mock-server end-to-end tests (no real network). See the
+[coverage matrix](../API.md#feature-coverage).


### PR DESCRIPTION
Fixes #116（Round 4 审计 4e-H，经独立校验）

## 问题

`nextPart` 的超时分支先调 `throwFromC(err)`（返回 `Nothing` 必抛 `TimeoutError`），`AimuxTranscriptionTimeoutException` 永不可达——文档承诺的 retryable 哨兵契约破坏，用户无法判定"超时会话仍活可续调"（RFC-0028:197）。

## 修复

- 超时分支改为释放 FFI 错误串（与 throwFromC 相同的释放路径，抽为 `consumeErrorStrings` 辅助两处复用）后抛哨兵；无泄漏/双释放（native free 对 NULL 安全）
- 哨兵保持非 AimuxException/TimeoutError 类型，与 Go/Java/Swift/Flutter 的"超时非引擎错误"语义对齐；KDoc 补 retryable 说明
- `docs/api/kotlin.md` 新增 Streaming Transcription 章节（nextPart 语义 + 哨兵用法）

## 测试

新增 TranscriptionSessionTest（停滞 TCP 服务器诱导握手超时，确定性无时序运气）：超时抛哨兵且会话可续调、非超时错误仍映射 typed 层级；负对照验证过修复前必失败。gradle 58/58 通过（含新 2 项）。独立评审 CLEAN。