### PR TITLE
test: RFC-0028 transcription error paths (Rust + python + node)

### DIFF
--- a/aimux-providers/tests/openai_transcription_stream_test.rs
+++ b/aimux-providers/tests/openai_transcription_stream_test.rs
@@ -367,6 +367,121 @@ async fn stream_rejects_non_realtime_models() {
     }
 }
 
+/// A closed port (connection refused) — `do_stream` itself must fail with a
+/// clear connect error, not an in-stream error part (#118).
+#[tokio::test]
+async fn stream_connect_failure_errors() {
+    // Port 1 is never listening on loopback: TCP refuses immediately.
+    let config = OpenAIConfig::new("k").with_base_url("http://127.0.0.1:1".to_string());
+    let provider = OpenAIProvider::new(config);
+    let model = provider.transcription("gpt-realtime-whisper");
+
+    let err = model
+        .do_stream(stream_options(vec![AudioChunk::Binary(vec![1])], None))
+        .await
+        .unwrap_err();
+    match &err {
+        AiMuxError::ApiCall(d) => {
+            assert!(
+                d.message.contains("websocket connect failed"),
+                "connect failure must name the phase, got: {}",
+                d.message
+            );
+        }
+        other => panic!("expected ApiCall connect error, got {other:?}"),
+    }
+}
+
+/// Abort while the WS handshake is still in flight — `Aborted`, not a
+/// timeout and not an IO error (#118).
+#[tokio::test]
+async fn stream_abort_during_connect() {
+    // A black-hole server: accepts TCP but never completes the WS handshake,
+    // so `connect_async` pends and only the abort can end the connect phase.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        // Hold the socket open without writing the 101 response.
+        let _hold = stream;
+        std::future::pending::<()>().await;
+    });
+
+    let abort = AbortSignal::new();
+    let abort_clone = abort.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        abort.abort();
+    });
+
+    let model = realtime_model(&format!("http://127.0.0.1:{port}"));
+    let err = model
+        .do_stream(stream_options(
+            vec![AudioChunk::Binary(vec![1])],
+            Some(abort_clone),
+        ))
+        .await
+        .unwrap_err();
+    // Abort semantics exactly: distinct from timeout and from IO failure.
+    assert!(
+        matches!(err, AiMuxError::Aborted),
+        "connect-phase abort must surface Aborted, got {err:?}"
+    );
+    assert!(!matches!(&err, AiMuxError::Timeout(_)));
+    assert!(!matches!(&err, AiMuxError::ApiCall(_)));
+}
+
+/// `first_chunk_ms` doubles as the connect budget: against a black-hole
+/// server the CONNECT phase itself must time out with its own message —
+/// distinguishable from both the first-EVENT timeout and a connect IO
+/// failure (#118).
+#[tokio::test]
+async fn stream_connect_timeout_fires() {
+    // Accepts TCP but never answers the WS handshake — connect pends.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let _hold = stream;
+        std::future::pending::<()>().await;
+    });
+
+    let config = OpenAIConfig::new("k").with_base_url(format!("http://127.0.0.1:{port}"));
+    let provider = OpenAIProvider::new(config);
+    let model = provider.transcription("gpt-realtime-whisper");
+
+    let options = TranscriptionStreamOptions {
+        audio: Box::pin(futures::stream::iter(vec![AudioChunk::Binary(vec![1])])),
+        input_audio_format: InputAudioFormat {
+            format_type: "audio/pcm".to_string(),
+            rate: None,
+        },
+        provider_options: None,
+        abort_signal: None,
+        headers: None,
+        include_raw_chunks: false,
+        timeout: Some(aimux_core::options::TimeoutConfiguration {
+            first_chunk_ms: Some(300),
+            total_ms: None,
+            chunk_ms: None,
+        }),
+    };
+    let err = model.do_stream(options).await.unwrap_err();
+    match &err {
+        AiMuxError::Timeout(msg) => {
+            assert_eq!(
+                msg, "websocket connect timed out",
+                "connect timeout must carry its own message"
+            );
+            assert!(
+                !msg.contains("first websocket event"),
+                "must not be confused with the first-event timeout"
+            );
+        }
+        other => panic!("expected connect Timeout, got {other:?}"),
+    }
+}
+
 /// A silent server (accepts + reads session.update, then goes quiet) — the
 /// first-chunk timeout must fire (B1/timer coverage).
 #[tokio::test]
@@ -414,4 +529,237 @@ async fn stream_first_chunk_timeout_fires() {
         timed_out,
         "expected a Timeout error against a silent server; got: {parts:?}"
     );
+}
+
+/// The server emits a realtime `error` event — the provider message must
+/// propagate verbatim and readable (not wrapped in transport noise), and the
+/// session must terminate there (#118).
+#[tokio::test]
+async fn stream_server_error_event_propagates() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let _ = ws.next().await; // session.update
+        ws.send(Message::Text(
+            r#"{"type":"error","error":{"message":"insufficient quota for realtime transcription","type":"insufficient_quota"}}"#
+                .to_string(),
+        ))
+        .await
+        .unwrap();
+        // The client closes(1000) after surfacing the error.
+        let _ = ws.next().await;
+    });
+
+    let model = realtime_model(&format!("http://127.0.0.1:{port}"));
+    let result = model
+        .do_stream(stream_options(vec![AudioChunk::Binary(vec![1])], None))
+        .await
+        .unwrap();
+    let parts = collect(result).await;
+
+    // StreamStart then the terminal error — nothing after it.
+    assert_eq!(parts.len(), 2, "parts: {parts:?}");
+    assert!(matches!(
+        &parts[0],
+        Ok(TranscriptionStreamPart::StreamStart { .. })
+    ));
+    match &parts[1] {
+        Err(AiMuxError::ApiCall(d)) => {
+            assert_eq!(
+                d.message, "insufficient quota for realtime transcription",
+                "the provider's own message must propagate verbatim"
+            );
+            assert!(
+                !d.message.contains("websocket"),
+                "must not be wrapped in transport noise: {}",
+                d.message
+            );
+        }
+        other => panic!("expected ApiCall from server error event, got {other:?}"),
+    }
+}
+
+/// The server closes the socket (close frame with code + reason) after the
+/// handshake — the client must surface peer-closed semantics carrying the
+/// code/reason, not a bare EOF or a hang (#118).
+#[tokio::test]
+async fn stream_peer_close_before_completion() {
+    use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+    use tokio_tungstenite::tungstenite::protocol::frame::{CloseFrame as WsCloseFrame, Frame};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let _ = ws.next().await; // session.update
+        // Server-initiated abnormal close: code 1011 + a human reason.
+        let frame = WsCloseFrame {
+            code: CloseCode::Error,
+            reason: std::borrow::Cow::Borrowed("server overloaded"),
+        };
+        ws.send(Message::Frame(Frame::close(Some(frame))))
+            .await
+            .unwrap();
+        // Drain until the client side tears down.
+        let _ = ws.next().await;
+    });
+
+    let model = realtime_model(&format!("http://127.0.0.1:{port}"));
+    let result = model
+        .do_stream(stream_options(vec![AudioChunk::Binary(vec![1])], None))
+        .await
+        .unwrap();
+    let parts = collect(result).await;
+
+    assert_eq!(parts.len(), 2, "parts: {parts:?}");
+    match &parts[1] {
+        Err(AiMuxError::ApiCall(d)) => {
+            assert!(
+                d.message.contains("websocket closed by peer"),
+                "peer close must be identifiable, got: {}",
+                d.message
+            );
+            assert!(
+                d.message.contains("1011") && d.message.contains("server overloaded"),
+                "close code and reason must be carried: {}",
+                d.message
+            );
+        }
+        other => panic!("expected ApiCall peer-closed error, got {other:?}"),
+    }
+}
+
+/// chunk-idle timeout: the server delivers one event, then goes silent while
+/// holding the socket open — `chunk_ms` must trip with its own message,
+/// distinct from the total timeout (#118).
+#[tokio::test]
+async fn stream_chunk_idle_timeout_fires() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let _ = ws.next().await; // session.update
+        // One event so the stream is established and alive…
+        ws.send(Message::Text(r#"{"type":"session.created"}"#.to_string()))
+            .await
+            .unwrap();
+        // …then total silence while KEEPING the socket open (drain client
+        // messages for 2s, far past the 400ms idle window) — the idle timer,
+        // not a disconnect, must end the session.
+        while let Ok(Some(_)) = tokio::time::timeout(Duration::from_secs(2), ws.next()).await {}
+    });
+
+    let config = OpenAIConfig::new("k").with_base_url(format!("http://127.0.0.1:{port}"));
+    let provider = OpenAIProvider::new(config);
+    let model = provider.transcription("gpt-realtime-whisper");
+
+    let options = TranscriptionStreamOptions {
+        audio: Box::pin(futures::stream::iter(vec![AudioChunk::Binary(vec![1])])),
+        input_audio_format: InputAudioFormat {
+            format_type: "audio/pcm".to_string(),
+            rate: None,
+        },
+        provider_options: None,
+        abort_signal: None,
+        headers: None,
+        include_raw_chunks: false,
+        timeout: Some(aimux_core::options::TimeoutConfiguration {
+            first_chunk_ms: None,
+            total_ms: None,
+            chunk_ms: Some(400),
+        }),
+    };
+    let result = model.do_stream(options).await.unwrap();
+    let parts = collect(result).await;
+
+    assert_eq!(parts.len(), 2, "parts: {parts:?}");
+    match &parts[1] {
+        Err(AiMuxError::Timeout(msg)) => {
+            assert_eq!(
+                msg, "websocket chunk idle timeout",
+                "chunk-idle must fire with its own message"
+            );
+            assert!(
+                !msg.contains("total"),
+                "must not be confused with the total timeout"
+            );
+        }
+        other => panic!("expected chunk-idle Timeout, got {other:?}"),
+    }
+}
+
+/// total timeout: the server keeps events flowing (so chunk-idle never
+/// trips) — the hard connection deadline must still fire, with a message
+/// distinct from chunk-idle (#118).
+#[tokio::test]
+async fn stream_total_timeout_fires() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let _ = ws.next().await; // session.update
+        // Keep the stream visibly alive: a delta every 100ms for 2s — well
+        // inside the 300ms chunk window, well past the 700ms total deadline.
+        for i in 0..20 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let event = format!(
+                r#"{{"type":"conversation.item.input_audio_transcription.delta","item_id":"i","delta":"{i}"}}"#
+            );
+            if ws.send(Message::Text(event)).await.is_err() {
+                break; // client tore down after the total timeout
+            }
+        }
+    });
+
+    let config = OpenAIConfig::new("k").with_base_url(format!("http://127.0.0.1:{port}"));
+    let provider = OpenAIProvider::new(config);
+    let model = provider.transcription("gpt-realtime-whisper");
+
+    let options = TranscriptionStreamOptions {
+        audio: Box::pin(futures::stream::iter(vec![AudioChunk::Binary(vec![1])])),
+        input_audio_format: InputAudioFormat {
+            format_type: "audio/pcm".to_string(),
+            rate: None,
+        },
+        provider_options: None,
+        abort_signal: None,
+        headers: None,
+        include_raw_chunks: false,
+        timeout: Some(aimux_core::options::TimeoutConfiguration {
+            first_chunk_ms: None,
+            total_ms: Some(700),
+            chunk_ms: Some(300),
+        }),
+    };
+    let result = model.do_stream(options).await.unwrap();
+    let parts = collect(result).await;
+
+    // StreamStart + several deltas (alive stream) + the terminal total error.
+    let deltas = parts
+        .iter()
+        .filter(|p| matches!(p, Ok(TranscriptionStreamPart::TranscriptDelta { .. })))
+        .count();
+    assert!(
+        deltas >= 2,
+        "stream must be alive pre-timeout; parts: {parts:?}"
+    );
+    let last = parts.last().expect("must end with an error part");
+    match last {
+        Err(AiMuxError::Timeout(msg)) => {
+            assert_eq!(
+                msg, "websocket total timeout",
+                "total deadline must fire with its own message"
+            );
+            assert!(
+                !msg.contains("chunk"),
+                "must not be confused with the chunk-idle timeout"
+            );
+        }
+        other => panic!("expected total Timeout as the last part, got {other:?}"),
+    }
 }

--- a/bindings/node/__test__/transcription-session.test.ts
+++ b/bindings/node/__test__/transcription-session.test.ts
@@ -1,0 +1,190 @@
+// transcription-session.test.ts — RFC-0028 session behavior through the Node binding.
+//
+// Node twin of bindings/python/tests/test_transcription_session.py (issue #118
+// requires one binding-behavior group per language). Same three cases against
+// a fake realtime WebSocket server:
+//
+// - `nextPart(timeoutMs)` rejects with a `TimeoutError` whose retry verdict is
+//   *determinable* (`retryable` is false), and the session stays live.
+// - A server-sent realtime `error` event propagates verbatim as an `Err` part
+//   (the provider's own message, decidable retry verdict), then the channel
+//   ends normally.
+// - A connect failure rejects through the session channel on the first
+//   `nextPart` (the session API never silently hangs), and the following
+//   `nextPart` resolves `null` (channel closed).
+//
+// No `ws` dependency exists in this package, so the fake server hand-rolls the
+// HTTP Upgrade handshake (SHA-1 accept via node:crypto) and the server→client
+// text-frame codec (<126-byte payloads), mirroring the python side's raw-socket
+// fake. Client frames are masked and simply drained.
+
+import test from 'ava'
+import { createHash } from 'node:crypto'
+import { createServer, type Server } from 'node:http'
+import type { Duplex } from 'node:stream'
+
+import { openaiTranscription, startTranscriptionSession } from '../index.js'
+import { AimuxError, APICallError, TimeoutError } from '../src/index.ts'
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+
+// ── Minimal server-side WebSocket codec (frames < 126 bytes) ────────────────
+
+function textFrame(payload: string): Buffer {
+  const data = Buffer.from(payload, 'utf8')
+  if (data.length >= 126) throw new Error('extend the codec for long payloads')
+  return Buffer.concat([Buffer.from([0x81, data.length]), data])
+}
+
+interface ScriptStep {
+  /** Milliseconds after the handshake completes. */
+  delayMs: number
+  /** Text-frame payload (a realtime event JSON). */
+  json: string
+}
+
+interface FakeRealtimeServer {
+  server: Server
+  url: string
+}
+
+/**
+ * Fake realtime WS server playing `script` (relative to handshake completion).
+ * After the script it holds the socket open — the client drives the teardown,
+ * so a silent gap is never an accidental disconnect.
+ */
+function startFakeRealtimeServer(script: ScriptStep[]): Promise<FakeRealtimeServer> {
+  return new Promise((resolve) => {
+    const sockets = new Set<Duplex>()
+    const server = createServer()
+    server.on('upgrade', (req, socket) => {
+      const key = req.headers['sec-websocket-key']
+      if (typeof key !== 'string') {
+        socket.destroy()
+        return
+      }
+      const accept = createHash('sha1').update(key + WS_GUID).digest('base64')
+      socket.write(
+        'HTTP/1.1 101 Switching Protocols\r\n' +
+          'Upgrade: websocket\r\n' +
+          'Connection: Upgrade\r\n' +
+          `Sec-WebSocket-Accept: ${accept}\r\n` +
+          '\r\n',
+      )
+      sockets.add(socket)
+      // Drain client frames (masked; content irrelevant to the script).
+      socket.on('data', () => {})
+      socket.on('close', () => sockets.delete(socket))
+      socket.on('error', () => sockets.delete(socket))
+      for (const step of script) {
+        setTimeout(() => {
+          if (sockets.has(socket)) socket.write(textFrame(step.json))
+        }, step.delayMs)
+      }
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number }
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` })
+    })
+    ;(server as unknown as { __sockets: Set<Duplex> }).__sockets = sockets
+  })
+}
+
+function stopFakeRealtimeServer(server: Server): Promise<void> {
+  const sockets = (server as unknown as { __sockets: Set<Duplex> }).__sockets
+  for (const socket of sockets) socket.destroy()
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+// ── Realtime event fixtures (same shapes as the python twin) ────────────────
+
+const SESSION_CREATED = '{"type":"session.created"}'
+const ERROR_EVENT = JSON.stringify({
+  type: 'error',
+  error: { message: 'insufficient quota for realtime transcription' },
+})
+const DELTA_EVENT = JSON.stringify({
+  type: 'conversation.item.input_audio_transcription.delta',
+  item_id: 'i',
+  delta: 'he',
+})
+
+// Serial: the timing-sensitive scripts must not race each other.
+
+test.serial('nextPart timeout is determinable for retries and the session survives', async (t) => {
+  // session.created at 50ms (no part mapping), delta at 900ms: the 250ms
+  // nextPart window must time out in between and the session must still
+  // deliver the later delta.
+  const { server, url } = await startFakeRealtimeServer([
+    { delayMs: 50, json: SESSION_CREATED },
+    { delayMs: 900, json: DELTA_EVENT },
+  ])
+  t.teardown(() => stopFakeRealtimeServer(server))
+
+  const model = await openaiTranscription('k', 'gpt-realtime-whisper', url)
+  const session = await startTranscriptionSession(model, null)
+  try {
+    const first = JSON.parse((await session.nextPart(3000)) as string)
+    t.truthy('StreamStart' in first.Ok)
+
+    const thrown = await t.throwsAsync(session.nextPart(250))
+    const err = AimuxError.fromNative(thrown as Error)
+    // Timeout is a spent budget, not a transport failure — the retry verdict
+    // must be decidable (and be "don't retry").
+    t.true(err instanceof TimeoutError)
+    t.regex(err.message, /no transcription part within timeout/)
+    t.is(err.retryable, false)
+
+    // The session stayed live across the timeout.
+    const late = JSON.parse((await session.nextPart(5000)) as string)
+    t.truthy('TranscriptDelta' in late.Ok)
+  } finally {
+    session.close()
+  }
+})
+
+test.serial('server error event propagates verbatim as an Err part', async (t) => {
+  // NOTE on contract: in-stream errors (a server `error` event) are delivered
+  // as a serialized `{"Err": {...}}` *part* — only connect failures and
+  // nextPart timeouts reject (the session channel returns Err items).
+  const { server, url } = await startFakeRealtimeServer([
+    { delayMs: 50, json: ERROR_EVENT },
+  ])
+  t.teardown(() => stopFakeRealtimeServer(server))
+
+  const model = await openaiTranscription('k', 'gpt-realtime-whisper', url)
+  const session = await startTranscriptionSession(model, null)
+  try {
+    const first = JSON.parse((await session.nextPart(5000)) as string)
+    t.truthy('StreamStart' in first.Ok)
+
+    const errPart = JSON.parse((await session.nextPart(5000)) as string)
+    const api = errPart.Err.ApiCall
+    // The provider's own message, verbatim, not transport noise.
+    t.is(api.message, 'insufficient quota for realtime transcription')
+    // The retry verdict is decidable from the part.
+    t.is(api.is_retryable, false)
+    t.is(api.status_code, null)
+
+    // The error terminated the stream: the channel ends normally.
+    t.is(await session.nextPart(3000), null)
+  } finally {
+    session.close()
+  }
+})
+
+test.serial('connect failure surfaces through the channel', async (t) => {
+  // Port 1 on loopback: connection refused immediately.
+  const model = await openaiTranscription('k', 'gpt-realtime-whisper', 'http://127.0.0.1:1')
+  const session = await startTranscriptionSession(model, null)
+  try {
+    const thrown = await t.throwsAsync(session.nextPart(5000))
+    const err = AimuxError.fromNative(thrown as Error)
+    t.true(err instanceof APICallError)
+    t.regex(err.message, /websocket connect failed/)
+    // The session terminated with the connect error (channel closed).
+    t.is(await session.nextPart(3000), null)
+  } finally {
+    session.close()
+  }
+})

--- a/bindings/python/tests/test_transcription_session.py
+++ b/bindings/python/tests/test_transcription_session.py
@@ -1,0 +1,238 @@
+"""Behavioral tests for the RFC-0028 transcription session API (Python binding).
+
+Covers the session surface (`start_transcription_session` / `push_audio` /
+`next_part` / `close`) against a fake realtime WebSocket server:
+
+- `next_part(timeout_ms=...)` raises `APITimeoutError` that is *determinable*
+  for retries (`retryable` is False), and the session stays live afterwards.
+- A server-sent realtime `error` event propagates verbatim as `APICallError`.
+- A connect failure is delivered through the session channel as the first
+  `next_part` result (the session API never silently hangs).
+
+The fake WS server runs in a separate process (multiprocessing), like the
+HTTP mocks in test_e2e — PyO3 blocks the calling thread, so a threading-based
+server would deadlock. Handshake + frame codec are hand-rolled (no deps).
+"""
+
+import base64
+import hashlib
+import json
+import socket
+from multiprocessing import Process
+
+import pytest
+
+from aimux import (
+    APICallError,
+    APITimeoutError,
+    openai_transcription,
+    start_transcription_session,
+)
+
+WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+# ── Minimal server-side WebSocket codec (frames < 126 bytes) ────────────────
+
+def _text_frame(payload: str) -> bytes:
+    data = payload.encode()
+    assert len(data) < 126, "extend the codec for long payloads"
+    return bytes([0x81, len(data)]) + data
+
+
+def _close_frame(code: int, reason: str) -> bytes:
+    data = code.to_bytes(2, "big") + reason.encode()
+    return bytes([0x88, len(data)]) + data
+
+
+def _handshake(sock: socket.socket) -> None:
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise EOFError("client vanished mid-handshake")
+        buf += chunk
+    key = None
+    for line in buf.decode("latin-1").split("\r\n"):
+        if line.lower().startswith("sec-websocket-key:"):
+            key = line.split(":", 1)[1].strip()
+    if key is None:
+        raise ValueError("no Sec-WebSocket-Key in request")
+    accept = base64.b64encode(
+        hashlib.sha1((key + WS_GUID).encode()).digest()
+    ).decode()
+    sock.sendall(
+        (
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Accept: {accept}\r\n"
+            "\r\n"
+        ).encode()
+    )
+
+
+def _ws_server_proc(port, script):
+    """Fake realtime server. `script` is a list of (delay_ms, action) tuples
+    (relative to handshake completion); action is ("event", json_text) or
+    ("close", code, reason). Client frames are masked and simply drained.
+    Readiness probes (bare TCP connects from the test process) are skipped.
+    """
+    import time as _time
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", port))
+        listener.listen(1)
+        listener.settimeout(10)
+        while True:
+            conn, _ = listener.accept()
+            with conn:
+                try:
+                    _handshake(conn)
+                except (EOFError, ValueError, OSError):
+                    # Readiness probe (closes without speaking WS) — skip.
+                    continue
+                start = _time.monotonic()
+                for delay_ms, action in script:
+                    target = start + delay_ms / 1000
+                    # Drain client frames (masked; content irrelevant).
+                    while _time.monotonic() < target:
+                        conn.settimeout(max(0.01, target - _time.monotonic()))
+                        try:
+                            if not conn.recv(65536):
+                                return
+                        except socket.timeout:
+                            pass
+                    if action[0] == "event":
+                        conn.sendall(_text_frame(action[1]))
+                    elif action[0] == "close":
+                        conn.sendall(_close_frame(action[1], action[2]))
+                    else:
+                        raise ValueError(f"unknown action {action!r}")
+                # Hold the socket open after the script — the client drives
+                # the teardown — so a silent gap is never an accidental
+                # disconnect.
+                conn.settimeout(10)
+                try:
+                    while conn.recv(65536):
+                        pass
+                except OSError:
+                    pass
+                return
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class FakeRealtimeServer:
+    """Context manager: fake realtime WS server playing `script`."""
+
+    def __init__(self, script):
+        self.port = _find_free_port()
+        self.url = f"http://127.0.0.1:{self.port}"
+        self.proc = Process(target=_ws_server_proc, args=(self.port, script))
+
+    def __enter__(self):
+        self.proc.start()
+        # Wait for the listener to be ready (probe connects are skipped by
+        # the server), same gate as test_e2e.MockServer.
+        import time as _time
+
+        for _ in range(100):
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.connect(("127.0.0.1", self.port))
+                break
+            except ConnectionRefusedError:
+                _time.sleep(0.05)
+        return self
+
+    def __exit__(self, *args):
+        self.proc.terminate()
+        self.proc.join(timeout=2)
+
+
+SESSION_CREATED = '{"type":"session.created"}'
+ERROR_EVENT = (
+    '{"type":"error","error":'
+    '{"message":"insufficient quota for realtime transcription"}}'
+)
+DELTA_EVENT = (
+    '{"type":"conversation.item.input_audio_transcription.delta",'
+    '"item_id":"i","delta":"he"}'
+)
+
+
+class TestTranscriptionSessionBehavior:
+    """Session API semantics through the PyO3 channel."""
+
+    def test_next_part_timeout_is_determinable_and_session_survives(self):
+        # session.created at 50ms (no part mapping), delta at 900ms: the
+        # 250ms next_part window must time out in between and the session
+        # must still deliver the later delta.
+        with FakeRealtimeServer([(50, ("event", SESSION_CREATED)),
+                                 (900, ("event", DELTA_EVENT))]) as mock:
+            model = openai_transcription("k", "gpt-realtime-whisper", mock.url)
+            session = start_transcription_session(model, None)
+            try:
+                first = session.next_part(timeout_ms=3000)
+                assert first is not None
+                assert "StreamStart" in json.loads(first)["Ok"]
+
+                with pytest.raises(APITimeoutError) as ei:
+                    session.next_part(timeout_ms=250)
+                # Timeout is a spent budget, not a transport failure — the
+                # retry verdict must be decidable (and be "don't retry").
+                assert "no transcription part within timeout" in str(ei.value)
+                assert ei.value.retryable is False
+
+                # The session stayed live across the timeout.
+                late = session.next_part(timeout_ms=5000)
+                assert late is not None
+                assert "TranscriptDelta" in json.loads(late)["Ok"]
+            finally:
+                session.close()
+
+    def test_server_error_event_propagates_verbatim(self):
+        # NOTE on contract: in-stream errors (a server `error` event) are
+        # delivered by the Python driver as a serialized
+        # `{"Err": {...}}` *part* — only connect failures and next_part
+        # timeouts raise (see the FFI session, which returns Err items).
+        with FakeRealtimeServer([(50, ("event", ERROR_EVENT))]) as mock:
+            model = openai_transcription("k", "gpt-realtime-whisper", mock.url)
+            session = start_transcription_session(model, None)
+            try:
+                first = session.next_part(timeout_ms=5000)
+                assert first is not None
+                assert "StreamStart" in json.loads(first)["Ok"]
+
+                err_part = session.next_part(timeout_ms=5000)
+                assert err_part is not None
+                api = json.loads(err_part)["Err"]["ApiCall"]
+                # The provider's own message, verbatim, not transport noise.
+                assert (
+                    api["message"] == "insufficient quota for realtime transcription"
+                )
+                # The retry verdict is decidable from the part.
+                assert api["is_retryable"] is False
+                assert api["status_code"] is None
+
+                # The error terminated the stream: the channel ends normally.
+                assert session.next_part(timeout_ms=3000) is None
+            finally:
+                session.close()
+
+    def test_connect_failure_surfaces_through_the_channel(self):
+        # Port 1 on loopback: connection refused immediately.
+        model = openai_transcription("k", "gpt-realtime-whisper",
+                                     "http://127.0.0.1:1")
+        session = start_transcription_session(model, None)
+        with pytest.raises(APICallError) as ei:
+            session.next_part(timeout_ms=5000)
+        assert "websocket connect failed" in str(ei.value)
+        # The session terminated with the connect error (channel closed).
+        assert session.next_part(timeout_ms=3000) is None

--- a/bindings/python/tests/test_transcription_session.py
+++ b/bindings/python/tests/test_transcription_session.py
@@ -154,6 +154,10 @@ class FakeRealtimeServer:
     def __exit__(self, *args):
         self.proc.terminate()
         self.proc.join(timeout=2)
+        if self.proc.is_alive():
+            # SIGTERM missed the deadline — SIGKILL so tests never leak the
+            # fake-server process.
+            self.proc.kill()
 
 
 SESSION_CREATED = '{"type":"session.created"}'


### PR DESCRIPTION
Fixes #118

## 覆盖（对应 issue 的五条零覆盖路径）

**Rust**（openai_transcription_stream_test.rs，+7 用例，文件 13/13 过，llvm-cov 确认目标行全覆盖）：
- connect 失败 → ApiCall "websocket connect failed"；connect 超时 → 专属消息
- connect 期间 abort → Aborted（与超时/IO 错误区分）
- 服务端 error 事件 → provider 消息逐字传播且终止
- peer close → "closed by peer (code 1011: …)" 含 code/reason
- chunk-idle 与 total 超时各自触发、消息互斥

**绑定**（python 3 + node 3，两侧逐条对等）：
- nextPart 超时 → TimeoutError/APITimeoutError，retryable 可判定，会话存活可续调
- error 事件以 Err part 原样传播（message 逐字、is_retryable/status_code 可判）
- connect 失败 → 结构化 APICallError 冒出

node 侧手写 RFC 6455 握手+帧封装的假 WS 服务器（无 ws 依赖），t.teardown 全句柄清理，串行+时序裕量保证确定性。零生产代码改动。

## 评审

两轮独立评审：Round 1（断言强度/确定性/覆盖核对通过，2 整改项）→ 1451de5 落实 → Round 2 CLEAN。
**新发现已立 issue**：#145（python/node 流内错误以 {"Err":…} part 返回与 docstring/FFI 语义不一致，待维护者裁决方向）。

## 验证

Rust 13/13 + fmt/clippy -D warnings 干净；python 套件 73 过；node ava 3/3（均本地复跑）。