### PR TITLE
fix(utils): fallible shared HTTP client init

### DIFF
--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -131,38 +131,62 @@ fn global_proxy() -> ProxyConfig {
     GLOBAL_PROXY.get().cloned().unwrap_or_default()
 }
 
-/// 全局共享的 reqwest::Client（非流式，带 30s 整体超时）。
-static SHARED: OnceLock<Client> = OnceLock::new();
+/// 全局共享的 reqwest::Client（非流式，带 30s 整体超时）。构建失败（如 TLS
+/// 后端初始化失败、系统资源耗尽）以错误字符串粘性保存——之后每次访问都返回
+/// 同一错误，而非在 release `panic=abort` 下杀死宿主进程（issue #115）。
+static SHARED: OnceLock<Result<Client, String>> = OnceLock::new();
 
-/// 全局共享的流式 reqwest::Client（无整体超时）。
-static SHARED_STREAMING: OnceLock<Client> = OnceLock::new();
+/// 全局共享的流式 reqwest::Client（无整体超时）。同上的粘性错误语义。
+static SHARED_STREAMING: OnceLock<Result<Client, String>> = OnceLock::new();
+
+/// 把构建失败映射为可诊断错误（无 HTTP 交换，status 留空、不可重试）。
+fn client_init_error(source: &str) -> AiMuxError {
+    AiMuxError::ApiCall(ApiCallError {
+        message: format!("shared HTTP client initialization failed: {source}"),
+        ..Default::default()
+    })
+}
 
 /// 获取（或惰性初始化）共享 reqwest Client（带 30s 整体超时，非流式用）。
 ///
-/// 返回 `&'static Client`——provider **拿引用即用**，不持有、不 clone、不传参。
-pub fn shared_client() -> &'static Client {
-    SHARED.get_or_init(|| {
-        build_client(
-            PoolConfig::default(),
-            TimeoutConfig::default(),
-            global_proxy(),
-        )
-    })
+/// 成功返回 `&'static Client`——provider **拿引用即用**，不持有、不 clone、
+/// 不传参；首次构建失败（及之后的每次调用）返回 [`AiMuxError::ApiCall`]
+/// （message 带 "client initialization failed"，status 为 None）。
+pub fn shared_client() -> Result<&'static Client, AiMuxError> {
+    SHARED
+        .get_or_init(|| {
+            build_client(
+                PoolConfig::default(),
+                TimeoutConfig::default(),
+                global_proxy(),
+            )
+        })
+        .as_ref()
+        .map_err(|e| client_init_error(e))
 }
 
 /// 获取（或惰性初始化）流式共享 reqwest Client（无整体超时，流式用）。
-pub fn shared_streaming_client() -> &'static Client {
-    SHARED_STREAMING.get_or_init(|| {
-        build_client(
-            PoolConfig::default(),
-            TimeoutConfig::streaming(),
-            global_proxy(),
-        )
-    })
+pub fn shared_streaming_client() -> Result<&'static Client, AiMuxError> {
+    SHARED_STREAMING
+        .get_or_init(|| {
+            build_client(
+                PoolConfig::default(),
+                TimeoutConfig::streaming(),
+                global_proxy(),
+            )
+        })
+        .as_ref()
+        .map_err(|e| client_init_error(e))
 }
 
-/// 用给定配置构建一个 reqwest Client。
-fn build_client(pool: PoolConfig, timeout: TimeoutConfig, proxy: ProxyConfig) -> Client {
+/// 用给定配置构建一个 reqwest Client。构建失败返回错误字符串（reqwest 仅
+/// 提供 Display），由调用方决定映射——不再 `expect`（issue #115：受限环境
+/// 下 TLS/资源初始化失败不应在 panic=abort 产物中直接终止宿主进程）。
+fn build_client(
+    pool: PoolConfig,
+    timeout: TimeoutConfig,
+    proxy: ProxyConfig,
+) -> Result<Client, String> {
     let mut b = Client::builder()
         .connect_timeout(Duration::from_millis(timeout.connect_timeout_ms))
         .pool_max_idle_per_host(pool.max_idle_per_host)
@@ -174,7 +198,7 @@ fn build_client(pool: PoolConfig, timeout: TimeoutConfig, proxy: ProxyConfig) ->
         b = b.timeout(Duration::from_millis(timeout.response_timeout_ms));
     }
     b = apply_proxy(b, &proxy);
-    b.build().expect("shared reqwest Client build failed")
+    b.build().map_err(|e| e.to_string())
 }
 
 /// Apply proxy configuration to a reqwest client builder (by-value chain).
@@ -332,7 +356,7 @@ pub async fn send(
     error_structure: &ErrorStructure,
 ) -> Result<HttpResponse, AiMuxError> {
     auto_init_from_env();
-    let client = shared_client();
+    let client = shared_client()?;
     let started = Instant::now();
     let (resp, attempt) =
         send_with_retry_raw(client, &request, retry_config, error_structure).await?;
@@ -443,7 +467,7 @@ pub async fn send_stream(
     error_structure: &ErrorStructure,
 ) -> Result<HttpStreamResponse, AiMuxError> {
     auto_init_from_env();
-    let client = shared_streaming_client();
+    let client = shared_streaming_client()?;
     let started = Instant::now();
     let (resp, attempt) =
         send_with_retry_raw(client, &request, retry_config, error_structure).await?;
@@ -1546,21 +1570,40 @@ mod tests {
 
     #[test]
     fn shared_client_is_stable_handle() {
-        let a = shared_client();
-        let b = shared_client();
+        let a = shared_client().expect("client init in test env");
+        let b = shared_client().expect("client init in test env");
         assert!(std::ptr::eq(a, b));
     }
 
     #[test]
     fn shared_streaming_client_is_stable_handle() {
-        let a = shared_streaming_client();
-        let b = shared_streaming_client();
+        let a = shared_streaming_client().expect("client init in test env");
+        let b = shared_streaming_client().expect("client init in test env");
         assert!(std::ptr::eq(a, b));
     }
 
     #[test]
     fn shared_and_streaming_are_distinct() {
-        assert!(!std::ptr::eq(shared_client(), shared_streaming_client()));
+        let a = shared_client().expect("client init in test env");
+        let b = shared_streaming_client().expect("client init in test env");
+        assert!(!std::ptr::eq(a, b));
+    }
+
+    #[test]
+    fn client_init_error_is_non_retryable_api_call() {
+        // Shape lock for the #115 mapping: no HTTP exchange, no status, and a
+        // message that names the failure source (so users can tell an init
+        // failure apart from a provider-side API call).
+        let e = client_init_error("simulated TLS backend failure");
+        match e {
+            AiMuxError::ApiCall(call) => {
+                assert_eq!(call.status_code, None);
+                assert!(!call.is_retryable);
+                assert!(call.message.contains("client initialization failed"));
+                assert!(call.message.contains("simulated TLS backend failure"));
+            }
+            other => panic!("expected ApiCall, got {other:?}"),
+        }
     }
 
     #[test]

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -6,9 +6,9 @@
 //! provider 不持有 `Client`、不构造 `RequestBuilder`、不碰 `reqwest::Response`。
 //!
 //! 三个职责：
-//! - **连接池**：`shared_client()` / `shared_streaming_client()` 返回 `&'static
-//!   Client` 全局单例，TLS 会话与连接池全仓复用（RFC-0009 §4.1）。替代散落
-//!   各处的 `Client::new()`。
+//! - **连接池**：`shared_client()` / `shared_streaming_client()` 返回共享单例
+//!   （`Result<&'static Client, AiMuxError>`——构建失败粘性返回错误），TLS 会话
+//!   与连接池全仓复用（RFC-0009 §4.1）。替代散落各处的 `Client::new()`。
 //! - **超时**：非流式带 30s 整体超时；流式禁用整体超时（LLM 流式时长取决于
 //!   生成长度，固定超时会误杀长生成，RFC-0009 §4.3）。
 //! - **retry**：408/409/429/5xx 重试 + Full Jitter 退避（RFC-0009 §4.2）。retry 是本


### PR DESCRIPTION
Fixes #115（Round 4 审计 4d；mutex DoS 半边此前已被校验推翻并从 issue 移除）

## 修复

- `build_client` 不再 `.expect`：返回 `Result<Client, String>`
- 共享槽改存 `OnceLock<Result<Client, String>>`——首次构建失败粘性保留，后续访问返回同一错误
- `shared_client()` / `shared_streaming_client()` → `Result<&'static Client, AiMuxError>`：失败映射为**不可重试、无 status** 的 `ApiCall`，message 带 "client initialization failed: {源}"，与 provider 侧 API 调用错误可区分
- 调用方（send / send_stream / send_stream_timed）本就返回 Result，直接传播
- 注意：访问器是 crate root 再导出的公共 API，签名变更（0.x 期可接受）

## 测试

- 新增 shape-lock 用例：ApiCall / status None / is_retryable false / message 双段包含
- 既有 stable-handle / distinct 用例更新为 Result 形态
- utils 全套 153/0；workspace check + fmt + clippy -D warnings 干净

## 无法注入的路径说明

TLS/资源初始化失败在测试环境不可移植注入（reqwest build 失败条件依赖系统态）；粘性语义与错误形状由单元测试锁定，端到端失败路径留待真实受限环境验证。