### PR TITLE
chore: enable permanent clippy lint subset (5 lints, 1,521 fixes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,8 @@ ts-rs = { version = "12", features = ["serde-json-impl", "no-serde-warnings"] }
 # CI additionally promotes all warnings to errors.
 [workspace.lints.clippy]
 all = "warn"
+uninlined_format_args = "warn"
+must_use_candidate = "warn"
+redundant_closure_for_method_calls = "warn"
+return_self_not_must_use = "warn"
+missing_errors_doc = "warn"

--- a/aimux-core/src/composite.rs
+++ b/aimux-core/src/composite.rs
@@ -33,6 +33,7 @@ pub type ChildModel = Arc<dyn LanguageModel>;
 ///
 /// Each `TokenUsage` field is `Option<u32>`; `None` is treated as zero so a
 /// child that doesn't report a breakdown doesn't erase the other child's data.
+#[must_use]
 pub fn add_usage(a: Usage, b: &Usage) -> Usage {
     Usage {
         input_tokens: add_token_usage(a.input_tokens, &b.input_tokens),
@@ -64,6 +65,7 @@ fn opt_add(a: Option<u32>, b: Option<u32>) -> Option<u32> {
 /// Extract concatenated text from a `GenerateContent` list. Only `Text` parts
 /// are kept; `Reasoning` / `ToolCall` / `Source` / `File` are dropped (MoA
 /// thin version — references contribute analysis text, not tool calls).
+#[must_use]
 pub fn extract_text(content: &[GenerateContent]) -> String {
     let mut out = String::new();
     for c in content {
@@ -82,6 +84,7 @@ pub fn extract_text(content: &[GenerateContent]) -> String {
 /// the user message; when `None`, a default aggregation instruction is used.
 /// The reference list may be empty — in that case the aggregator just runs the
 /// original prompt (degenerates to a single-model call).
+#[must_use]
 pub fn build_aggregator_prompt(
     prompt: &LanguageModelPrompt,
     instructions: Option<&str>,

--- a/aimux-core/src/error.rs
+++ b/aimux-core/src/error.rs
@@ -70,7 +70,7 @@ impl std::fmt::Display for ApiCallError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match (self.status_code, self.message.is_empty()) {
             (Some(status), false) => write!(f, "HTTP {}: {}", status, self.message),
-            (Some(status), true) => write!(f, "HTTP {}", status),
+            (Some(status), true) => write!(f, "HTTP {status}"),
             (None, _) => f.write_str(&self.message),
         }
     }
@@ -172,6 +172,7 @@ impl AiMuxError {
     /// caller-side time budget — the AI SDK treats it as part of the abort
     /// family (`isAbortError` matches `"TimeoutError"`) and does not retry
     /// it; neither do we.
+    #[must_use]
     pub fn is_retryable(&self) -> bool {
         match self {
             AiMuxError::ApiCall(d) => d.is_retryable,
@@ -187,6 +188,7 @@ impl AiMuxError {
     ///
     /// Mirrors the header-consulting behaviour of
     /// `retryWithExponentialBackoffRespectingRetryHeaders` in the TS SDK.
+    #[must_use]
     pub fn retry_after_hint(&self) -> Option<i64> {
         match self {
             AiMuxError::ApiCall(d) => d.retry_after_ms.map(|ms| ms as i64),
@@ -206,6 +208,7 @@ impl AiMuxError {
     /// its only producer is the codex subscription channel's observed-401
     /// mapping (RFC-0018), which trades the carried fields for the "refresh
     /// helps" bit — the status is part of the variant's contract.
+    #[must_use]
     pub fn status_code(&self) -> Option<u16> {
         match self {
             AiMuxError::TokenExpired(_) => Some(401),

--- a/aimux-core/src/generate.rs
+++ b/aimux-core/src/generate.rs
@@ -84,6 +84,7 @@ pub struct GenerateTextOptions {
 
 impl GenerateTextOptions {
     /// Build the provider-facing `CallOptions` from user-facing options.
+    #[must_use]
     pub fn into_call_options(
         self,
         prompt: crate::language_model_message::LanguageModelPrompt,
@@ -222,6 +223,11 @@ impl std::fmt::Debug for StreamTextResult {
 
 impl StreamTextResult {
     /// Consume the stream and collect all text deltas into a single `String`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the stream's error part or transport error, propagated from the
+    /// underlying model stream.
     pub async fn text(self) -> Result<String, AiMuxError> {
         use futures::StreamExt;
         let mut result = String::new();
@@ -242,6 +248,11 @@ impl StreamTextResult {
     /// Unlike [`text`](Self::text) (which returns only the concatenated text),
     /// this collects reasoning, tool calls, sources, files, usage, finish
     /// reason, and builds `response_messages` for the next turn.
+    ///
+    /// # Errors
+    ///
+    /// Returns the stream's error part or transport error, propagated from the
+    /// underlying model stream.
     pub async fn consume(self) -> Result<StreamTextResultAggregated, AiMuxError> {
         use futures::StreamExt;
 
@@ -443,6 +454,11 @@ impl StreamTextResult {
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// Returns the error produced by the model's `do_generate` call (provider API,
+/// network, or abort).
 pub async fn generate_text(
     model: &dyn LanguageModel,
     prompt: impl Into<ModelPrompt>,
@@ -687,6 +703,11 @@ pub async fn generate_text(
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// Propagates `generate_text` failures; additionally returns `JsonParse` when
+/// the (repaired) model output is not valid JSON.
 pub async fn generate_object(
     model: &dyn LanguageModel,
     prompt: impl Into<ModelPrompt>,
@@ -763,6 +784,12 @@ fn extract_reasoning_signature(provider_metadata: Option<&Value>) -> Option<Stri
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// Returns the error produced by the model's `do_stream` call (provider API,
+/// network, or abort); errors raised mid-stream surface as `StreamPart::Error`
+/// items instead.
 pub async fn stream_text(
     model: &dyn LanguageModel,
     prompt: impl Into<ModelPrompt>,
@@ -936,6 +963,10 @@ use crate::openai_output::{
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// Propagates any error from the underlying `generate_text` call.
 pub async fn generate_text_as_openai(
     model: &dyn LanguageModel,
     prompt: impl Into<ModelPrompt>,
@@ -979,6 +1010,10 @@ pub async fn generate_text_as_openai(
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// Propagates any error from the underlying `stream_text` call.
 pub async fn stream_text_as_openai(
     model: &dyn LanguageModel,
     prompt: impl Into<ModelPrompt>,

--- a/aimux-core/src/json_repair.rs
+++ b/aimux-core/src/json_repair.rs
@@ -360,6 +360,7 @@ impl<'a> Fixer<'a> {
 /// Repairs a (possibly partial) JSON string into valid JSON.
 ///
 /// Port of `fixJson` in `packages/ai/src/util/fix-json.ts`.
+#[must_use]
 pub fn fix_json(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let mut fixer = Fixer::new(&chars);
@@ -399,6 +400,7 @@ pub struct ParsePartialJsonResult {
 /// The TS original is `async` only because its `safeParseJSON` helper is
 /// async; the Rust port is synchronous (it uses `serde_json::from_str` as the
 /// equivalent of `safeParseJSON`).
+#[must_use]
 pub fn parse_partial_json(json_text: Option<&str>) -> ParsePartialJsonResult {
     let Some(text) = json_text else {
         return ParsePartialJsonResult {

--- a/aimux-core/src/language_model_message.rs
+++ b/aimux-core/src/language_model_message.rs
@@ -33,6 +33,7 @@ pub type LanguageModelPrompt = Vec<LanguageModelPromptMessage>;
 ///
 /// - String content is normalized to a single `ContentPart::Text`.
 /// - If `instructions` is provided, it is prepended as a system message.
+#[must_use]
 pub fn convert_to_language_model_prompt(
     messages: &[crate::message::ModelMessage],
     instructions: Option<&str>,

--- a/aimux-core/src/math.rs
+++ b/aimux-core/src/math.rs
@@ -17,6 +17,11 @@ pub enum UtilError {
 /// Returns `Ok(0.0)` for empty vectors or when either vector is the zero
 /// vector, and `Err(UtilError::VectorLengthMismatch)` when the lengths differ
 /// (the TS version throws an `InvalidArgumentError`).
+///
+/// # Errors
+///
+/// Returns `UtilError::VectorLengthMismatch` when the two vectors have
+/// different lengths.
 pub fn cosine_similarity(vector1: &[f64], vector2: &[f64]) -> Result<f64, UtilError> {
     if vector1.len() != vector2.len() {
         return Err(UtilError::VectorLengthMismatch);

--- a/aimux-core/src/message.rs
+++ b/aimux-core/src/message.rs
@@ -65,6 +65,7 @@ impl ModelMessage {
     }
 
     /// User message with multi-part content.
+    #[must_use]
     pub fn user_parts(parts: Vec<ContentPart>) -> Self {
         Self {
             role: Role::User,

--- a/aimux-core/src/moa.rs
+++ b/aimux-core/src/moa.rs
@@ -647,7 +647,7 @@ mod tests {
             ..Default::default()
         };
         let ref_opts = moa.reference_options(&opts);
-        assert_eq!(ref_opts.tools.as_ref().map(|t| t.len()), Some(0));
+        assert_eq!(ref_opts.tools.as_ref().map(std::vec::Vec::len), Some(0));
         assert_eq!(ref_opts.tool_choice, ToolChoice::Required);
     }
 

--- a/aimux-core/src/model_id.rs
+++ b/aimux-core/src/model_id.rs
@@ -20,10 +20,12 @@ impl ModelId {
         }
     }
 
+    #[must_use]
     pub fn provider(&self) -> &str {
         &self.provider
     }
 
+    #[must_use]
     pub fn model(&self) -> &str {
         &self.model
     }

--- a/aimux-core/src/openai_output.rs
+++ b/aimux-core/src/openai_output.rs
@@ -224,6 +224,7 @@ impl Default for OpenAiStreamOptions {
 /// `model` is the model ID to place in the response (usually the model the
 /// caller invoked). If `result.response.model_id` is present it takes
 /// precedence.
+#[must_use]
 pub fn to_chat_completion(result: &GenerateResult, model: &str) -> ChatCompletion {
     let mut content_text = String::new();
     let mut reasoning_text = String::new();
@@ -297,9 +298,9 @@ pub fn to_chat_completion(result: &GenerateResult, model: &str) -> ChatCompletio
                     content_text.push('\n');
                 }
                 let prefix = if is_error.unwrap_or(false) {
-                    format!("[tool error: {}] ", tool_name)
+                    format!("[tool error: {tool_name}] ")
                 } else {
-                    format!("[tool result: {}] ", tool_name)
+                    format!("[tool result: {tool_name}] ")
                 };
                 content_text.push_str(&prefix);
                 content_text.push_str(&result.to_string());
@@ -399,6 +400,7 @@ impl std::fmt::Debug for ChatCompletionStream {
 /// the first chunk carries `delta.role = "assistant"`, content/reasoning/tool
 /// deltas follow, and the final chunk carries `finish_reason` (and `usage` if
 /// `include_usage` is set).
+#[must_use]
 pub fn to_chat_completion_stream(
     stream: Pin<Box<dyn Stream<Item = Result<StreamPart, AiMuxError>> + Send>>,
     model: &str,
@@ -745,7 +747,7 @@ impl StreamState {
                 if let Some(c) = self.ensure_started() {
                     chunks.push(c);
                 }
-                let text = format!("[tool result: {}] {}", tool_name, result);
+                let text = format!("[tool result: {tool_name}] {result}");
                 let mut chunk = self.base_chunk();
                 chunk.choices = vec![ChatCompletionChunkChoice {
                     index: 0,
@@ -834,7 +836,7 @@ impl StreamState {
         chunk.choices = vec![ChatCompletionChunkChoice {
             index: 0,
             delta: ChatCompletionDelta {
-                content: Some(format!("[error] {}", error)),
+                content: Some(format!("[error] {error}")),
                 ..Default::default()
             },
             finish_reason: None,
@@ -889,9 +891,10 @@ impl StreamState {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Encode a [`ChatCompletionChunk`] as an SSE `data:` line: `data: {json}\n\n`.
+#[must_use]
 pub fn encode_chunk_sse(chunk: &ChatCompletionChunk) -> String {
     let json = serde_json::to_string(chunk).unwrap_or_else(|_| "{}".to_string());
-    format!("data: {}\n\n", json)
+    format!("data: {json}\n\n")
 }
 
 /// The SSE terminator frame.
@@ -943,12 +946,12 @@ fn file_data_to_text(data: &FileData, media_type: &str) -> String {
         FileData::Url { url } => url.clone(),
         FileData::Data { data } => match data {
             crate::shared::FileBytes::Base64(b64) => {
-                format!("data:{};base64,{}", media_type, b64)
+                format!("data:{media_type};base64,{b64}")
             }
             crate::shared::FileBytes::Binary(bytes) => {
                 use base64::Engine;
                 let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
-                format!("data:{};base64,{}", media_type, b64)
+                format!("data:{media_type};base64,{b64}")
             }
         },
         FileData::Reference { reference } => serde_json::to_string(reference).unwrap_or_default(),
@@ -973,7 +976,7 @@ fn random_id() -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let count = COUNTER.fetch_add(1, Ordering::Relaxed);
     let ts = now_unix();
-    format!("{:012x}{:012x}", ts, count)
+    format!("{ts:012x}{count:012x}")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/aimux-core/src/options.rs
+++ b/aimux-core/src/options.rs
@@ -166,6 +166,7 @@ impl CallOptions {
     /// struct-update syntax (`CallOptions { tools: Some(..), ..CallOptions::new(prompt) }`)
     /// it avoids spelling out every `None` field, so adding a new optional
     /// field to `CallOptions` no longer requires batch-editing every test.
+    #[must_use]
     pub fn new(prompt: LanguageModelPrompt) -> Self {
         CallOptions {
             prompt,

--- a/aimux-core/src/provider.rs
+++ b/aimux-core/src/provider.rs
@@ -20,6 +20,11 @@ pub trait Provider: Send + Sync {
     /// Stability, Recraft) do not implement this and get the default
     /// `Unsupported` error. Only providers that actually expose a language
     /// model override it (issue M9).
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `AiMuxError::UnsupportedFunctionality`;
+    /// implementations return lookup/auth errors for model ids they cannot serve.
     fn language_model(&self, _model_id: &str) -> Result<Box<dyn LanguageModel>, AiMuxError> {
         Err(AiMuxError::UnsupportedFunctionality(format!(
             "provider '{}' does not provide language models",

--- a/aimux-core/src/recording.rs
+++ b/aimux-core/src/recording.rs
@@ -72,6 +72,7 @@ pub struct Recording {
 
 impl Recording {
     /// 以 call_id 开一条新录制(字段由事件流填充)。
+    #[must_use]
     pub fn new(call_id: &str, input: InputRecord, provider: ProviderRecord) -> Self {
         Self {
             schema: RECORDING_SCHEMA,
@@ -117,6 +118,7 @@ pub struct InputRecord {
 
 impl InputRecord {
     /// 从 CallOptions 提取输入侧快照(options 序列化后递归脱敏)。
+    #[must_use]
     pub fn from_call_options(options: &CallOptions) -> Self {
         let value = serde_json::to_value(options).unwrap_or(serde_json::Value::Null);
         Self {
@@ -145,6 +147,7 @@ pub struct ProviderRecord {
 
 impl ProviderRecord {
     /// 最小快照(provider/model_id)——`config_snapshot` 默认实现;cover 的部分放结构方法。
+    #[must_use]
     pub fn minimal(provider: &str, model_id: &str) -> Self {
         Self {
             provider: provider.to_string(),
@@ -232,18 +235,20 @@ pub struct OutcomeRecord {
 
 impl OutcomeRecord {
     /// 非流式成功。
+    #[must_use]
     pub fn from_generate_result(r: &crate::result::GenerateResult) -> Self {
         Self {
             status: OutcomeStatus::Success,
             finish_reason: serde_json::to_value(r.finish_reason.unified)
                 .ok()
-                .and_then(|v| v.as_str().map(|s| s.to_string())),
+                .and_then(|v| v.as_str().map(std::string::ToString::to_string)),
             error: None,
             usage: serde_json::to_value(&r.usage).ok(),
         }
     }
 
     /// 失败(非流式 / 流式立即失败)。
+    #[must_use]
     pub fn from_error(e: &crate::error::AiMuxError) -> Self {
         Self {
             status: OutcomeStatus::Error,
@@ -329,6 +334,12 @@ pub trait Recorder: Send + Sync {
     fn flush(&self);
     /// 显式 flush:同 [`flush`](Self::flush) 但把 writer 退出/超时等写失败作为
     /// `Result` 返回(A9/N4)。默认 `Ok(())`(无 I/O 的实现,如 `RingRecorder`)。
+    ///
+    /// # Errors
+    ///
+    /// The default (I/O-free) implementation always returns `Ok(())`;
+    /// file-backed implementations return `RecordingError` on write or timeout
+    /// failures.
     fn try_flush(&self) -> Result<(), RecordingError> {
         Ok(())
     }
@@ -364,6 +375,7 @@ pub fn init_recording(recorder: Option<Arc<dyn Recorder>>) {
 
 /// 从环境变量初始化:`AIMUX_RECORD=1` 开启,`AIMUX_RECORD_DIR` 指定目录(默认 `./recordings`)。
 /// 未开启返回 false(静默)。
+#[must_use]
 pub fn init_recording_from_env() -> bool {
     if std::env::var("AIMUX_RECORD").as_deref() != Ok("1") {
         return false;
@@ -419,6 +431,7 @@ pub fn new_call_id() -> String {
 /// 精确匹配 AWS Bedrock sigv4 真实写入的凭据头 `x-amz-security-token`(name 已
 /// lowercase 归一化,直接 `==` 比较即可)。其余 needle 维持 contains,以覆盖
 /// `x-goog-api-key`/`proxy-authorization` 等变体。
+#[must_use]
 pub fn is_sensitive_key(name: &str) -> bool {
     let n = name.to_ascii_lowercase();
     n == "cookie"
@@ -523,6 +536,11 @@ impl JsonlRecorder {
     /// 显式构造(`try_new`,A9/N4):`create_dir_all` / 打开文件 / 派生 writer
     /// 线程失败均返回 `Err`(替代原 `.ok()` 静默与 `.expect` panic)。
     /// 文件:`{dir}/recordings.jsonl`。
+    ///
+    /// # Errors
+    ///
+    /// Returns `RecordingError::Init` / `OpenFile` / `Spawn` when creating the
+    /// directory, opening `recordings.jsonl`, or spawning the writer thread fails.
     pub fn try_new(dir: impl Into<PathBuf>) -> Result<Self, RecordingError> {
         let dir = dir.into();
         std::fs::create_dir_all(&dir).map_err(|source| RecordingError::Init {
@@ -601,6 +619,12 @@ impl JsonlRecorder {
     /// 显式 flush(A9/N4):把 writer 退出 / 超时 / **写失败** 作为 `Result`
     /// 返回。阻塞至落盘——writer 端发生过的首个 I/O 错误会让本次(及后续)
     /// flush 返回 [`RecordingError::Write`],磁盘满不再静默。
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RecordingError::Write`] when the writer hit an I/O error,
+    /// `WriterGone` when the writer thread has exited, and `FlushTimeout` when the
+    /// flush deadline expires.
     pub fn try_flush(&self) -> Result<(), RecordingError> {
         let Some(tx) = &self.tx else {
             // The writer is gone, but it may have recorded a terminal write
@@ -854,7 +878,7 @@ fn try_finalize(
     call_id: &str,
     write_error: &Mutex<Option<String>>,
 ) {
-    if pending.get(call_id).map(|r| r.ready()).unwrap_or(false)
+    if pending.get(call_id).map(Recording::ready).unwrap_or(false)
         && let Some(mut rec) = pending.remove(call_id)
     {
         if !rec.exchanges.is_empty() || rec.transport_closed {
@@ -1080,10 +1104,12 @@ struct RingInner {
 
 impl RingRecorder {
     /// 默认容量(2048 条)。
+    #[must_use]
     pub fn new() -> Self {
         Self::with_capacity(DEFAULT_RING_CAPACITY)
     }
 
+    #[must_use]
     pub fn with_capacity(cap: usize) -> Self {
         assert!(cap > 0, "RingRecorder capacity must be > 0");
         Self {
@@ -1150,6 +1176,11 @@ impl RingRecorder {
 
     /// 导出全部已完成录制(每行一个 `Recording`)。pending 未完成条目不导出
     /// (但被 A3 淘汰的 pending 会以 incomplete 形式进 ring,可导出)。
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error (JSON serialization failures included) when
+    /// serializing a record or writing a line fails.
     pub fn export_jsonl(&self, w: &mut impl Write) -> std::io::Result<()> {
         let inner = self.inner.lock().unwrap();
         for rec in &inner.completed {
@@ -1210,7 +1241,7 @@ impl RingInner {
 
     /// 合并一个已 ready 的分片(barrier 满足则入 ring)。
     fn finalize(&mut self, call_id: &str) {
-        if self.pending.get(call_id).is_some_and(|r| r.ready())
+        if self.pending.get(call_id).is_some_and(Recording::ready)
             && let Some(mut rec) = self.pending.remove(call_id)
         {
             if !rec.exchanges.is_empty() || rec.transport_closed {
@@ -1396,7 +1427,7 @@ where
                             status: OutcomeStatus::Success,
                             finish_reason: serde_json::to_value(finish_reason.unified)
                                 .ok()
-                                .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                .and_then(|v| v.as_str().map(std::string::ToString::to_string)),
                             error: None,
                             usage: serde_json::to_value(usage).ok(),
                         };

--- a/aimux-core/src/replay.rs
+++ b/aimux-core/src/replay.rs
@@ -31,6 +31,11 @@ use crate::types::{FinishReason, FinishReasonUnified, ResponseMetadata, Usage};
 /// 可插拔匹配策略:从录制集中选一次命中。
 pub trait ReplayMatcher: Send + Sync {
     /// 按输入侧匹配;未命中返回明确错误。
+    ///
+    /// # Errors
+    ///
+    /// `Err` means no recording in the set matches the call; implementations
+    /// choose the matching strictness and error text.
     fn r#match<'a>(
         &self,
         options: &CallOptions,
@@ -290,7 +295,7 @@ fn match_score(options: &CallOptions, rec: &Recording) -> u64 {
             .input
             .options
             .get("temperature")
-            .and_then(|v| v.as_f64())
+            .and_then(serde_json::Value::as_f64)
     {
         score += 1;
     }
@@ -392,6 +397,11 @@ impl MockReplayModel {
 
     /// 从 jsonl 录制文件加载(每行一条 `Recording`)。
     /// provider/model_id 取首条录制;同一文件应同源录制。
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the file cannot be read or
+    /// contains no recordings, and `JsonParse` when a line is not valid JSON.
     pub fn from_jsonl(path: &str) -> Result<Self, AiMuxError> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| AiMuxError::InvalidArgument(format!("mock replay: {e}")))?;
@@ -415,6 +425,7 @@ impl MockReplayModel {
     }
 
     /// 已加载的录制(只读)。
+    #[must_use]
     pub fn recordings(&self) -> &[Recording] {
         &self.recordings
     }
@@ -475,7 +486,7 @@ fn parse_finish(raw: Option<&str>) -> (FinishReasonUnified, Option<String>) {
         Some("error") => FinishReasonUnified::Error,
         _ => FinishReasonUnified::Other,
     };
-    (unified, raw.map(|s| s.to_string()))
+    (unified, raw.map(std::string::ToString::to_string))
 }
 
 /// 从 `serde_json::Value` 取一个 u64 usage 计数并转 u32;溢出返回明确错误
@@ -605,7 +616,7 @@ fn rebuild_generate_result(rec: &Recording) -> Result<GenerateResult, AiMuxError
 
     let raw_finish = v["choices"][0]["finish_reason"]
         .as_str()
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
     let (unified, raw) = parse_finish(raw_finish.as_deref());
 
     Ok(GenerateResult {
@@ -615,9 +626,9 @@ fn rebuild_generate_result(rec: &Recording) -> Result<GenerateResult, AiMuxError
         warnings: Vec::new(),
         provider_metadata: None,
         response: ResponseMetadata {
-            id: v["id"].as_str().map(|s| s.to_string()),
+            id: v["id"].as_str().map(std::string::ToString::to_string),
             timestamp: None,
-            model_id: v["model"].as_str().map(|s| s.to_string()),
+            model_id: v["model"].as_str().map(std::string::ToString::to_string),
         },
         request_body: None,
         response_headers: None,
@@ -689,9 +700,9 @@ fn rebuild_stream_result(rec: &Recording) -> Result<StreamResult, AiMuxError> {
         {
             response_meta_emitted = true;
             parts.push(Ok(StreamPart::ResponseMetadata {
-                id: v["id"].as_str().map(|s| s.to_string()),
+                id: v["id"].as_str().map(std::string::ToString::to_string),
                 timestamp: None,
-                model_id: v["model"].as_str().map(|s| s.to_string()),
+                model_id: v["model"].as_str().map(std::string::ToString::to_string),
             }));
         }
 
@@ -764,7 +775,7 @@ fn rebuild_stream_result(rec: &Recording) -> Result<StreamResult, AiMuxError> {
                     for dtc in tcs {
                         let idx = dtc
                             .get("index")
-                            .and_then(|x| x.as_u64())
+                            .and_then(serde_json::Value::as_u64)
                             .map(|n| n as usize)
                             .unwrap_or(0);
                         let func = dtc.get("function").cloned().unwrap_or_default();
@@ -941,6 +952,12 @@ pub struct ReplayOverrides {
 ///     重发会用脱敏后的 `[REDACTED]` 值——需要真实头时用 `overrides` 或
 ///     重建 provider 时补充。
 ///   - 逐消息 `provider_options`(如 anthropic cacheControl)不参与重建。
+///
+/// # Errors
+///
+/// Returns `AiMuxError::JsonParse` when the recorded call options cannot be
+/// deserialized, and propagates any error from the re-sent `generate_text`
+/// call.
 pub async fn replay_with_model(
     recording: &Recording,
     model: &dyn LanguageModel,

--- a/aimux-core/src/router.rs
+++ b/aimux-core/src/router.rs
@@ -28,6 +28,11 @@ use crate::result::{GenerateResult, StreamResult};
 /// learned routing is intentionally out of core (see RFC-0021 §6.1).
 pub trait Router: Send + Sync {
     /// Choose a child-model index. `Err` means "no child can serve this prompt".
+    ///
+    /// # Errors
+    ///
+    /// `Err` means no child model can serve this prompt (all children filtered
+    /// out).
     fn route(
         &self,
         prompt: &LanguageModelPrompt,
@@ -65,6 +70,7 @@ pub struct WeightedRouter {
 impl WeightedRouter {
     /// Weights are positional — `weights[i]` applies to `models[i]`. Missing
     /// trailing weights default to `0.0`.
+    #[must_use]
     pub fn new(weights: Vec<f64>) -> Self {
         Self { weights }
     }
@@ -141,6 +147,7 @@ pub struct RouterModel {
 }
 
 impl RouterModel {
+    #[must_use]
     pub fn new(
         models: Vec<ChildModel>,
         router: Box<dyn Router>,

--- a/aimux-core/src/session.rs
+++ b/aimux-core/src/session.rs
@@ -101,11 +101,13 @@ struct Entry {
 
 impl SessionStore {
     /// A store with default bounds (256 sessions × 64 calls/session).
+    #[must_use]
     pub fn new() -> Self {
         Self::with_capacity(DEFAULT_MAX_SESSIONS, DEFAULT_MAX_CALLS_PER_SESSION)
     }
 
     /// A store with explicit bounds. Panics if either bound is zero.
+    #[must_use]
     pub fn with_capacity(max_sessions: usize, max_calls_per_session: usize) -> Self {
         assert!(
             max_sessions > 0 && max_calls_per_session > 0,
@@ -244,12 +246,14 @@ pub struct SessionInferer {
 
 impl SessionInferer {
     /// Inferer with the default capacity, enabled or disabled.
+    #[must_use]
     pub fn new(enabled: bool) -> Self {
         Self::with_capacity(enabled, DEFAULT_INFERER_CAPACITY)
     }
 
     /// Inferer with an explicit capacity (recent calls remembered). Panics if
     /// the capacity is zero.
+    #[must_use]
     pub fn with_capacity(enabled: bool, capacity: usize) -> Self {
         assert!(capacity > 0, "SessionInferer capacity must be positive");
         Self {
@@ -360,6 +364,7 @@ pub fn ensure_inferer_from_env() {
 ///
 /// Returns `(session_id, source)` or `None` when no explicit id is present
 /// and inference is off (or not registered).
+#[must_use]
 pub fn resolve_session_id(
     explicit: Option<&str>,
     prompt: &LanguageModelPrompt,
@@ -373,6 +378,7 @@ pub fn resolve_session_id(
 
 /// Query: all calls of a session (by step). Empty if the session is unknown
 /// or no store is registered.
+#[must_use]
 pub fn session_calls(session_id: &str) -> Vec<SessionCall> {
     session_store()
         .map(|s| s.session_calls(session_id))
@@ -380,6 +386,7 @@ pub fn session_calls(session_id: &str) -> Vec<SessionCall> {
 }
 
 /// Query: all known sessions.
+#[must_use]
 pub fn list_sessions() -> Vec<SessionView> {
     session_store()
         .map(|s| s.list_sessions())

--- a/aimux-core/src/shared.rs
+++ b/aimux-core/src/shared.rs
@@ -101,6 +101,7 @@ impl Default for AbortSignal {
 
 impl AbortSignal {
     /// Create a fresh, un-aborted signal.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             token: CancellationToken::new(),
@@ -114,6 +115,7 @@ impl AbortSignal {
     }
 
     /// Returns `true` once [`abort`](Self::abort) has been called.
+    #[must_use]
     pub fn is_aborted(&self) -> bool {
         self.token.is_cancelled()
     }
@@ -142,6 +144,7 @@ pub struct Size {
 
 impl Size {
     /// Create a size from explicit pixel dimensions.
+    #[must_use]
     pub const fn new(width: u32, height: u32) -> Self {
         Self { width, height }
     }
@@ -150,6 +153,11 @@ impl Size {
     ///
     /// Returns an error if the string is not in the expected format or either
     /// dimension is zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` describing the malformed input when it is not
+    /// `{width}x{height}` or either dimension is zero.
     pub fn parse(s: &str) -> Result<Self, String> {
         let (w, h) = parse_pair(s, 'x').ok_or_else(|| {
             format!("invalid size `{s}`: expected format `{{width}}x{{height}}` (e.g. `1024x1024`)")
@@ -161,11 +169,13 @@ impl Size {
     }
 
     /// Width in pixels.
+    #[must_use]
     pub const fn width(&self) -> u32 {
         self.width
     }
 
     /// Height in pixels.
+    #[must_use]
     pub const fn height(&self) -> u32 {
         self.height
     }
@@ -198,11 +208,17 @@ pub struct AspectRatio {
 
 impl AspectRatio {
     /// Create an aspect ratio from explicit components.
+    #[must_use]
     pub const fn new(width: u32, height: u32) -> Self {
         Self { width, height }
     }
 
     /// Parse a `{width}:{height}` string (e.g. `"16:9"`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` describing the malformed input when it is not
+    /// `{width}:{height}` or either value is zero.
     pub fn parse(s: &str) -> Result<Self, String> {
         let (w, h) = parse_pair(s, ':').ok_or_else(|| {
             format!(
@@ -218,11 +234,13 @@ impl AspectRatio {
     }
 
     /// Width component.
+    #[must_use]
     pub const fn width(&self) -> u32 {
         self.width
     }
 
     /// Height component.
+    #[must_use]
     pub const fn height(&self) -> u32 {
         self.height
     }

--- a/aimux-core/src/tool.rs
+++ b/aimux-core/src/tool.rs
@@ -47,12 +47,14 @@ impl FunctionTool {
     }
 
     /// Builder-style setter for `description`.
+    #[must_use]
     pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
     /// Builder-style setter for `strict`.
+    #[must_use]
     pub fn with_strict(mut self, strict: bool) -> Self {
         self.strict = Some(strict);
         self

--- a/aimux-core/src/trace/fingerprint.rs
+++ b/aimux-core/src/trace/fingerprint.rs
@@ -35,6 +35,7 @@ pub struct Chain {
 }
 
 impl Chain {
+    #[must_use]
     pub fn block_count(&self) -> u64 {
         self.block_hashes.len() as u64
     }
@@ -48,6 +49,7 @@ pub struct BlockChainFingerprint {
 }
 
 impl BlockChainFingerprint {
+    #[must_use]
     pub fn new(block_size: usize, scope_salt: u64) -> Self {
         debug_assert!(block_size >= 16, "block size too small");
         Self {
@@ -57,6 +59,7 @@ impl BlockChainFingerprint {
     }
 
     /// Compute the chain for a byte slice.
+    #[must_use]
     pub fn compute(&self, data: &[u8]) -> Chain {
         let n = data.len();
         let mut prev: u128 = 0;
@@ -89,6 +92,7 @@ impl BlockChainFingerprint {
 /// - Nested levels: only `request_id` / `requestId` (universal request ids;
 ///   `timestamp`/`nonce` may be legitimate business payload inside tool
 ///   arguments, so they are kept there).
+#[must_use]
 pub fn denoise(value: &Value) -> Value {
     denoise_at(value, 0)
 }

--- a/aimux-core/src/trace/hash.rs
+++ b/aimux-core/src/trace/hash.rs
@@ -9,6 +9,7 @@
 //! guarantee and NOT an HMAC.
 
 #[inline(always)]
+#[must_use]
 pub fn mix(mut x: u64) -> u64 {
     x ^= x >> 30;
     x = x.wrapping_mul(0xbf58_476d_1ce4_e5b9);
@@ -20,6 +21,7 @@ pub fn mix(mut x: u64) -> u64 {
 
 /// Keyed 64-bit hash: 8-byte word folding + rotation + finalization (length
 /// prefix included).
+#[must_use]
 pub fn hash64(key: u64, data: &[u8]) -> u64 {
     let mut h = key ^ 0x9e37_79b9_7f4a_7c15;
     let mut chunks = data.chunks_exact(8);
@@ -38,6 +40,7 @@ pub fn hash64(key: u64, data: &[u8]) -> u64 {
 }
 
 /// 128-bit keyed hash = two 64-bit hashes under two derived keys.
+#[must_use]
 pub fn hash128(key: u64, data: &[u8]) -> u128 {
     let k1 = mix(key ^ 0x243f_6a88_85a3_08d3);
     let k2 = mix(k1 ^ 0x1319_8a2e_0370_7344);
@@ -47,12 +50,14 @@ pub fn hash128(key: u64, data: &[u8]) -> u128 {
 /// Low 64 bits of a 128-bit hash (reverse-index key; collisions are rejected
 /// by full 128-bit chain verification).
 #[inline(always)]
+#[must_use]
 pub fn low64(h: u128) -> u64 {
     (h & 0xffff_ffff_ffff_ffff) as u64
 }
 
 /// Hex representation of a 128-bit hash (stable across JSON boundaries —
 /// `u128` cannot be serialized by serde_json).
+#[must_use]
 pub fn hex128(h: u128) -> String {
     format!("{h:032x}")
 }

--- a/aimux-core/src/trace/layer.rs
+++ b/aimux-core/src/trace/layer.rs
@@ -122,6 +122,7 @@ impl TraceLayer {
 
     /// Default session id (used when `CallOptions.session_id` is absent) +
     /// session key (32-byte HMAC-style salt for fingerprint scoping).
+    #[must_use]
     pub fn with_default_session(mut self, session_id: String, key: [u8; 32]) -> Self {
         self.default_session = Some(session_id);
         let mut acc = 0x9e37_79b9_7f4a_7c15u64;
@@ -137,12 +138,14 @@ impl TraceLayer {
     }
 
     /// Attach an auditor (default: none — verdict stays `None`).
+    #[must_use]
     pub fn with_auditor(mut self, auditor: Arc<dyn CacheAuditor>) -> Self {
         self.auditor = Some(auditor);
         self
     }
 
     /// Convenience: attach the built-in rules auditor in strict/shared mode.
+    #[must_use]
     pub fn with_rules_auditor(mut self, strict: bool) -> Self {
         self.strict = strict;
         self.auditor = Some(Arc::new(RuleAuditor));
@@ -338,12 +341,12 @@ impl RecordCtx {
                     .raw
                     .as_ref()
                     .and_then(|r| r.get("prompt_cache_hit_tokens"))
-                    .and_then(|v| v.as_u64()),
+                    .and_then(serde_json::Value::as_u64),
                 miss: usage
                     .raw
                     .as_ref()
                     .and_then(|r| r.get("prompt_cache_miss_tokens"))
-                    .and_then(|v| v.as_u64()),
+                    .and_then(serde_json::Value::as_u64),
                 usage_present,
                 response_cache_header_hit: self
                     .response_headers

--- a/aimux-core/src/trace/record.rs
+++ b/aimux-core/src/trace/record.rs
@@ -86,6 +86,7 @@ pub struct TraceRecord {
 impl TraceRecord {
     /// Reported hit rate — strictly `cache_read / input_total` (RFC-0015
     /// §5.2; never added to `cache_write`).
+    #[must_use]
     pub fn reported_hit_rate(&self) -> Option<f64> {
         match (self.usage.cache_read, self.usage.input_total) {
             (Some(r), Some(t)) if t > 0 => Some(r as f64 / t as f64),
@@ -94,6 +95,7 @@ impl TraceRecord {
     }
 
     /// Client-side upper bound hit rate — token estimate / input_total.
+    #[must_use]
     pub fn client_upper_bound_hit_rate(&self) -> Option<f64> {
         let t = self.usage.input_total?;
         if t == 0 {

--- a/aimux-core/src/trace/store.rs
+++ b/aimux-core/src/trace/store.rs
@@ -374,10 +374,12 @@ use std::sync::Arc as Arc2;
 
 impl RingTraceStore {
     /// A store with default bounds (2048 records, 512 per scope).
+    #[must_use]
     pub fn new() -> Self {
         Self::with_capacity(DEFAULT_RING_CAPACITY, DEFAULT_SCOPE_CAP)
     }
 
+    #[must_use]
     pub fn with_capacity(cap: usize, per_scope_cap: usize) -> Self {
         assert!(cap > 0 && per_scope_cap > 0);
         Self {
@@ -531,6 +533,11 @@ impl RingTraceStore {
     }
 
     /// Export all records as JSONL (one `TraceRecord` per line).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error (JSON serialization failures included) when
+    /// serializing a record or writing a line fails.
     pub fn export_jsonl(&self, w: &mut impl Write) -> std::io::Result<()> {
         let inner = self.inner.lock().unwrap();
         for rec in &inner.records {

--- a/aimux-core/src/trace/verdict.rs
+++ b/aimux-core/src/trace/verdict.rs
@@ -41,6 +41,7 @@ pub struct Verdict {
 }
 
 impl Verdict {
+    #[must_use]
     pub fn describe(&self) -> String {
         format!(
             "kind={:?} conf={:?} violated={:?} U={} claimed={} lcp={}B notes={:?}",
@@ -97,6 +98,7 @@ pub mod matrix {
     const HOUR: u64 = 3_600_000;
 
     /// OpenAI Chat/Responses, gpt-5.6+ (byte-exact, no quantization).
+    #[must_use]
     pub fn openai_56() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::OpenAi,
@@ -109,6 +111,7 @@ pub mod matrix {
     }
 
     /// OpenAI legacy (< 5.6) / compatible: 128-token quantization.
+    #[must_use]
     pub fn openai_legacy() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::OpenAi,
@@ -122,6 +125,7 @@ pub mod matrix {
 
     /// Azure: 128-token granularity across the board (differs from OpenAI
     /// 5.6+ byte-exact — matrix-verified).
+    #[must_use]
     pub fn azure() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::OpenAi,
@@ -134,6 +138,7 @@ pub mod matrix {
     }
 
     /// DeepSeek: 64-token granularity + equality invariant (hit+miss==prompt).
+    #[must_use]
     pub fn deepseek() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::DeepSeek,
@@ -146,6 +151,7 @@ pub mod matrix {
     }
 
     /// Mistral: 64-token granularity.
+    #[must_use]
     pub fn mistral() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::Generic,
@@ -159,6 +165,7 @@ pub mod matrix {
 
     /// Anthropic: qualitative (breakpoint + 20-block lookback), no strict
     /// quantization; conservative 1h TTL upper bound.
+    #[must_use]
     pub fn anthropic() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::Anthropic,
@@ -172,6 +179,7 @@ pub mod matrix {
 
     /// Bedrock Converse: usage-layer equality (total == input+read+write);
     /// quota burndown needs raw usage and is best-effort.
+    #[must_use]
     pub fn bedrock() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::Bedrock,
@@ -184,6 +192,7 @@ pub mod matrix {
     }
 
     /// Gemini/Vertex: 24h TTL, no quantization (24h conservative).
+    #[must_use]
     pub fn gemini() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::Gemini,
@@ -196,6 +205,7 @@ pub mod matrix {
     }
 
     /// vLLM: 16-token granularity, no wall-clock TTL (LRU).
+    #[must_use]
     pub fn vllm() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::Vllm,
@@ -209,6 +219,7 @@ pub mod matrix {
 
     /// Default for providers without a matrix entry (e.g. OpenRouter passthrough
     /// behaves like the upstream; start conservative).
+    #[must_use]
     pub fn generic() -> ProviderAuditSpec {
         ProviderAuditSpec {
             family: ProviderFamily::Generic,
@@ -221,6 +232,7 @@ pub mod matrix {
     }
 
     /// Resolve by provider name (best-effort; `None` → generic).
+    #[must_use]
     pub fn for_provider(provider: &str, model: &str) -> ProviderAuditSpec {
         let p = provider.to_ascii_lowercase();
         let m = model.to_ascii_lowercase();
@@ -324,6 +336,7 @@ pub struct JudgmentInput {
     pub session_stats: Option<SessionStats>,
 }
 
+#[must_use]
 pub fn quantize_down(x: u64, gran: Option<u64>) -> u64 {
     match gran {
         Some(g) if g > 0 => x / g * g,
@@ -362,6 +375,7 @@ fn is_byte_proxy_rule(rule: &str) -> bool {
 /// The built-in rule auditor (RFC-0015 §4.2: 8 hard invariants + diagnosis).
 ///
 /// Pure function over evidence; no state, no IO.
+#[must_use]
 pub fn judge(inp: &JudgmentInput) -> Verdict {
     let mut v = Verdict {
         kind: VerdictKind::Trusted,

--- a/aimux-core/src/types.rs
+++ b/aimux-core/src/types.rs
@@ -93,6 +93,7 @@ impl ReasoningEffort {
     ///
     /// Replaces the per-provider `is_custom_reasoning` helpers that were
     /// copy-pasted across openai/anthropic/xai convert modules (issue M10).
+    #[must_use]
     pub fn is_custom(self) -> bool {
         !matches!(self, ReasoningEffort::ProviderDefault)
     }
@@ -123,7 +124,7 @@ impl std::str::FromStr for ReasoningEffort {
             "medium" => Ok(ReasoningEffort::Medium),
             "high" => Ok(ReasoningEffort::High),
             "xhigh" => Ok(ReasoningEffort::Xhigh),
-            other => Err(format!("unknown reasoning effort: {}", other)),
+            other => Err(format!("unknown reasoning effort: {other}")),
         }
     }
 }

--- a/aimux-core/src/util.rs
+++ b/aimux-core/src/util.rs
@@ -1,4 +1,4 @@
-﻿//! Utility functions ported from the Vercel AI SDK TypeScript `util` package.
+//! Utility functions ported from the Vercel AI SDK TypeScript `util` package.
 //!
 //! This module is a facade — the implementations live in dedicated modules:
 //!
@@ -18,6 +18,7 @@ pub use crate::math::{UtilError, cosine_similarity};
 
 /// Current time as RFC 3339 UTC with millisecond precision
 /// (`2026-08-05T04:52:30.123Z`).
+#[must_use]
 pub fn rfc3339_now() -> String {
     let d = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/aimux-core/tests/cache_probe_test.rs
+++ b/aimux-core/tests/cache_probe_test.rs
@@ -482,7 +482,7 @@ impl LanguageModel for MockModel {
 
 fn model_opts(session_id: Option<&str>) -> CallOptions {
     let mut o = CallOptions::new(Default::default());
-    o.session_id = session_id.map(|s| s.to_string());
+    o.session_id = session_id.map(std::string::ToString::to_string);
     o
 }
 

--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -1587,11 +1587,11 @@ fn stream_text_as_openai_with_signal(
         .map(|v| OpenAiStreamOptions {
             include_usage: v
                 .get("include_usage")
-                .and_then(|b| b.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(true),
             include_reasoning: v
                 .get("include_reasoning")
-                .and_then(|b| b.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(true),
         })
         .unwrap_or_default();

--- a/aimux-provider-utils/src/api_key.rs
+++ b/aimux-provider-utils/src/api_key.rs
@@ -6,7 +6,11 @@ use aimux_core::AiMuxError;
 ///
 /// If `api_key` is `Some`, returns it directly.
 /// Otherwise reads from `environment_variable_name`.
-/// Returns `LoadAPIKeyError` if neither is available.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` when neither the `api_key` value nor
+/// the environment variable yields a key.
 pub fn load_api_key(
     api_key: Option<&str>,
     environment_variable_name: &str,
@@ -20,10 +24,9 @@ pub fn load_api_key(
 
     std::env::var(environment_variable_name).map_err(|_| {
         AiMuxError::InvalidArgument(format!(
-            "No API key found for {}. \
+            "No API key found for {description}. \
              Please provide it via the `api_key` parameter \
-             or set the `{}` environment variable.",
-            description, environment_variable_name
+             or set the `{environment_variable_name}` environment variable."
         ))
     })
 }

--- a/aimux-provider-utils/src/headers.rs
+++ b/aimux-provider-utils/src/headers.rs
@@ -9,6 +9,6 @@ const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 ///
 /// Pattern: `ai-sdk/<provider-name>/<version>`
 pub fn with_user_agent_suffix(headers: &mut HashMap<String, String>, provider_name: &str) {
-    let ua = format!("ai-sdk/{}/{}", provider_name, SDK_VERSION);
+    let ua = format!("ai-sdk/{provider_name}/{SDK_VERSION}");
     headers.insert("User-Agent".to_string(), ua);
 }

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -86,6 +86,7 @@ impl TimeoutConfig {
     ///
     /// LLM 流式时长取决于生成长度 / max_tokens，固定整体超时会误杀长
     /// 生成请求（RFC-0009 §4.3）。仅保留 connect timeout 守护建连阶段。
+    #[must_use]
     pub fn streaming() -> Self {
         Self {
             connect_timeout_ms: 10_000,
@@ -225,6 +226,7 @@ pub enum HttpMethod {
 
 impl HttpMethod {
     /// 方法名（小写），用于日志。
+    #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
             HttpMethod::Get => "get",
@@ -326,6 +328,12 @@ pub struct HttpStreamResponse {
 /// - 408/409/429/5xx 可重试；其他 4xx **立即返回不重试**
 ///
 /// 退避用 Full Jitter（`delay ∈ [0, base)`），防并发 429 惊群。
+///
+/// # Errors
+///
+/// Returns `ApiCall` for transport failures and non-2xx responses (after the
+/// configured retries), `Aborted` when the abort signal fires, and `Timeout`
+/// when reading the body exceeds the 30s overall deadline.
 pub async fn send(
     request: HttpRequest,
     retry_config: RetryConfig,
@@ -437,6 +445,12 @@ pub async fn send(
 ///
 /// retry 仅覆盖**建连阶段**——`.send()` 返回 200 后立即返回字节流，流中途
 /// 出错不重试（已吐 token 后重试会重复内容，RFC-0009 §5）。
+///
+/// # Errors
+///
+/// Returns `ApiCall` when establishing the connection (including retries)
+/// fails; transport errors on the byte stream surface as `Err` items in the
+/// returned stream.
 pub async fn send_stream(
     request: HttpRequest,
     retry_config: RetryConfig,
@@ -666,6 +680,12 @@ impl Drop for ObservedByteStream {
 /// The timeout covers the **entire** call: connect, response body, and any
 /// retry backoff. On expiry the call fails with `AiMuxError::Timeout` (no
 /// retry is attempted after the deadline).
+///
+/// # Errors
+///
+/// Returns `InvalidArgument` for a malformed timeout, `Timeout` when the
+/// total deadline expires, and the inner retry loop's `ApiCall`/`Aborted`
+/// errors.
 pub async fn send_timed(
     request: HttpRequest,
     retry_config: RetryConfig,
@@ -690,6 +710,12 @@ pub async fn send_timed(
 /// wrapped so that `first_chunk_ms` / `chunk_ms` / the remaining `total_ms`
 /// are enforced on the chunks themselves. Expired limits surface as
 /// `AiMuxError::Timeout` items in the stream (after which the stream ends).
+///
+/// # Errors
+///
+/// Returns `InvalidArgument` for a malformed timeout and `Timeout` when the
+/// connect-phase deadline expires; expired chunk limits surface as `Timeout`
+/// items inside the returned stream.
 pub async fn send_stream_timed(
     request: HttpRequest,
     retry_config: RetryConfig,
@@ -976,6 +1002,11 @@ impl Stream for TimeoutBodyStream {
 /// - cancellation is exactly [`AiMuxError::Aborted`].
 ///
 /// Shared by the retry backoff here and by provider polling waits.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::Aborted` when the cancellation signal fires before or
+/// during the sleep.
 pub async fn sleep_or_abort(
     duration: Duration,
     signal: Option<&AbortSignal>,

--- a/aimux-provider-utils/src/http.rs
+++ b/aimux-provider-utils/src/http.rs
@@ -153,6 +153,12 @@ fn client_init_error(source: &str) -> AiMuxError {
 /// 成功返回 `&'static Client`——provider **拿引用即用**，不持有、不 clone、
 /// 不传参；首次构建失败（及之后的每次调用）返回 [`AiMuxError::ApiCall`]
 /// （message 带 "client initialization failed"，status 为 None）。
+///
+/// # Errors
+///
+/// Returns a sticky, non-retryable [`AiMuxError::ApiCall`] (no HTTP status)
+/// when the shared client could not be built, e.g. TLS backend or resource
+/// initialization failures in restricted environments.
 pub fn shared_client() -> Result<&'static Client, AiMuxError> {
     SHARED
         .get_or_init(|| {
@@ -167,6 +173,11 @@ pub fn shared_client() -> Result<&'static Client, AiMuxError> {
 }
 
 /// 获取（或惰性初始化）流式共享 reqwest Client（无整体超时，流式用）。
+///
+/// # Errors
+///
+/// Same sticky-failure semantics as [`shared_client`]: a non-retryable
+/// [`AiMuxError::ApiCall`] without an HTTP status when the build failed.
 pub fn shared_streaming_client() -> Result<&'static Client, AiMuxError> {
     SHARED_STREAMING
         .get_or_init(|| {

--- a/aimux-provider-utils/src/logging.rs
+++ b/aimux-provider-utils/src/logging.rs
@@ -78,6 +78,7 @@ pub fn auto_init_from_env() {
 }
 
 /// Whether request/response body trace logging is enabled (`AIMUX_LOG_BODY=1`).
+#[must_use]
 pub fn body_logging_enabled() -> bool {
     std::env::var("AIMUX_LOG_BODY")
         .map(|v| v == "1")
@@ -119,6 +120,7 @@ fn truncate(body: &str) -> &str {
 /// contains `authorization` / `api-key` / `apikey` / `key` / `token` have
 /// their (string) values replaced with `***`. Non-JSON bodies pass through
 /// unchanged. Always truncated to [`BODY_LOG_LIMIT`].
+#[must_use]
 pub fn redact_body(body: &str) -> String {
     let truncated = truncate(body);
     match serde_json::from_str::<serde_json::Value>(truncated) {

--- a/aimux-provider-utils/src/multipart.rs
+++ b/aimux-provider-utils/src/multipart.rs
@@ -18,6 +18,7 @@ pub struct MultipartForm {
 
 impl MultipartForm {
     /// Create a new multipart form with a unique boundary.
+    #[must_use]
     pub fn new() -> Self {
         let boundary = format!(
             "----formdata-aimux-{}",
@@ -33,6 +34,11 @@ impl MultipartForm {
     ///
     /// `name` is validated before it is interpolated into the MIME headers; see
     /// `validate_multipart_param` for the rules.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `name` fails MIME-header
+    /// validation (see `validate_multipart_param`).
     pub fn text(&mut self, name: &str, value: &str) -> Result<&mut Self, AiMuxError> {
         validate_multipart_param(name, "name")?;
         self.parts
@@ -50,6 +56,11 @@ impl MultipartForm {
     /// `name`, `filename` and `media_type` are validated before they are
     /// interpolated into the MIME headers; see `validate_multipart_param` for
     /// the rules.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `name`, `filename`, or
+    /// `media_type` fails MIME-header validation.
     pub fn file(
         &mut self,
         name: &str,
@@ -75,6 +86,7 @@ impl MultipartForm {
 
     /// Finalize the body, returning the raw bytes and the content-type header
     /// value.
+    #[must_use]
     pub fn finish(mut self) -> (Vec<u8>, String) {
         self.parts
             .extend_from_slice(format!("--{}--\r\n", self.boundary).as_bytes());
@@ -90,6 +102,7 @@ impl Default for MultipartForm {
 }
 
 /// Convert a media type (e.g. `"audio/wav"`) to a file extension (e.g. `"wav"`).
+#[must_use]
 pub fn media_type_to_extension(media_type: &str) -> String {
     media_type
         .strip_prefix("audio/")

--- a/aimux-provider-utils/src/response.rs
+++ b/aimux-provider-utils/src/response.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_ERROR_STRUCTURE: ErrorStructure = ErrorStructure {
 /// caller the way the AI SDK reads `APICallError.statusCode`.
 /// Retryability (408/409/429/5xx) is stored in `is_retryable` at
 /// construction, as the AI SDK stores `APICallError.isRetryable`.
+#[must_use]
 pub fn parse_provider_error(status: u16, body: &str, structure: &ErrorStructure) -> AiMuxError {
     // Empty: `ApiCallError`'s Display shows the status on its own.
     let mut message = String::new();
@@ -82,6 +83,7 @@ pub fn parse_provider_error(status: u16, body: &str, structure: &ErrorStructure)
 /// `APICallError.statusCode`. The retry hint is stored only when the provider
 /// actually sent one (`retry-after-ms`/`retry-after`) — no fallback is
 /// fabricated; a hint-less 429 gets the retry loop's exponential backoff.
+#[must_use]
 pub fn error_for_status(
     status: u16,
     provider_code: Option<String>,
@@ -115,32 +117,33 @@ pub fn error_for_status(
 /// `provider_code`. Reading a string `code` as a status was the M3 bug, and so
 /// was defaulting a missing one to 500 — a mid-stream error arrives on a
 /// *successful* response, so "no status" is the truth.
+#[must_use]
 pub fn parse_stream_error(err_obj: &serde_json::Value) -> AiMuxError {
     let str_field = |k: &str| {
         err_obj
             .get(k)
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
     };
     let message = str_field("message").unwrap_or_else(|| "Unknown stream error".to_string());
     let code = err_obj.get("code");
     let status = code
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .filter(|c| (100..=599).contains(c))
         .map(|c| c as u16);
     let provider_code = code
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
         .or_else(|| str_field("type"));
     // Retry hint from the payload when the provider sends one (ms wins over
     // whole seconds); absent means absent — nothing is fabricated.
     let retry_after_ms = err_obj
         .get("retry_after_ms")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .or_else(|| {
             err_obj
                 .get("retry_after")
-                .and_then(|v| v.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .map(|s| s * 1000)
         });
 

--- a/aimux-provider-utils/src/retry.rs
+++ b/aimux-provider-utils/src/retry.rs
@@ -1,4 +1,4 @@
-﻿//! Retry with exponential backoff.
+//! Retry with exponential backoff.
 //!
 //! Two flavours are provided:
 //! - [`retry_with_exponential_backoff`] — a plain exponential-backoff retry
@@ -23,6 +23,11 @@ use rand::Rng;
 /// - `max_retries`: maximum number of retry attempts (0 = no retry).
 /// - `initial_delay`: initial delay between retries (doubled each time).
 /// - Only retries on `AiMuxError::is_retryable()` errors.
+///
+/// # Errors
+///
+/// Returns the operation's last error once retries are exhausted (or
+/// immediately for non-retryable errors).
 pub async fn retry_with_exponential_backoff<F, T>(
     max_retries: u32,
     initial_delay: Duration,
@@ -83,6 +88,11 @@ impl Default for RetryConfig {
 /// Only retries on `AiMuxError::is_retryable()` errors. The delay for each
 /// retry is chosen by [`get_retry_delay_ms`], fed from
 /// [`AiMuxError::retry_after_hint`].
+///
+/// # Errors
+///
+/// Returns the operation's last error once retries are exhausted (or
+/// immediately for non-retryable errors).
 pub async fn retry_with_exponential_backoff_respecting_retry_headers<F, T>(
     config: RetryConfig,
     mut f: F,
@@ -127,6 +137,7 @@ where
 /// used when it is present, non-negative, and either shorter than 60 seconds
 /// or shorter than the exponential backoff would be. Otherwise the exponential
 /// backoff delay is used.
+#[must_use]
 pub fn get_retry_delay_ms(hint: Option<i64>, exponential_delay_ms: i64) -> i64 {
     match hint {
         // Use the hint when it is non-negative AND (shorter than 60s OR shorter
@@ -165,6 +176,7 @@ pub fn get_retry_delay_ms_with_jitter(
 /// `now` is the reference instant used to compute the delay for HTTP-date
 /// values. Returns `None` when no header is present or none parse to a usable
 /// value. Mirrors the TS `getRetryDelayInMs` header-reading branch.
+#[must_use]
 pub fn parse_retry_after(
     retry_after_ms_header: Option<&str>,
     retry_after_header: Option<&str>,

--- a/aimux-provider-utils/src/url.rs
+++ b/aimux-provider-utils/src/url.rs
@@ -1,6 +1,7 @@
-﻿//! URL utilities.
+//! URL utilities.
 
 /// Remove a trailing slash from a URL string.
+#[must_use]
 pub fn without_trailing_slash(url: &str) -> String {
     if let Some(stripped) = url.strip_suffix('/') {
         stripped.to_string()
@@ -24,6 +25,11 @@ pub fn without_trailing_slash_opt(url: Option<&str>) -> Option<String> {
 ///
 /// Userinfo (username/password) is permitted but not required — some
 /// self-hosted endpoints use basic-auth credentials embedded in the URL.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` when the URL cannot be parsed, the
+/// scheme is not `http`/`https`, or the host is missing.
 pub fn validate_base_url(url: &str) -> Result<String, aimux_core::AiMuxError> {
     if url.is_empty() {
         return Err(aimux_core::AiMuxError::InvalidArgument(
@@ -38,7 +44,7 @@ pub fn validate_base_url(url: &str) -> Result<String, aimux_core::AiMuxError> {
             parsed.scheme()
         )));
     }
-    if parsed.host_str().map(|h| h.is_empty()).unwrap_or(true) {
+    if parsed.host_str().map(str::is_empty).unwrap_or(true) {
         return Err(aimux_core::AiMuxError::InvalidArgument(
             "base URL must have a host".to_string(),
         ));

--- a/aimux-provider-utils/src/ws.rs
+++ b/aimux-provider-utils/src/ws.rs
@@ -108,6 +108,12 @@ async fn connect_with_timeout(
 
 /// Open a WebSocket connection. The connect phase races abort and the
 /// `first_chunk_ms` timeout (which doubles as the connect timeout).
+///
+/// # Errors
+///
+/// Returns `InvalidArgument` for a bad URL or header value, `Aborted` when
+/// cancellation wins the connect race, and `Timeout` when `first_chunk_ms`
+/// expires while connecting.
 pub async fn ws_connect(req: &WebSocketRequest) -> Result<WsConnection, AiMuxError> {
     let mut http_req = req
         .url
@@ -181,6 +187,12 @@ pub async fn ws_connect(req: &WebSocketRequest) -> Result<WsConnection, AiMuxErr
 impl WsConnection {
     /// Send a text message. Aborted / timed out sends surface as errors; the
     /// pending-while-buffer-full behavior is the socket-level backpressure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Aborted` on cancellation, `Timeout` when the send exceeds the
+    /// total timeout, and a WebSocket error mapped to `ApiCall` when the socket
+    /// write fails.
     pub async fn send_text(&mut self, text: &str) -> Result<(), AiMuxError> {
         tokio::select! {
             biased;
@@ -195,6 +207,12 @@ impl WsConnection {
     }
 
     /// Send a binary message (same abort/timeout semantics as `send_text`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Aborted` on cancellation, `Timeout` when the send exceeds the
+    /// total timeout, and a WebSocket error mapped to `ApiCall` when the socket
+    /// write fails.
     pub async fn send_binary(&mut self, bytes: &[u8]) -> Result<(), AiMuxError> {
         tokio::select! {
             biased;

--- a/aimux-provider-utils/tests/http_recording_test.rs
+++ b/aimux-provider-utils/tests/http_recording_test.rs
@@ -44,7 +44,7 @@ fn json_post(url: &str, call_id: Option<&str>) -> HttpRequest {
         ],
         body: HttpBody::Json(serde_json::json!({"q": "hi"})),
         abort_signal: None,
-        call_id: call_id.map(|s| s.to_string()),
+        call_id: call_id.map(std::string::ToString::to_string),
         recording_context,
     }
 }

--- a/aimux-providers/src/anthropic/cache_control.rs
+++ b/aimux-providers/src/anthropic/cache_control.rs
@@ -1,4 +1,4 @@
-﻿//! Anthropic `cache_control` validation.
+//! Anthropic `cache_control` validation.
 //!
 //! Rust port of the TS `get-cache-control.ts` `CacheControlValidator`. The
 //! validator is constructed once per prompt conversion and tracks the number of
@@ -18,6 +18,7 @@ const MAX_CACHE_BREAKPOINTS: u32 = 4;
 /// snake_case `cache_control` keys under `providerOptions.anthropic`.
 ///
 /// The value is passed through unchanged (the Anthropic API validates it).
+#[must_use]
 pub fn extract_cache_control(provider_options: Option<&Value>) -> Option<Value> {
     let opts = provider_options?;
     let anthropic = opts.get("anthropic")?;
@@ -37,6 +38,7 @@ pub struct CacheControlValidator {
 }
 
 impl CacheControlValidator {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -68,8 +70,7 @@ impl CacheControlValidator {
             self.warnings.push(Warning::Unsupported {
                 feature: "cache_control on non-cacheable context".to_string(),
                 details: Some(format!(
-                    "cache_control cannot be set on {}. It will be ignored.",
-                    context_type
+                    "cache_control cannot be set on {context_type}. It will be ignored."
                 )),
             });
             return None;

--- a/aimux-providers/src/anthropic/convert.rs
+++ b/aimux-providers/src/anthropic/convert.rs
@@ -63,6 +63,12 @@ pub struct AnthropicPromptConversion {
 /// `send_reasoning` controls whether assistant `Reasoning` parts are converted
 /// into Anthropic `thinking` blocks (when `true`) or dropped with a warning
 /// (when `false`).
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` / `UnsupportedFunctionality` when a
+/// message part cannot be represented in the Anthropic wire format (e.g. an
+/// unresolvable file reference or an unsupported media type).
 pub fn convert_prompt_to_anthropic_full_fallible(
     prompt: &LanguageModelPrompt,
     send_reasoning: bool,
@@ -247,6 +253,7 @@ pub fn convert_prompt_to_anthropic_full_fallible(
     since = "0.2.1",
     note = "panics on failure; use convert_prompt_to_anthropic_full_fallible instead (issue #90 R1)"
 )]
+#[must_use]
 pub fn convert_prompt_to_anthropic_full(
     prompt: &LanguageModelPrompt,
     send_reasoning: bool,
@@ -268,6 +275,7 @@ pub fn convert_prompt_to_anthropic_full(
     since = "0.2.1",
     note = "panics on failure; use convert_prompt_to_anthropic_full_fallible instead (issue #90 R1)"
 )]
+#[must_use]
 pub fn convert_prompt_to_anthropic(
     prompt: &LanguageModelPrompt,
 ) -> (Option<Vec<Value>>, Vec<Value>) {
@@ -414,7 +422,7 @@ fn convert_part_to_anthropic(
                 .as_ref()
                 .and_then(|o| o.get("anthropic"))
                 .and_then(|a| a.get("containerUpload"))
-                .and_then(|v| v.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false);
             let block = if container_upload {
                 json!({ "type": "container_upload", "file_id": file_id })
@@ -585,8 +593,7 @@ fn route_file_bytes(
             Ok(block)
         }
         _ => Err(AiMuxError::UnsupportedFunctionality(format!(
-            "media type: {}",
-            full_media_type
+            "media type: {full_media_type}"
         ))),
     }
 }
@@ -630,8 +637,7 @@ fn route_file_base64(
             Ok(block)
         }
         _ => Err(AiMuxError::UnsupportedFunctionality(format!(
-            "media type: {}",
-            full_media_type
+            "media type: {full_media_type}"
         ))),
     }
 }
@@ -655,8 +661,7 @@ fn route_file_url(
             Ok(json!({ "type": "document", "source": { "type": "url", "url": url } }))
         }
         _ => Err(AiMuxError::UnsupportedFunctionality(format!(
-            "media type: {}",
-            media_type
+            "media type: {media_type}"
         ))),
     }
 }
@@ -722,8 +727,7 @@ fn resolve_full_media_type(media_type: &str, bytes: &[u8]) -> Result<String, AiM
     match detect_media_type(bytes, top) {
         Some(detected) => Ok(detected.to_string()),
         None => Err(AiMuxError::UnsupportedFunctionality(format!(
-            "file of media type \"{}\" must specify subtype since it could not be auto-detected",
-            media_type
+            "file of media type \"{media_type}\" must specify subtype since it could not be auto-detected"
         ))),
     }
 }
@@ -964,8 +968,7 @@ fn map_reasoning_to_effort(
             warnings.push(Warning::Unsupported {
                 feature: "reasoning".to_string(),
                 details: Some(format!(
-                    "reasoning \"{}\" is not supported by this model.",
-                    level
+                    "reasoning \"{level}\" is not supported by this model."
                 )),
             });
             return None;
@@ -976,8 +979,7 @@ fn map_reasoning_to_effort(
         warnings.push(Warning::Compatibility {
             feature: "reasoning".to_string(),
             details: Some(format!(
-                "reasoning \"{}\" is not directly supported by this model. mapped to effort \"{}\".",
-                level, mapped
+                "reasoning \"{level}\" is not directly supported by this model. mapped to effort \"{mapped}\"."
             )),
         });
     }
@@ -1012,8 +1014,7 @@ fn map_reasoning_to_budget(
             warnings.push(Warning::Unsupported {
                 feature: "reasoning".to_string(),
                 details: Some(format!(
-                    "reasoning \"{}\" is not supported by this model.",
-                    reasoning
+                    "reasoning \"{reasoning}\" is not supported by this model."
                 )),
             });
             return None;
@@ -1107,6 +1108,11 @@ fn strip_null_fields(value: &mut Value) {
 /// Build the Anthropic request body (without warnings). Returns an error when
 /// provider-option resolution fails (e.g. a custom skill provider reference
 /// that does not include the `anthropic` key).
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` when provider-option resolution
+/// fails (e.g. a custom skill reference missing the `anthropic` key).
 pub fn build_request_body(
     model_id: &str,
     options: &CallOptions,
@@ -1132,8 +1138,7 @@ fn strip_anthropic_sampling_params(
             warnings.push(Warning::Unsupported {
                 feature: "temperature".to_string(),
                 details: Some(format!(
-                    "temperature is not supported by {} and will be ignored",
-                    model_id
+                    "temperature is not supported by {model_id} and will be ignored"
                 )),
             });
             temperature = None;
@@ -1142,8 +1147,7 @@ fn strip_anthropic_sampling_params(
             warnings.push(Warning::Unsupported {
                 feature: "topK".to_string(),
                 details: Some(format!(
-                    "topK is not supported by {} and will be ignored",
-                    model_id
+                    "topK is not supported by {model_id} and will be ignored"
                 )),
             });
             top_k = None;
@@ -1152,8 +1156,7 @@ fn strip_anthropic_sampling_params(
             warnings.push(Warning::Unsupported {
                 feature: "topP".to_string(),
                 details: Some(format!(
-                    "topP is not supported by {} and will be ignored",
-                    model_id
+                    "topP is not supported by {model_id} and will be ignored"
                 )),
             });
             top_p = None;
@@ -1180,7 +1183,7 @@ fn resolve_anthropic_thinking(
     let mut thinking_config: Option<Value> =
         anthropic_option(&options.provider_options, "thinking");
     let mut effort: Option<String> = anthropic_option(&options.provider_options, "effort")
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string));
 
     if let Some(reasoning) = options.reasoning
         && reasoning.is_custom()
@@ -1243,7 +1246,7 @@ fn derive_anthropic_thinking(
         .as_ref()
         .and_then(|t| t.get("type"))
         .and_then(|t| t.as_str())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
 
     let is_thinking =
         thinking_type.as_deref() == Some("enabled") || thinking_type.as_deref() == Some("adaptive");
@@ -1253,7 +1256,7 @@ fn derive_anthropic_thinking(
         thinking_config
             .as_ref()
             .and_then(|t| t.get("budgetTokens"))
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|n| n as u32)
     } else {
         None
@@ -1531,8 +1534,7 @@ fn append_anthropic_container(
                     Some(id) => id.clone(),
                     None => {
                         return Err(AiMuxError::UnsupportedFunctionality(format!(
-                            "skill provider reference is missing the 'anthropic' key: {}",
-                            skill
+                            "skill provider reference is missing the 'anthropic' key: {skill}"
                         )));
                     }
                 }
@@ -1590,6 +1592,12 @@ fn append_anthropic_container(
 /// effort mapping (provider options take precedence), and thinking-enabled
 /// default budget. The single oversized function was split into focused
 /// helpers (issue M11); behavior is unchanged.
+///
+/// # Errors
+///
+/// Propagates prompt/provider-option conversion errors, e.g.
+/// `AiMuxError::InvalidArgument` for an unresolvable file reference or
+/// container option.
 pub fn build_request_body_with_warnings(
     model_id: &str,
     options: &CallOptions,
@@ -1704,6 +1712,7 @@ pub fn build_request_body_with_warnings(
 }
 
 /// Parse Anthropic stop_reason into `FinishReason`.
+#[must_use]
 pub fn parse_stop_reason(s: &str) -> FinishReason {
     let unified = match s {
         "end_turn" => FinishReasonUnified::Stop,

--- a/aimux-providers/src/anthropic/files.rs
+++ b/aimux-providers/src/anthropic/files.rs
@@ -63,6 +63,7 @@ pub struct AnthropicFiles {
 }
 
 impl AnthropicFiles {
+    #[must_use]
     pub fn new(config: AnthropicConfig) -> Self {
         Self { config }
     }
@@ -111,7 +112,7 @@ impl Files for AnthropicFiles {
 
         // Build multipart/form-data body manually.
         let (body, content_type) = build_multipart_form(
-            &format!("form-data; name=\"file\"; filename=\"{}\"", filename),
+            &format!("form-data; name=\"file\"; filename=\"{filename}\""),
             &options.media_type,
             &file_bytes,
             &[],

--- a/aimux-providers/src/anthropic/mod.rs
+++ b/aimux-providers/src/anthropic/mod.rs
@@ -70,6 +70,7 @@ impl AnthropicConfig {
     /// Start a builder for more involved configurations (e.g. `auth_token`,
     /// custom `name`, extra `headers`). The builder validates that `api_key`
     /// and `auth_token` are not both provided.
+    #[must_use]
     pub fn builder() -> AnthropicConfigBuilder {
         AnthropicConfigBuilder::default()
     }
@@ -77,44 +78,51 @@ impl AnthropicConfig {
     /// Override the base URL. Normalizes the value (strips a trailing slash and
     /// a trailing `/v1` segment so the endpoint formula `{base_url}/v1/messages`
     /// never doubles the version) and rejects empty strings.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = normalize_base_url(&url.into());
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// Set a custom provider name.
+    #[must_use]
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
         self.name = name.into();
         self
     }
 
     /// Authenticate with a bearer token instead of an API key.
+    #[must_use]
     pub fn with_auth_token(mut self, token: impl Into<String>) -> Self {
         self.auth_token = Some(token.into());
         self
     }
 
     /// Attach extra headers merged into every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Set provider-level request body overrides (RFC-0017).
+    #[must_use]
     pub fn with_body_overrides(mut self, overrides: Value) -> Self {
         self.body_overrides = Some(overrides);
         self
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
@@ -123,6 +131,11 @@ impl AnthropicConfig {
     /// Reads `ANTHROPIC_API_KEY` (required) and the optional
     /// `ANTHROPIC_BASE_URL`. `ANTHROPIC_AUTH_TOKEN` is not auto-loaded here;
     /// use [`AnthropicConfig::builder`]`.auth_token` for token auth.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `ANTHROPIC_API_KEY` is not set
+    /// and no key was supplied.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "ANTHROPIC_API_KEY", "Anthropic")?;
         let mut config = Self::new(api_key).with_api_key_source(Some("env:ANTHROPIC_API_KEY"));
@@ -148,31 +161,37 @@ pub struct AnthropicConfigBuilder {
 }
 
 impl AnthropicConfigBuilder {
+    #[must_use]
     pub fn api_key(mut self, api_key: impl Into<String>) -> Self {
         self.api_key = Some(api_key.into());
         self
     }
 
+    #[must_use]
     pub fn auth_token(mut self, auth_token: impl Into<String>) -> Self {
         self.auth_token = Some(auth_token.into());
         self
     }
 
+    #[must_use]
     pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = Some(base_url.into());
         self
     }
 
+    #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
+    #[must_use]
     pub fn headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    #[must_use]
     pub fn body_overrides(mut self, overrides: Value) -> Self {
         self.body_overrides = Some(overrides);
         self
@@ -180,6 +199,11 @@ impl AnthropicConfigBuilder {
 
     /// Build the config, validating that `api_key` and `auth_token` are not
     /// both set and that a provided `base_url` is non-empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when both `api_key` and `auth_token`
+    /// are set, or when a provided `base_url` is empty.
     pub fn build(self) -> Result<AnthropicConfig, AiMuxError> {
         if self.api_key.is_some() && self.auth_token.is_some() {
             return Err(AiMuxError::InvalidArgument(
@@ -230,15 +254,18 @@ pub struct AnthropicProvider {
 }
 
 impl AnthropicProvider {
+    #[must_use]
     pub fn new(config: AnthropicConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> model::AnthropicModel {
         model::AnthropicModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a Files interface for uploading files to Anthropic.
+    #[must_use]
     pub fn files(&self) -> files::AnthropicFiles {
         files::AnthropicFiles::new(self.config.clone())
     }

--- a/aimux-providers/src/anthropic/model.rs
+++ b/aimux-providers/src/anthropic/model.rs
@@ -25,6 +25,7 @@ pub struct AnthropicModel {
 }
 
 impl AnthropicModel {
+    #[must_use]
     pub fn new(model_id: String, config: AnthropicConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/anthropic/prepare_tools.rs
+++ b/aimux-providers/src/anthropic/prepare_tools.rs
@@ -1,4 +1,4 @@
-﻿//! Tool preparation for the Anthropic provider.
+//! Tool preparation for the Anthropic provider.
 //!
 //! Faithful Rust port of the function-tool and tool-choice handling of the
 //! TypeScript `prepareTools` in `packages/anthropic/src/anthropic-prepare-tools.ts`,
@@ -37,6 +37,7 @@ const BETA_ADVANCED_TOOL_USE: &str = "advanced-tool-use-2025-11-20";
 /// `disable_parallel_tool_use` mirrors the TS `disableParallelToolUse` flag and
 /// is attached to the chosen `tool_choice` when set. `default_eager_input_streaming`
 /// is the model-level default for `eager_input_streaming` on function tools.
+#[must_use]
 pub fn prepare_tools(
     tools: Option<&[FunctionTool]>,
     tool_choice: Option<&ToolChoice>,
@@ -133,6 +134,7 @@ fn arg(args: &Value, key: &str) -> Value {
 /// Prepare a mix of function and provider-defined tools into the Anthropic
 /// `tools` / `tool_choice` shape. This is the provider-tool-aware counterpart of
 /// [`prepare_tools`]; it mirrors the TS `prepareTools` `case 'provider'` branch.
+#[must_use]
 pub fn prepare_tools_with_provider(
     tools: Option<&[AnthropicTool]>,
     tool_choice: Option<&ToolChoice>,
@@ -168,7 +170,7 @@ pub fn prepare_tools_with_provider(
                             anthropic_tools.push(def);
                         } else {
                             tool_warnings.push(Warning::Unsupported {
-                                feature: format!("provider-defined tool {}", id),
+                                feature: format!("provider-defined tool {id}"),
                                 details: None,
                             });
                         }
@@ -257,11 +259,11 @@ fn prepare_function_tool(
 
     let eager_input_streaming = anthropic_options
         .and_then(|o| o.get("eagerInputStreaming"))
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(default_eager_input_streaming);
     let defer_loading = anthropic_options
         .and_then(|o| o.get("deferLoading"))
-        .and_then(|v| v.as_bool());
+        .and_then(serde_json::Value::as_bool);
     let allowed_callers = anthropic_options.and_then(|o| o.get("allowedCallers"));
 
     #[allow(clippy::collapsible_if, reason = "let-chain not stable on 1.97")]

--- a/aimux-providers/src/anthropic/sanitize_json_schema.rs
+++ b/aimux-providers/src/anthropic/sanitize_json_schema.rs
@@ -44,6 +44,7 @@ const DESCRIPTION_CONSTRAINT_KEYS: &[&str] = &[
 
 /// Sanitize a JSON Schema, removing keywords Anthropic rejects and adding
 /// readable descriptions for stripped constraints.
+#[must_use]
 pub fn sanitize_json_schema(schema: &Value) -> Value {
     sanitize_schema(schema)
 }

--- a/aimux-providers/src/anthropic/usage.rs
+++ b/aimux-providers/src/anthropic/usage.rs
@@ -76,6 +76,7 @@ pub struct AnthropicUsageResult {
 ///
 /// `raw_usage` corresponds to the TS `rawUsage` argument; when `None`, the
 /// `usage` object itself is used as `raw`.
+#[must_use]
 pub fn convert_anthropic_usage(usage: &Value, raw_usage: Option<&Value>) -> AnthropicUsageResult {
     let u: AnthropicUsageInput = serde_json::from_value(usage.clone()).unwrap_or_default();
 
@@ -141,6 +142,7 @@ pub fn convert_anthropic_usage(usage: &Value, raw_usage: Option<&Value>) -> Anth
 /// Semantics (RFC-0015 P0-2): `input_tokens.total` = input + cache_read +
 /// cache_creation (Anthropic's own `input_tokens` excludes cache). This is a
 /// deliberate correction for consumers.
+#[must_use]
 pub fn usage_from_anthropic(usage: &AnthropicUsage) -> Usage {
     match serde_json::to_value(usage) {
         Ok(v) => {

--- a/aimux-providers/src/anthropic_aws/mod.rs
+++ b/aimux-providers/src/anthropic_aws/mod.rs
@@ -59,7 +59,7 @@ impl AnthropicAwsProviderConfig {
         region: impl Into<String>,
     ) -> Self {
         let region = region.into();
-        let base_url = format!("https://aws-external-anthropic.{}.api.aws/v1", region);
+        let base_url = format!("https://aws-external-anthropic.{region}.api.aws/v1");
         Self {
             base_url,
             auth: AnthropicAwsAuth::SigV4(AwsCredentials {
@@ -78,7 +78,7 @@ impl AnthropicAwsProviderConfig {
     /// Create a config using an API key (`x-api-key` auth).
     pub fn with_api_key(api_key: impl Into<String>, region: impl Into<String>) -> Self {
         let region = region.into();
-        let base_url = format!("https://aws-external-anthropic.{}.api.aws/v1", region);
+        let base_url = format!("https://aws-external-anthropic.{region}.api.aws/v1");
         Self {
             base_url,
             auth: AnthropicAwsAuth::ApiKey(api_key.into()),
@@ -90,36 +90,42 @@ impl AnthropicAwsProviderConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Set the Anthropic API version header.
+    #[must_use]
     pub fn with_api_version(mut self, version: impl Into<String>) -> Self {
         self.api_version = version.into();
         self
     }
 
     /// Set the workspace ID.
+    #[must_use]
     pub fn with_workspace_id(mut self, workspace_id: impl Into<String>) -> Self {
         self.workspace_id = Some(workspace_id.into());
         self
     }
 
     /// 标注凭证来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// Add a session token for temporary STS credentials.
+    #[must_use]
     pub fn with_session_token(mut self, token: impl Into<String>) -> Self {
         if let AnthropicAwsAuth::SigV4(ref mut creds) = self.auth {
             creds.session_token = Some(token.into());
@@ -131,6 +137,11 @@ impl AnthropicAwsProviderConfig {
     ///
     /// Checks for `ANTHROPIC_AWS_API_KEY` first (API key auth), then falls
     /// back to `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when neither `ANTHROPIC_AWS_API_KEY`
+    /// nor the `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` pair is present.
     pub fn from_env() -> Result<Self, AiMuxError> {
         if let Ok(key) = std::env::var("ANTHROPIC_AWS_API_KEY")
             && !key.trim().is_empty()
@@ -172,12 +183,14 @@ pub struct AnthropicAwsProvider {
 }
 
 impl AnthropicAwsProvider {
+    #[must_use]
     pub fn new(config: AnthropicAwsProviderConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given Anthropic model id
     /// (e.g. `"claude-sonnet-4-20250514"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> AnthropicAwsModel {
         AnthropicAwsModel::new(
             model_id.to_string(),

--- a/aimux-providers/src/anthropic_aws/model.rs
+++ b/aimux-providers/src/anthropic_aws/model.rs
@@ -43,6 +43,7 @@ pub struct AnthropicAwsModel {
 }
 
 impl AnthropicAwsModel {
+    #[must_use]
     pub fn new(model_id: String, config: AnthropicAwsConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/assemblyai.rs
+++ b/aimux-providers/src/assemblyai.rs
@@ -45,16 +45,24 @@ impl AssemblyAIConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Create from the `ASSEMBLYAI_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "ASSEMBLYAI_API_KEY", "AssemblyAI")?;
         Ok(Self::new(api_key))
@@ -66,10 +74,12 @@ pub struct AssemblyAIProvider {
 }
 
 impl AssemblyAIProvider {
+    #[must_use]
     pub fn new(config: AssemblyAIConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> AssemblyAITranscriptionModel {
         AssemblyAITranscriptionModel::new(model_id.to_string(), self.config.clone())
     }
@@ -141,6 +151,7 @@ pub struct AssemblyAITranscriptionModel {
 }
 
 impl AssemblyAITranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: AssemblyAIConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/aws_polly.rs
+++ b/aimux-providers/src/aws_polly.rs
@@ -88,7 +88,7 @@ impl AwsPollyConfig {
         region: impl Into<String>,
     ) -> Self {
         let region = region.into();
-        let base_url = format!("https://polly.{}.amazonaws.com", region);
+        let base_url = format!("https://polly.{region}.amazonaws.com");
         Self {
             access_key_id: access_key_id.into(),
             secret_access_key: secret_access_key.into(),
@@ -99,12 +99,14 @@ impl AwsPollyConfig {
     }
 
     /// Override the base URL (for testing or proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into().trim_end_matches('/').to_string();
         self
     }
 
     /// Add a session token for temporary STS credentials.
+    #[must_use]
     pub fn with_session_token(mut self, token: impl Into<String>) -> Self {
         self.session_token = Some(token.into());
         self
@@ -114,6 +116,11 @@ impl AwsPollyConfig {
     ///
     /// Reads `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION`
     /// (defaulting to `us-east-1`), and the optional `AWS_SESSION_TOKEN`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `AWS_ACCESS_KEY_ID` or
+    /// `AWS_SECRET_ACCESS_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -184,12 +191,14 @@ pub struct AwsPollyProvider {
 }
 
 impl AwsPollyProvider {
+    #[must_use]
     pub fn new(config: AwsPollyConfig) -> Self {
         Self { config }
     }
 
     /// Create a speech (TTS) model instance for the given model id
     /// (e.g. `"aws_polly/neural"` or `"neural"`).
+    #[must_use]
     pub fn speech(&self, model_id: &str) -> AwsPollySpeechModel {
         AwsPollySpeechModel::new(model_id.to_string(), self.config.clone())
     }
@@ -210,6 +219,7 @@ pub struct AwsPollySpeechModel {
 }
 
 impl AwsPollySpeechModel {
+    #[must_use]
     pub fn new(model_id: String, config: AwsPollyConfig) -> Self {
         Self { model_id, config }
     }
@@ -335,8 +345,7 @@ fn build_request(
         warnings.push(Warning::Unsupported {
             feature: "outputFormat".to_string(),
             details: Some(format!(
-                "Unsupported output format: {}. Using mp3 instead.",
-                output_format
+                "Unsupported output format: {output_format}. Using mp3 instead."
             )),
         });
         body.insert("OutputFormat".to_string(), json!(DEFAULT_OUTPUT_FORMAT));
@@ -399,8 +408,7 @@ fn resolve_engine(model_id: &str) -> (&'static str, Option<Warning>) {
             Some(Warning::Unsupported {
                 feature: "engine".to_string(),
                 details: Some(format!(
-                    "Unknown Polly engine: {}. Using standard instead.",
-                    other
+                    "Unknown Polly engine: {other}. Using standard instead."
                 )),
             }),
         ),
@@ -433,22 +441,22 @@ fn parse_polly_provider_options(
         engine: opts
             .get("engine")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         sample_rate: opts.get("sampleRate").and_then(|v| {
             v.as_str()
-                .map(|s| s.to_string())
+                .map(std::string::ToString::to_string)
                 .or_else(|| v.as_u64().map(|n| n.to_string()))
         }),
         text_type: opts
             .get("textType")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         lexicon_names: opts
             .get("lexiconNames")
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                     .collect()
             }),
         speech_mark_types: opts
@@ -456,7 +464,7 @@ fn parse_polly_provider_options(
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                     .collect()
             }),
     })
@@ -533,7 +541,7 @@ mod tests {
     fn config_debug_redacts_credentials() {
         let config = AwsPollyConfig::new("AKIAEXAMPLE", "super-secret-key", "us-west-2")
             .with_session_token("session-token");
-        let debug = format!("{:?}", config);
+        let debug = format!("{config:?}");
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("AKIAEXAMPLE"));
         assert!(!debug.contains("super-secret-key"));

--- a/aimux-providers/src/azure/model.rs
+++ b/aimux-providers/src/azure/model.rs
@@ -94,6 +94,7 @@ pub struct AzureConfig {
 impl AzureConfig {
     /// Create a new config with default settings (deployment-based URLs,
     /// `api-version = 2024-10-21`, no auth yet).
+    #[must_use]
     pub fn new() -> Self {
         Self {
             resource_name: None,
@@ -108,60 +109,70 @@ impl AzureConfig {
     }
 
     /// Set the Azure resource name.
+    #[must_use]
     pub fn with_resource_name(mut self, name: impl Into<String>) -> Self {
         self.resource_name = Some(name.into());
         self
     }
 
     /// Override the base URL prefix (takes precedence over `resource_name`).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = Some(without_trailing_slash(&url.into()));
         self
     }
 
     /// Set the `api-version` query parameter.
+    #[must_use]
     pub fn with_api_version(mut self, version: impl Into<String>) -> Self {
         self.api_version = version.into();
         self
     }
 
     /// Authenticate with an API key (sent as the `api-key` header).
+    #[must_use]
     pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
         self.auth = Some(AzureAuth::ApiKey(api_key.into()));
         self
     }
 
     /// Authenticate with an Azure AD token provider (sent as `Bearer`).
+    #[must_use]
     pub fn with_token_provider(mut self, provider: Arc<dyn TokenProvider>) -> Self {
         self.auth = Some(AzureAuth::TokenProvider(provider));
         self
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// Add a provider-level extra header.
+    #[must_use]
     pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra_headers.insert(key.into(), value.into());
         self
     }
 
     /// Use the deployment-based URL form (the default).
+    #[must_use]
     pub fn use_deployment_based_urls(mut self) -> Self {
         self.use_deployment_based_urls = true;
         self
     }
 
     /// Use the newer `v1` URL form (`…/openai/v1/chat/completions?api-version=…`).
+    #[must_use]
     pub fn use_v1_urls(mut self) -> Self {
         self.use_deployment_based_urls = false;
         self
@@ -171,6 +182,10 @@ impl AzureConfig {
     ///
     /// Reads `AZURE_API_KEY` (required) and `AZURE_RESOURCE_NAME` (optional —
     /// may also be supplied via `with_resource_name`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `AZURE_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "AZURE_API_KEY", "Azure OpenAI")?;
         let mut config = Self::new()
@@ -204,6 +219,12 @@ impl AzureProvider {
     /// Returns [`AiMuxError::InvalidArgument`] if both an API key and a token
     /// provider were supplied, or if neither `resource_name` nor `base_url` is
     /// set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AiMuxError::InvalidArgument`] when both an API key and a token
+    /// provider are supplied, or when neither `resource_name` nor `base_url` is
+    /// set.
     pub fn new(config: AzureConfig) -> Result<Self, AiMuxError> {
         // Reject both auth methods — mirrors the TS `createAzure` guard.
         // (The builder API makes it hard to set both, but a hand-built config
@@ -218,11 +239,13 @@ impl AzureProvider {
 
     /// Create a model instance for the given deployment name
     /// (e.g. `"gpt-4o-deployment"`).
+    #[must_use]
     pub fn deployment(&self, deployment: &str) -> AzureModel {
         AzureModel::new(deployment.to_string(), self.config.clone())
     }
 
     /// Alias for [`Self::deployment`] (matches the OpenAI provider's `model`).
+    #[must_use]
     pub fn model(&self, deployment: &str) -> AzureModel {
         self.deployment(deployment)
     }
@@ -233,11 +256,13 @@ impl AzureProvider {
     /// deployment-based URL form) instead of `/chat/completions`.
     ///
     /// Mirrors the TS `createResponsesModel` / `provider.responses()` factory.
+    #[must_use]
     pub fn responses_model(&self, deployment: &str) -> AzureResponsesModel {
         AzureResponsesModel::new(deployment.to_string(), self.config.clone())
     }
 
     /// Alias for [`Self::responses_model`] (matches the TS `provider.responses`).
+    #[must_use]
     pub fn responses(&self, deployment: &str) -> AzureResponsesModel {
         self.responses_model(deployment)
     }
@@ -356,6 +381,7 @@ pub struct AzureModel {
 }
 
 impl AzureModel {
+    #[must_use]
     pub fn new(deployment: String, config: AzureConfig) -> Self {
         Self { deployment, config }
     }
@@ -398,7 +424,7 @@ impl AzureModel {
         if is_azure || self.config.use_deployment_based_urls {
             format!("{}{}?api-version={}", prefix, path, self.config.api_version)
         } else {
-            format!("{}{}", prefix, path)
+            format!("{prefix}{path}")
         }
     }
 
@@ -416,7 +442,7 @@ impl AzureModel {
             }
             Some(AzureAuth::TokenProvider(tp)) => {
                 let token = tp.get_token().await?;
-                headers.insert("Authorization".to_string(), format!("Bearer {}", token));
+                headers.insert("Authorization".to_string(), format!("Bearer {token}"));
             }
             None => {
                 return Err(AiMuxError::InvalidArgument(

--- a/aimux-providers/src/azure/responses.rs
+++ b/aimux-providers/src/azure/responses.rs
@@ -63,6 +63,7 @@ pub struct AzureResponsesModel {
 }
 
 impl AzureResponsesModel {
+    #[must_use]
     pub fn new(deployment: String, config: AzureConfig) -> Self {
         Self { deployment, config }
     }
@@ -100,7 +101,7 @@ impl AzureResponsesModel {
         if is_azure || self.config.use_deployment_based_urls {
             format!("{}{}?api-version={}", prefix, path, self.config.api_version)
         } else {
-            format!("{}{}", prefix, path)
+            format!("{prefix}{path}")
         }
     }
 
@@ -118,7 +119,7 @@ impl AzureResponsesModel {
             }
             Some(AzureAuth::TokenProvider(tp)) => {
                 let token = tp.get_token().await?;
-                headers.insert("Authorization".to_string(), format!("Bearer {}", token));
+                headers.insert("Authorization".to_string(), format!("Bearer {token}"));
             }
             None => {
                 return Err(AiMuxError::InvalidArgument(
@@ -176,7 +177,7 @@ fn apply_prefix_to_part(part: &mut Value) {
             .and_then(|v| v.as_str())
             .and_then(extract_base64_data)
             .filter(|data| data.starts_with(AZURE_FILE_ID_PREFIX))
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         if let Some(file_id) = file_id
             && let Some(obj) = part.as_object_mut()
         {
@@ -190,7 +191,7 @@ fn apply_prefix_to_part(part: &mut Value) {
         let file_data = part
             .get("file_data")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         if let Some(file_data) = file_data {
             let media_type = extract_media_type(&file_data).unwrap_or("");
             let data = extract_base64_data(&file_data);
@@ -325,7 +326,7 @@ impl LanguageModel for AzureResponsesModel {
             .as_ref()
             .and_then(|m| m.get("openai"))
             .and_then(|o| o.get("store"))
-            .and_then(|v| v.as_bool())
+            .and_then(serde_json::Value::as_bool)
             == Some(true);
 
         let retry_config = crate::openai::model::resolve_retry_config(

--- a/aimux-providers/src/bedrock/convert.rs
+++ b/aimux-providers/src/bedrock/convert.rs
@@ -1,4 +1,4 @@
-﻿//! Conversion between `LanguageModelPrompt` and Amazon Bedrock Converse format.
+//! Conversion between `LanguageModelPrompt` and Amazon Bedrock Converse format.
 //!
 //! Mirrors `convert-to-amazon-bedrock-chat-messages.ts`,
 //! `amazon-bedrock-prepare-tools.ts`, `map-amazon-bedrock-finish-reason.ts`,
@@ -34,6 +34,7 @@ use serde_json::{Value, json};
 /// messages into a single `assistant` block. Assistant text is trimmed when it
 /// is the last content part of the last message of the last block; empty
 /// assistant text is dropped unless the message also carries reasoning.
+#[must_use]
 pub fn convert_prompt_to_bedrock(prompt: &LanguageModelPrompt) -> (Vec<Value>, Vec<Value>) {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Blk {
@@ -309,7 +310,7 @@ fn citations_enabled(provider_options: &Option<Value>) -> bool {
             .get(key)
             .and_then(|b| b.get("citations"))
             .and_then(|c| c.get("enabled"))
-            .and_then(|e| e.as_bool())
+            .and_then(serde_json::Value::as_bool)
         {
             return enabled;
         }
@@ -424,6 +425,7 @@ fn mime_to_document_format(media_type: &str) -> &'static str {
 ///
 /// Mirrors the TS `supportsStrictTools`: the newest Claude models reject
 /// `strict` (and `output_config.format`), so the field is omitted for them.
+#[must_use]
 pub fn supports_strict_tools(model_id: &str) -> bool {
     const REJECTING: &[&str] = &[
         "claude-opus-4-7",
@@ -448,6 +450,7 @@ pub fn supports_strict_tools(model_id: &str) -> bool {
 /// Provider-defined tools (web_search, anthropic provider tools) and the
 /// `additionalTools`/`betas`/`toolWarnings` they produce are not modelled in
 /// the Rust `FunctionTool` and are intentionally not handled here.
+#[must_use]
 pub fn prepare_tools(
     tools: &Option<Vec<FunctionTool>>,
     tool_choice: &ToolChoice,
@@ -514,6 +517,7 @@ pub fn prepare_tools(
 /// and `inferenceConfig.maxTokens` is bumped by `budgetTokens`. The
 /// `reasoningConfig` key never appears in the request body. User-supplied
 /// `additionalModelRequestFields` are merged with the derived `thinking` field.
+#[must_use]
 pub fn build_request_body(model_id: &str, options: &CallOptions) -> Value {
     let (system, messages) = convert_prompt_to_bedrock(&options.prompt);
 
@@ -530,7 +534,7 @@ pub fn build_request_body(model_id: &str, options: &CallOptions) -> Value {
     let mut budget_tokens: Option<u64> = None;
     if let Some(rc) = reasoning_config
         && rc.get("type").and_then(|v| v.as_str()) == Some("enabled")
-        && let Some(bt) = rc.get("budgetTokens").and_then(|v| v.as_u64())
+        && let Some(bt) = rc.get("budgetTokens").and_then(serde_json::Value::as_u64)
     {
         thinking = Some(json!({ "type": "enabled", "budget_tokens": bt }));
         budget_tokens = Some(bt);
@@ -612,6 +616,7 @@ pub fn build_request_body(model_id: &str, options: &CallOptions) -> Value {
 }
 
 /// Map a Bedrock `stopReason` to the unified `FinishReason`.
+#[must_use]
 pub fn map_finish_reason(reason: &str) -> FinishReason {
     let unified = match reason {
         "stop_sequence" | "end_turn" | "stop" => FinishReasonUnified::Stop,
@@ -635,6 +640,7 @@ pub fn map_finish_reason(reason: &str) -> FinishReason {
 /// `Usage` (the TS `undefined` fields). The TS `raw` echo is not modelled on
 /// the Rust `Usage` type (see `convert-usage` tests for the skipped `raw`
 /// cases); `outputTokens.text` mirrors the TS `outputTokens.text` field.
+#[must_use]
 pub fn convert_usage(usage: Option<&BedrockUsage>) -> aimux_core::types::Usage {
     use aimux_core::types::{TokenUsage, Usage};
 

--- a/aimux-providers/src/bedrock/embedding.rs
+++ b/aimux-providers/src/bedrock/embedding.rs
@@ -37,6 +37,7 @@ pub struct BedrockEmbeddingModel {
 }
 
 impl BedrockEmbeddingModel {
+    #[must_use]
     pub fn new(model_id: String, config: BedrockConfig) -> Self {
         Self { model_id, config }
     }
@@ -64,7 +65,7 @@ impl BedrockEmbeddingModel {
 
         match &self.config.auth {
             BedrockAuth::BearerToken(token) => {
-                let mut headers = vec![("Authorization".to_string(), format!("Bearer {}", token))];
+                let mut headers = vec![("Authorization".to_string(), format!("Bearer {token}"))];
                 headers.extend(extra_headers);
                 Ok(headers)
             }
@@ -286,11 +287,14 @@ impl EmbeddingModel for BedrockEmbeddingModel {
 
         let tokens = if let Some(count) = raw_value
             .get("inputTextTokenCount")
-            .and_then(|t| t.as_u64())
+            .and_then(serde_json::Value::as_u64)
         {
             // Titan response
             count as u32
-        } else if let Some(count) = raw_value.get("inputTokenCount").and_then(|t| t.as_u64()) {
+        } else if let Some(count) = raw_value
+            .get("inputTokenCount")
+            .and_then(serde_json::Value::as_u64)
+        {
             // Nova response
             count as u32
         } else if let Some(header_count) = header_token_count {
@@ -340,30 +344,30 @@ fn parse_bedrock_provider_options(
     BedrockEmbeddingProviderOptions {
         dimensions: provider_opts
             .and_then(|o| o.get("dimensions"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
         normalize: provider_opts
             .and_then(|o| o.get("normalize"))
-            .and_then(|v| v.as_bool()),
+            .and_then(serde_json::Value::as_bool),
         embedding_dimension: provider_opts
             .and_then(|o| o.get("embeddingDimension"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
         embedding_purpose: provider_opts
             .and_then(|o| o.get("embeddingPurpose"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         input_type: provider_opts
             .and_then(|o| o.get("inputType"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         truncate: provider_opts
             .and_then(|o| o.get("truncate"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         output_dimension: provider_opts
             .and_then(|o| o.get("outputDimension"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
     }
 }

--- a/aimux-providers/src/bedrock/event_stream.rs
+++ b/aimux-providers/src/bedrock/event_stream.rs
@@ -62,6 +62,7 @@ enum HeaderValue {
 /// Encode a single event stream message.
 ///
 /// Returns the binary frame ready to be sent on the wire.
+#[must_use]
 pub fn encode_message(message_type: &str, event_type: &str, payload: &str) -> Vec<u8> {
     // Headers: :message-type, :event-type, :content-type
     let headers = vec![
@@ -120,6 +121,7 @@ pub fn encode_message(message_type: &str, event_type: &str, payload: &str) -> Ve
 }
 
 /// Encode multiple messages into a single byte stream.
+#[must_use]
 pub fn encode_messages(messages: &[(&str, &str, &str)]) -> Vec<u8> {
     let mut buf = Vec::new();
     for (msg_type, event_type, payload) in messages {
@@ -132,6 +134,7 @@ pub fn encode_messages(messages: &[(&str, &str, &str)]) -> Vec<u8> {
 ///
 /// Returns a vector of decoded messages. Malformed frames — including those
 /// that fail the prelude CRC or message CRC check — are skipped.
+#[must_use]
 pub fn decode_messages(data: &[u8]) -> Vec<EventStreamMessage> {
     let mut messages = Vec::new();
     let mut offset = 0;

--- a/aimux-providers/src/bedrock/image.rs
+++ b/aimux-providers/src/bedrock/image.rs
@@ -42,6 +42,7 @@ pub struct BedrockImageModel {
 }
 
 impl BedrockImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: BedrockConfig) -> Self {
         Self { model_id, config }
     }
@@ -64,7 +65,7 @@ impl BedrockImageModel {
         }
         match &self.config.auth {
             BedrockAuth::BearerToken(token) => {
-                let mut headers = vec![("Authorization".into(), format!("Bearer {}", token))];
+                let mut headers = vec![("Authorization".into(), format!("Bearer {token}"))];
                 headers.extend(extra_headers);
                 Ok(headers)
             }
@@ -241,8 +242,7 @@ impl ImageModel for BedrockImageModel {
                 }
                 _ => {
                     return Err(AiMuxError::InvalidArgument(format!(
-                        "Unsupported task type: {}",
-                        task_type
+                        "Unsupported task type: {task_type}"
                     )));
                 }
             }
@@ -317,7 +317,7 @@ impl ImageModel for BedrockImageModel {
             return Err(AiMuxError::ApiCall(ApiCallError {
                 status_code: Some(resp.status),
                 provider_code: Some(s.to_string()),
-                message: format!("Amazon Bedrock request was moderated: {}", reasons_str),
+                message: format!("Amazon Bedrock request was moderated: {reasons_str}"),
                 response_body: Some(String::from_utf8_lossy(&resp.body).into_owned()),
                 ..Default::default()
             }));

--- a/aimux-providers/src/bedrock/mod.rs
+++ b/aimux-providers/src/bedrock/mod.rs
@@ -61,7 +61,7 @@ impl BedrockProviderConfig {
         region: impl Into<String>,
     ) -> Self {
         let region = region.into();
-        let base_url = format!("https://bedrock-runtime.{}.amazonaws.com", region);
+        let base_url = format!("https://bedrock-runtime.{region}.amazonaws.com");
         Self {
             base_url,
             auth: BedrockAuth::SigV4(AwsCredentials {
@@ -79,7 +79,7 @@ impl BedrockProviderConfig {
     /// Create a config using a Bearer token.
     pub fn with_bearer_token(token: impl Into<String>, region: impl Into<String>) -> Self {
         let region = region.into();
-        let base_url = format!("https://bedrock-runtime.{}.amazonaws.com", region);
+        let base_url = format!("https://bedrock-runtime.{region}.amazonaws.com");
         Self {
             base_url,
             auth: BedrockAuth::BearerToken(token.into()),
@@ -90,24 +90,28 @@ impl BedrockProviderConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// 标注凭证来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
     /// Add a session token for temporary STS credentials.
+    #[must_use]
     pub fn with_session_token(mut self, token: impl Into<String>) -> Self {
         if let BedrockAuth::SigV4(ref mut creds) = self.auth {
             creds.session_token = Some(token.into());
@@ -119,6 +123,11 @@ impl BedrockProviderConfig {
     ///
     /// Checks for `AWS_BEARER_TOKEN_BEDROCK` first (Bearer auth), then falls
     /// back to `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when neither `AWS_BEARER_TOKEN_BEDROCK`
+    /// nor the `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` pair is present.
     pub fn from_env() -> Result<Self, AiMuxError> {
         // Check for bearer token first.
         if let Ok(token) = std::env::var("AWS_BEARER_TOKEN_BEDROCK")
@@ -152,6 +161,7 @@ impl BedrockProviderConfig {
     }
 
     /// The Bedrock Agent Runtime base URL for this region (used for reranking).
+    #[must_use]
     pub fn agent_runtime_url(&self) -> String {
         format!(
             "https://bedrock-agent-runtime.{}.amazonaws.com",
@@ -169,12 +179,14 @@ pub struct BedrockProvider {
 }
 
 impl BedrockProvider {
+    #[must_use]
     pub fn new(config: BedrockProviderConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given Bedrock model id
     /// (e.g. `"anthropic.claude-3-5-sonnet-20240620-v1:0"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> BedrockModel {
         BedrockModel::new(
             model_id.to_string(),
@@ -189,6 +201,7 @@ impl BedrockProvider {
 
     /// Create an embedding model instance for the given Bedrock model id
     /// (e.g. `"amazon.titan-embed-text-v2:0"`).
+    #[must_use]
     pub fn embedding_model(&self, model_id: &str) -> BedrockEmbeddingModel {
         BedrockEmbeddingModel::new(
             model_id.to_string(),
@@ -203,6 +216,7 @@ impl BedrockProvider {
 
     /// Create an image generation model instance for the given Bedrock model id
     /// (e.g. `"amazon.titan-image-generator-v1"` or `"amazon.nova-canvas-v1:0"`).
+    #[must_use]
     pub fn image(&self, model_id: &str) -> BedrockImageModel {
         BedrockImageModel::new(
             model_id.to_string(),
@@ -218,6 +232,7 @@ impl BedrockProvider {
     /// Create a reranking model instance for the given Bedrock model id
     /// (e.g. `"cohere.rerank-v3-5:0"`). Uses the Bedrock Agent Runtime
     /// `/rerank` endpoint.
+    #[must_use]
     pub fn reranking_model(&self, model_id: &str) -> BedrockRerankingModel {
         // Derive the agent-runtime URL from the base URL by replacing
         // `bedrock-runtime` with `bedrock-agent-runtime`. When the base URL

--- a/aimux-providers/src/bedrock/model.rs
+++ b/aimux-providers/src/bedrock/model.rs
@@ -51,6 +51,7 @@ pub struct BedrockConfig {
 }
 
 impl BedrockModel {
+    #[must_use]
     pub fn new(model_id: String, config: BedrockConfig) -> Self {
         Self { model_id, config }
     }
@@ -86,7 +87,7 @@ impl BedrockModel {
 
         match &self.config.auth {
             BedrockAuth::BearerToken(token) => {
-                let mut headers = vec![("Authorization".to_string(), format!("Bearer {}", token))];
+                let mut headers = vec![("Authorization".to_string(), format!("Bearer {token}"))];
                 headers.extend(extra_headers);
                 Ok(headers)
             }
@@ -305,7 +306,7 @@ impl LanguageModel for BedrockModel {
                     "contentBlockStart" => {
                         let idx = payload
                             .get("contentBlockIndex")
-                            .and_then(|v| v.as_u64())
+                            .and_then(serde_json::Value::as_u64)
                             .unwrap_or(block_counter as u64) as usize;
 
                         // Check if this is a tool use block.
@@ -322,7 +323,7 @@ impl LanguageModel for BedrockModel {
                                     .unwrap_or("")
                                     .to_string();
                                 let id = if id.is_empty() {
-                                    format!("call-{}", idx)
+                                    format!("call-{idx}")
                                 } else {
                                     id
                                 };
@@ -352,7 +353,7 @@ impl LanguageModel for BedrockModel {
                     "contentBlockDelta" => {
                         let idx = payload
                             .get("contentBlockIndex")
-                            .and_then(|v| v.as_u64())
+                            .and_then(serde_json::Value::as_u64)
                             .unwrap_or(0) as usize;
 
                         if let Some(delta) = payload.get("delta") {
@@ -425,7 +426,7 @@ impl LanguageModel for BedrockModel {
                     "contentBlockStop" => {
                         let idx = payload
                             .get("contentBlockIndex")
-                            .and_then(|v| v.as_u64())
+                            .and_then(serde_json::Value::as_u64)
                             .unwrap_or(0) as usize;
 
                         if let Some((id, name, acc)) = tool_blocks.remove(&idx) {

--- a/aimux-providers/src/bedrock/reranking.rs
+++ b/aimux-providers/src/bedrock/reranking.rs
@@ -74,6 +74,7 @@ pub struct BedrockRerankingModel {
 }
 
 impl BedrockRerankingModel {
+    #[must_use]
     pub fn new(model_id: String, base_url: String, region: String, auth: BedrockAuth) -> Self {
         Self {
             model_id,
@@ -102,7 +103,7 @@ impl BedrockRerankingModel {
 
         match &self.auth {
             BedrockAuth::BearerToken(token) => {
-                let mut headers = vec![("Authorization".to_string(), format!("Bearer {}", token))];
+                let mut headers = vec![("Authorization".to_string(), format!("Bearer {token}"))];
                 headers.extend(extra_headers);
                 Ok(headers)
             }

--- a/aimux-providers/src/bedrock/sigv4.rs
+++ b/aimux-providers/src/bedrock/sigv4.rs
@@ -47,6 +47,7 @@ type HmacSha256 = Hmac<Sha256>;
 /// - `body` - The request body as a string (e.g. JSON).
 /// - `extra_headers` - Additional headers to include in the request (these are
 ///   also included in the canonical headers for signing).
+#[must_use]
 pub fn sign_request(
     credentials: &AwsCredentials,
     service: &str,
@@ -106,7 +107,7 @@ pub fn sign_request(
 
     let canonical_headers_str: String = canonical_headers
         .iter()
-        .map(|(k, v)| format!("{}:{}\n", k, v))
+        .map(|(k, v)| format!("{k}:{v}\n"))
         .collect();
     let signed_headers: String = canonical_headers
         .iter()
@@ -134,10 +135,8 @@ pub fn sign_request(
     );
 
     // String to sign
-    let string_to_sign = format!(
-        "AWS4-HMAC-SHA256\n{}\n{}\n{}",
-        amz_date, credential_scope, canonical_request_hash
-    );
+    let string_to_sign =
+        format!("AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{canonical_request_hash}");
 
     // Signing key: derived through chained HMAC
     let k_date = hmac_sha256(

--- a/aimux-providers/src/bedrock_mantle.rs
+++ b/aimux-providers/src/bedrock_mantle.rs
@@ -29,7 +29,7 @@ const PROVIDER_NAME: &str = "bedrock_mantle";
 /// Build the Bedrock Mantle base URL for a region:
 /// `https://bedrock-mantle.{region}.api.aws/v1`.
 fn base_url_for_region(region: &str) -> String {
-    format!("https://bedrock-mantle.{}.api.aws/v1", region)
+    format!("https://bedrock-mantle.{region}.api.aws/v1")
 }
 
 /// Resolve the Bedrock Mantle region from the environment.
@@ -66,14 +66,19 @@ impl BedrockMantleConfig {
     /// Create from the `BEDROCK_MANTLE_API_KEY` environment variable.
     ///
     /// The region is resolved from `BEDROCK_MANTLE_REGION` / `AWS_REGION`
-    /// (defaulting to `us-east-1`). Returns an `Auth` error when the API key
-    /// is not set.
+    /// (defaulting to `us-east-1`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AiMuxError::InvalidArgument`] when `BEDROCK_MANTLE_API_KEY` is
+    /// not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let key = load_api_key(None, ENV_VAR, "Bedrock Mantle")?;
         Ok(Self::new(key))
     }
 
     /// Override the base URL (useful for tests / self-hosted endpoints).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -84,12 +89,14 @@ impl BedrockMantleConfig {
 pub struct BedrockMantleProvider(OpenAIProvider);
 
 impl BedrockMantleProvider {
+    #[must_use]
     pub fn new(config: BedrockMantleConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given model id
     /// (e.g. `"bedrock_mantle/openai.gpt-oss-120b"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/black_forest_labs.rs
+++ b/aimux-providers/src/black_forest_labs.rs
@@ -43,14 +43,22 @@ impl BlackForestLabsConfig {
             headers: None,
         }
     }
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
+    /// Create from the `BFL_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "BFL_API_KEY", "Black Forest Labs")?;
         Ok(Self::new(api_key))
@@ -61,9 +69,11 @@ pub struct BlackForestLabsProvider {
     config: BlackForestLabsConfig,
 }
 impl BlackForestLabsProvider {
+    #[must_use]
     pub fn new(config: BlackForestLabsConfig) -> Self {
         Self { config }
     }
+    #[must_use]
     pub fn image(&self, model_id: &str) -> BlackForestLabsImageModel {
         BlackForestLabsImageModel::new(model_id.to_string(), self.config.clone())
     }
@@ -75,6 +85,7 @@ pub struct BlackForestLabsImageModel {
     config: BlackForestLabsConfig,
 }
 impl BlackForestLabsImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: BlackForestLabsConfig) -> Self {
         Self { model_id, config }
     }
@@ -309,11 +320,11 @@ impl ImageModel for BlackForestLabsImageModel {
         // Poll for result
         let poll_interval = bfl_opts
             .and_then(|o| o.get("pollIntervalMillis"))
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(DEFAULT_POLL_INTERVAL_MS);
         let poll_timeout = bfl_opts
             .and_then(|o| o.get("pollTimeoutMillis"))
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(DEFAULT_POLL_TIMEOUT_MS);
         let max_attempts = (poll_timeout / poll_interval.max(1)) as usize;
 

--- a/aimux-providers/src/cartesia.rs
+++ b/aimux-providers/src/cartesia.rs
@@ -67,24 +67,31 @@ impl CartesiaConfig {
     }
 
     /// Override the base URL (for testing or proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into().trim_end_matches('/').to_string();
         self
     }
 
     /// Override the Cartesia API version.
+    #[must_use]
     pub fn with_version(mut self, version: impl Into<String>) -> Self {
         self.version = version.into();
         self
     }
 
     /// Attach extra headers merged into every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Create from environment variable `CARTESIA_API_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `CARTESIA_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "CARTESIA_API_KEY", "Cartesia")?;
         Ok(Self::new(api_key))
@@ -99,18 +106,21 @@ pub struct CartesiaProvider {
 }
 
 impl CartesiaProvider {
+    #[must_use]
     pub fn new(config: CartesiaConfig) -> Self {
         Self { config }
     }
 
     /// Create a speech (TTS) model instance for the given model name (e.g.
     /// `"sonic-3.5"`).
+    #[must_use]
     pub fn speech(&self, model_id: &str) -> CartesiaSpeechModel {
         CartesiaSpeechModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a transcription (STT) model instance for the given model name
     /// (e.g. `"best"`). Uses the `/stt` endpoint.
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> CartesiaTranscriptionModel {
         CartesiaTranscriptionModel::new(model_id.to_string(), self.config.clone())
     }
@@ -125,6 +135,7 @@ pub struct CartesiaSpeechModel {
 }
 
 impl CartesiaSpeechModel {
+    #[must_use]
     pub fn new(model_id: String, config: CartesiaConfig) -> Self {
         Self { model_id, config }
     }
@@ -308,8 +319,7 @@ fn resolve_output_format(
         warnings.push(Warning::Unsupported {
             feature: "outputFormat".to_string(),
             details: Some(format!(
-                "Unknown output format \"{}\". Falling back to mp3. Use providerOptions.cartesia to configure container, encoding, and sampleRate directly.",
-                output_format
+                "Unknown output format \"{output_format}\". Falling back to mp3. Use providerOptions.cartesia to configure container, encoding, and sampleRate directly."
             )),
         });
         default_output_format()
@@ -562,24 +572,24 @@ fn parse_cartesia_provider_options(
         container: opts
             .get("container")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         encoding: opts
             .get("encoding")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         sample_rate: opts
             .get("sampleRate")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|n| n as u32),
         bit_rate: opts
             .get("bitRate")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|n| n as u32),
-        speed: opts.get("speed").and_then(|v| v.as_f64()),
+        speed: opts.get("speed").and_then(serde_json::Value::as_f64),
         language: opts
             .get("language")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
     })
 }
 
@@ -632,6 +642,7 @@ pub struct CartesiaTranscriptionModel {
 }
 
 impl CartesiaTranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: CartesiaConfig) -> Self {
         Self { model_id, config }
     }
@@ -709,7 +720,7 @@ impl TranscriptionModel for CartesiaTranscriptionModel {
             {
                 timestamp_granularities = Some(
                     tg.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                         .collect(),
                 );
             }

--- a/aimux-providers/src/catalogue.rs
+++ b/aimux-providers/src/catalogue.rs
@@ -70,6 +70,7 @@ const PROVIDER_ALIASES: &[(&str, &str)] = &[
 ];
 
 /// Map an anya2a provider id to an aimux registry name.
+#[must_use]
 pub fn normalize_provider_name(anya2a_id: &str) -> String {
     for (from, to) in PROVIDER_ALIASES {
         if *from == anya2a_id {
@@ -95,15 +96,21 @@ pub struct Catalogue {
 
 impl Catalogue {
     /// Look up the portrait for `(provider, model_id)`.
+    #[must_use]
     pub fn lookup(&self, provider: &str, model_id: &str) -> Option<ModelSpec> {
         self.specs.get(provider)?.get(model_id).cloned()
     }
 
+    #[must_use]
     pub fn provider_count(&self) -> usize {
         self.specs.len()
     }
+    #[must_use]
     pub fn model_count(&self) -> usize {
-        self.specs.values().map(|m| m.len()).sum()
+        self.specs
+            .values()
+            .map(std::collections::HashMap::len)
+            .sum()
     }
 }
 
@@ -118,6 +125,11 @@ impl Catalogue {
 /// host decides how to manage the result.
 ///
 /// `source_url` defaults to [`DEFAULT_ANYA2A_URL`] (anya2a `dist/all.json`).
+///
+/// # Errors
+///
+/// Returns `ApiCall` when the fetch fails and `JsonParse` when the source
+/// JSON does not deserialize into a [`Catalogue`].
 pub async fn get_model_specs(source_url: Option<&str>) -> Result<Catalogue, AiMuxError> {
     let url = source_url.unwrap_or(DEFAULT_ANYA2A_URL);
     let body = fetch_text(url).await?;
@@ -127,6 +139,11 @@ pub async fn get_model_specs(source_url: Option<&str>) -> Result<Catalogue, AiMu
 }
 
 /// Parse anya2a `dist/all.json` into a [`Catalogue`].
+///
+/// # Errors
+///
+/// Returns `AiMuxError::JsonParse` when the JSON lacks the expected
+/// `providers` object.
 pub fn parse_anya2a_all(json: &Value) -> Result<Catalogue, AiMuxError> {
     let providers = json
         .get("providers")
@@ -245,7 +262,9 @@ fn num_field(m: &Value, path: &[&str]) -> Option<u64> {
 }
 
 fn bool_field(m: &Value, key: &str) -> bool {
-    m.get(key).and_then(|v| v.as_bool()).unwrap_or(false)
+    m.get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn modality_list(m: &Value, path: &[&str]) -> Vec<Modality> {
@@ -270,14 +289,14 @@ fn build_reasoning_spec(m: &Value) -> Option<ReasoningSpec> {
         Some(Value::Bool(b)) => *b,
         Some(obj) => obj
             .get("supported")
-            .and_then(|v| v.as_bool())
+            .and_then(serde_json::Value::as_bool)
             .unwrap_or(false),
         None => false,
     };
     let default_enabled = m
         .get("reasoning")
         .and_then(|v| v.get("default"))
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
     let ec = m.get("extra_capabilities").and_then(|v| v.get("reasoning"));
@@ -303,7 +322,7 @@ fn build_reasoning_spec(m: &Value) -> Option<ReasoningSpec> {
     let budget_min = ec
         .and_then(|v| v.get("budget"))
         .and_then(|v| v.get("min"))
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .or_else(|| {
             m.get("reasoning_options")
                 .and_then(|v| v.as_array())
@@ -314,7 +333,7 @@ fn build_reasoning_spec(m: &Value) -> Option<ReasoningSpec> {
                             .and_then(|t| t.as_str())
                             .is_some_and(|t| t == "budget_tokens");
                         if is_budget {
-                            o.get("min").and_then(|v| v.as_u64())
+                            o.get("min").and_then(serde_json::Value::as_u64)
                         } else {
                             None
                         }
@@ -323,7 +342,7 @@ fn build_reasoning_spec(m: &Value) -> Option<ReasoningSpec> {
         });
     let interleaved = ec
         .and_then(|v| v.get("interleaved"))
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
     let visibility = ec
         .and_then(|v| v.get("visibility"))
@@ -381,10 +400,10 @@ fn build_cost(m: &Value) -> Option<ModelCost> {
         return None;
     }
     Some(ModelCost {
-        input: cost.get("input").and_then(|v| v.as_f64()),
-        output: cost.get("output").and_then(|v| v.as_f64()),
-        cache_read: cost.get("cache_read").and_then(|v| v.as_f64()),
-        cache_write: cost.get("cache_write").and_then(|v| v.as_f64()),
+        input: cost.get("input").and_then(serde_json::Value::as_f64),
+        output: cost.get("output").and_then(serde_json::Value::as_f64),
+        cache_read: cost.get("cache_read").and_then(serde_json::Value::as_f64),
+        cache_write: cost.get("cache_write").and_then(serde_json::Value::as_f64),
     })
 }
 

--- a/aimux-providers/src/codex.rs
+++ b/aimux-providers/src/codex.rs
@@ -112,36 +112,45 @@ impl CodexConfig {
     }
 
     /// API-key mode reading `CODEX_API_KEY` from the environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `CODEX_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let key = aimux_provider_utils::load_api_key(None, CODEX_API_KEY_ENV_VAR, "Codex")?;
         Ok(Self::new(key).with_api_key_source(Some("env:CODEX_API_KEY")))
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。透传到内部 `OpenAIConfig`。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
         self.openai = self.openai.with_api_key_source(source);
         self
     }
 
     /// Override the base URL (tests / self-hosted endpoints).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.openai = self.openai.with_base_url(url);
         self
     }
 
     /// Subscription mode: set the `ChatGPT-Account-Id` header.
+    #[must_use]
     pub fn with_chatgpt_account_id(mut self, id: impl Into<String>) -> Self {
         self.chatgpt_account_id = Some(id.into());
         self
     }
 
     /// Subscription mode: override the `Originator` header (default `"aimux"`).
+    #[must_use]
     pub fn with_originator(mut self, originator: impl Into<String>) -> Self {
         self.originator = originator.into();
         self
     }
 
     /// Override the retry configuration.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.openai = self.openai.with_retry_config(config);
         self
@@ -149,6 +158,7 @@ impl CodexConfig {
 
     /// Extra headers merged into every request (user-supplied values win over
     /// the subscription-mode defaults).
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.openai = self.openai.with_headers(headers);
         self
@@ -161,12 +171,14 @@ pub struct CodexProvider {
 }
 
 impl CodexProvider {
+    #[must_use]
     pub fn new(config: CodexConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given Codex model id
     /// (e.g. `"gpt-5.2-codex"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> CodexModel {
         CodexModel {
             model_id: model_id.to_string(),
@@ -345,7 +357,7 @@ impl CodexModel {
                                 provider_code: err_obj
                                     .and_then(|e| e.get("code").or_else(|| e.get("type")))
                                     .and_then(|c| c.as_str())
-                                    .map(|s| s.to_string()),
+                                    .map(std::string::ToString::to_string),
                                 message: message.to_string(),
                                 response_body: Some(ev.data.clone()),
                                 ..Default::default()
@@ -486,6 +498,12 @@ pub struct CodexTokens {
 /// Retries are disabled on purpose: refresh tokens rotate on first use, so
 /// retrying a refresh whose first response was lost would burn the rotation
 /// (`refresh_token_reused`).
+///
+/// # Errors
+///
+/// Returns `ApiCall` for HTTP/transport failures of the token endpoint,
+/// `JsonParse` for a malformed body, and `InvalidResponseData` when the
+/// response has no `access_token`.
 pub async fn codex_refresh(
     refresh_token: &str,
     client_id: &str,
@@ -495,6 +513,12 @@ pub async fn codex_refresh(
 
 /// [`codex_refresh`] with an explicit token endpoint (tests / self-hosted
 /// identity providers).
+///
+/// # Errors
+///
+/// Returns `ApiCall` for HTTP/transport failures of the token endpoint,
+/// `JsonParse` for a malformed body, and `InvalidResponseData` when the
+/// response has no `access_token`.
 pub async fn codex_refresh_at(
     refresh_token: &str,
     client_id: &str,
@@ -538,7 +562,7 @@ pub async fn codex_refresh_at(
             .get("refresh_token")
             .and_then(|v| v.as_str())
             .map(str::to_string),
-        expires_in_secs: data.get("expires_in").and_then(|v| v.as_u64()),
+        expires_in_secs: data.get("expires_in").and_then(serde_json::Value::as_u64),
     })
 }
 

--- a/aimux-providers/src/cohere/convert.rs
+++ b/aimux-providers/src/cohere/convert.rs
@@ -1,4 +1,4 @@
-﻿//! Conversion between `LanguageModelPrompt` and Cohere API format.
+//! Conversion between `LanguageModelPrompt` and Cohere API format.
 //!
 //! Mirrors the TS `convert-to-cohere-chat-prompt.ts`,
 //! `cohere-prepare-tools.ts`, and `map-cohere-finish-reason.ts`.
@@ -31,6 +31,7 @@ pub struct PreparedTools {
 /// - `ToolChoice::None` → `"NONE"`
 /// - `ToolChoice::Required` → `"REQUIRED"`
 /// - `ToolChoice::Tool` → filter tools and use `"REQUIRED"`
+#[must_use]
 pub fn prepare_tools(tools: &Option<Vec<Tool>>, tool_choice: Option<&ToolChoice>) -> PreparedTools {
     let non_empty = tools.as_ref().filter(|t| !t.is_empty());
 
@@ -117,6 +118,7 @@ pub struct ConvertedPrompt {
 /// - Non-image file parts are extracted as `documents` (RAG), not in the message.
 /// - Assistant content is a plain string; with tool calls, `content` is omitted.
 /// - Tool messages are flat `{role:"tool", content, tool_call_id}`.
+#[must_use]
 pub fn convert_prompt_to_cohere(prompt: &LanguageModelPrompt) -> ConvertedPrompt {
     let mut messages = Vec::new();
     let mut documents = Vec::new();
@@ -194,7 +196,7 @@ pub fn convert_prompt_to_cohere(prompt: &LanguageModelPrompt) -> ConvertedPrompt
                             if p.get("type").and_then(|t| t.as_str()) == Some("text") {
                                 p.get("text")
                                     .and_then(|t| t.as_str())
-                                    .map(|s| s.to_string())
+                                    .map(std::string::ToString::to_string)
                             } else {
                                 None
                             }
@@ -306,6 +308,7 @@ pub struct RequestBodyResult {
 /// Mirrors the TS `getArgs` in `cohere-chat-language-model.ts`: assembles the
 /// model id, messages, documents, sampling settings, response format, tools,
 /// and the `thinking` config resolved from `reasoning` / provider options.
+#[must_use]
 pub fn build_request_body(
     model_id: &str,
     options: &CallOptions,
@@ -410,6 +413,7 @@ fn reasoning_budget_percentage(reasoning: ReasoningEffort) -> Option<f64> {
 /// - `reasoning: None` (not specified) → no `thinking` field.
 /// - `reasoning: "none"` → `{ type: "disabled" }`.
 /// - other reasoning levels → `{ type: "enabled", token_budget: <n> }`.
+#[must_use]
 pub fn resolve_cohere_thinking(
     reasoning: Option<ReasoningEffort>,
     provider_options: &Option<std::collections::HashMap<String, Value>>,
@@ -425,7 +429,10 @@ pub fn resolve_cohere_thinking(
             .unwrap_or("enabled")
             .to_string();
         let mut obj = json!({ "type": t_type });
-        if let Some(budget) = thinking.get("tokenBudget").and_then(|v| v.as_u64()) {
+        if let Some(budget) = thinking
+            .get("tokenBudget")
+            .and_then(serde_json::Value::as_u64)
+        {
             obj["token_budget"] = json!(budget);
         }
         return Some(obj);
@@ -447,6 +454,7 @@ pub fn resolve_cohere_thinking(
 }
 
 /// Parse Cohere finish reason string into `FinishReason`.
+#[must_use]
 pub fn parse_finish_reason(s: &str) -> FinishReason {
     let unified = match s {
         "COMPLETE" | "STOP_SEQUENCE" => FinishReasonUnified::Stop,

--- a/aimux-providers/src/cohere/embedding.rs
+++ b/aimux-providers/src/cohere/embedding.rs
@@ -28,6 +28,7 @@ pub struct CohereEmbeddingModel {
 }
 
 impl CohereEmbeddingModel {
+    #[must_use]
     pub fn new(model_id: String, config: CohereConfig) -> Self {
         Self { model_id, config }
     }
@@ -146,7 +147,7 @@ impl EmbeddingModel for CohereEmbeddingModel {
             .get("meta")
             .and_then(|m| m.get("billed_units"))
             .and_then(|b| b.get("input_tokens"))
-            .and_then(|t| t.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|tokens| EmbeddingUsage {
                 tokens: tokens as u32,
             })
@@ -181,14 +182,14 @@ fn parse_cohere_provider_options(
         input_type: provider_opts
             .and_then(|o| o.get("inputType"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         truncate: provider_opts
             .and_then(|o| o.get("truncate"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         output_dimension: provider_opts
             .and_then(|o| o.get("outputDimension"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
     }
 }

--- a/aimux-providers/src/cohere/mod.rs
+++ b/aimux-providers/src/cohere/mod.rs
@@ -41,24 +41,31 @@ impl CohereConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// Create from environment variable `COHERE_API_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `COHERE_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "COHERE_API_KEY", "Cohere")?;
         Ok(Self::new(api_key).with_api_key_source(Some("env:COHERE_API_KEY")))
@@ -71,23 +78,27 @@ pub struct CohereProvider {
 }
 
 impl CohereProvider {
+    #[must_use]
     pub fn new(config: CohereConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given model name (e.g. `"command-r-plus"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> model::CohereModel {
         model::CohereModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a reranking model instance for the given model name (e.g.
     /// `"rerank-english-v3.0"`).
+    #[must_use]
     pub fn reranking_model(&self, model_id: &str) -> reranking::CohereRerankingModel {
         reranking::CohereRerankingModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create an embedding model instance for the given model name (e.g.
     /// `"embed-english-v3.0"`).
+    #[must_use]
     pub fn embedding_model(&self, model_id: &str) -> embedding::CohereEmbeddingModel {
         embedding::CohereEmbeddingModel::new(model_id.to_string(), self.config.clone())
     }

--- a/aimux-providers/src/cohere/model.rs
+++ b/aimux-providers/src/cohere/model.rs
@@ -201,10 +201,10 @@ impl LanguageModel for CohereModel {
                     .and_then(|src| src.get("document"))
                     .and_then(|d| d.get("title"))
                     .and_then(|t| t.as_str())
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
                     .unwrap_or_else(|| "Document".to_string());
                 content.push(GenerateContent::Source {
-                    id: format!("citation-{}", i),
+                    id: format!("citation-{i}"),
                     source_type: "document".to_string(),
                     url: None,
                     title: Some(title),
@@ -337,12 +337,12 @@ impl LanguageModel for CohereModel {
                                 if content_type == Some("thinking") {
                                     is_reasoning = true;
                                     yield Ok(StreamPart::ReasoningStart {
-                                        id: format!("reasoning-{}", idx),
+                                        id: format!("reasoning-{idx}"),
                                         provider_metadata: None,
                                     });
                                 } else {
                                     yield Ok(StreamPart::TextStart {
-                                        id: format!("{}", idx),
+                                        id: format!("{idx}"),
                                         provider_metadata: None,
                                     });
                                 }
@@ -362,7 +362,7 @@ impl LanguageModel for CohereModel {
                                         content.get("thinking").and_then(|t| t.as_str())
                                     {
                                         yield Ok(StreamPart::ReasoningDelta {
-                                            id: format!("reasoning-{}", idx),
+                                            id: format!("reasoning-{idx}"),
                                             delta: thinking.to_string(),
                                             provider_metadata: None,
                                         });
@@ -372,7 +372,7 @@ impl LanguageModel for CohereModel {
                                         content.get("text").and_then(|t| t.as_str())
                                     {
                                         yield Ok(StreamPart::TextDelta {
-                                            id: format!("{}", idx),
+                                            id: format!("{idx}"),
                                             delta: text.to_string(),
                                             provider_metadata: None,
                                         });
@@ -384,13 +384,13 @@ impl LanguageModel for CohereModel {
                                 let idx = parsed.index.unwrap_or(0);
                                 if is_reasoning {
                                     yield Ok(StreamPart::ReasoningEnd {
-                                        id: format!("reasoning-{}", idx),
+                                        id: format!("reasoning-{idx}"),
                                         provider_metadata: None,
                                     });
                                     is_reasoning = false;
                                 } else {
                                     yield Ok(StreamPart::TextEnd {
-                                        id: format!("{}", idx),
+                                        id: format!("{idx}"),
                                         provider_metadata: None,
                                     });
                                 }

--- a/aimux-providers/src/cohere/reranking.rs
+++ b/aimux-providers/src/cohere/reranking.rs
@@ -35,10 +35,13 @@ fn parse_cohere_reranking_options(
     if let Some(po) = provider_options
         && let Some(cohere) = po.get("cohere")
     {
-        if let Some(v) = cohere.get("maxTokensPerDoc").and_then(|v| v.as_u64()) {
+        if let Some(v) = cohere
+            .get("maxTokensPerDoc")
+            .and_then(serde_json::Value::as_u64)
+        {
             opts.max_tokens_per_doc = Some(v);
         }
-        if let Some(v) = cohere.get("priority").and_then(|v| v.as_u64()) {
+        if let Some(v) = cohere.get("priority").and_then(serde_json::Value::as_u64) {
             opts.priority = Some(v);
         }
     }
@@ -66,6 +69,7 @@ pub struct CohereRerankingModel {
 }
 
 impl CohereRerankingModel {
+    #[must_use]
     pub fn new(model_id: String, config: CohereConfig) -> Self {
         Self { model_id, config }
     }
@@ -115,7 +119,10 @@ impl RerankingModel for CohereRerankingModel {
                     feature: "object documents".to_string(),
                     details: Some("Object documents are converted to strings.".to_string()),
                 });
-                values.iter().map(|v| v.to_string()).collect()
+                values
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect()
             }
         };
 

--- a/aimux-providers/src/cybertron.rs
+++ b/aimux-providers/src/cybertron.rs
@@ -30,6 +30,13 @@ impl CybertronConfig {
         )
     }
 
+    /// Create from the `CYBERTRON_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl CybertronConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl CybertronConfig {
 pub struct CybertronProvider(OpenAIProvider);
 
 impl CybertronProvider {
+    #[must_use]
     pub fn new(config: CybertronConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/dataforseo.rs
+++ b/aimux-providers/src/dataforseo.rs
@@ -70,12 +70,18 @@ impl DataforseoConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Create from the `DATAFORSEO_LOGIN` + `DATAFORSEO_PASSWORD` environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `DATAFORSEO_LOGIN` or
+    /// `DATAFORSEO_PASSWORD` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let login = std::env::var("DATAFORSEO_LOGIN").map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -113,11 +119,13 @@ pub struct DataforseoProvider {
 }
 
 impl DataforseoProvider {
+    #[must_use]
     pub fn new(config: DataforseoConfig) -> Self {
         Self { config }
     }
 
     /// Create a search model instance.
+    #[must_use]
     pub fn search_model(&self) -> DataforseoSearchModel {
         DataforseoSearchModel::new(self.config.clone())
     }
@@ -205,6 +213,7 @@ pub struct DataforseoSearchModel {
 }
 
 impl DataforseoSearchModel {
+    #[must_use]
     pub fn new(config: DataforseoConfig) -> Self {
         Self { config }
     }
@@ -213,7 +222,7 @@ impl DataforseoSearchModel {
     fn basic_auth(&self) -> String {
         let credentials = format!("{}:{}", self.config.login, self.config.password);
         let encoded = base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes());
-        format!("Basic {}", encoded)
+        format!("Basic {encoded}")
     }
 
     fn build_headers(&self, extra: Option<&SharedHeaders>) -> HashMap<String, String> {

--- a/aimux-providers/src/deepgram.rs
+++ b/aimux-providers/src/deepgram.rs
@@ -46,16 +46,24 @@ impl DeepgramConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Create from the `DEEPGRAM_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "DEEPGRAM_API_KEY", "Deepgram")?;
         Ok(Self::new(api_key))
@@ -68,10 +76,12 @@ pub struct DeepgramProvider {
 }
 
 impl DeepgramProvider {
+    #[must_use]
     pub fn new(config: DeepgramConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> DeepgramTranscriptionModel {
         DeepgramTranscriptionModel::new(model_id.to_string(), self.config.clone())
     }
@@ -101,22 +111,26 @@ fn parse_deepgram_options(provider_options: Option<&HashMap<String, Value>>) -> 
     if let Some(po) = provider_options
         && let Some(dg) = po.get("deepgram")
     {
-        opts.detect_entities = dg.get("detectEntities").and_then(|v| v.as_bool());
-        opts.detect_language = dg.get("detectLanguage").and_then(|v| v.as_bool());
-        opts.filler_words = dg.get("fillerWords").and_then(|v| v.as_bool());
+        opts.detect_entities = dg
+            .get("detectEntities")
+            .and_then(serde_json::Value::as_bool);
+        opts.detect_language = dg
+            .get("detectLanguage")
+            .and_then(serde_json::Value::as_bool);
+        opts.filler_words = dg.get("fillerWords").and_then(serde_json::Value::as_bool);
         opts.language = dg
             .get("language")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-        opts.punctuate = dg.get("punctuate").and_then(|v| v.as_bool());
+            .map(std::string::ToString::to_string);
+        opts.punctuate = dg.get("punctuate").and_then(serde_json::Value::as_bool);
         opts.redact = dg.get("redact").cloned();
         opts.search = dg.get("search").cloned();
-        opts.smart_format = dg.get("smartFormat").and_then(|v| v.as_bool());
-        opts.summarize = dg.get("summarize").and_then(|v| v.as_bool());
+        opts.smart_format = dg.get("smartFormat").and_then(serde_json::Value::as_bool);
+        opts.summarize = dg.get("summarize").and_then(serde_json::Value::as_bool);
         opts.topics = dg.get("topics").cloned();
-        opts.utterances = dg.get("utterances").and_then(|v| v.as_bool());
-        opts.utt_split = dg.get("uttSplit").and_then(|v| v.as_f64());
-        opts.diarize = dg.get("diarize").and_then(|v| v.as_bool());
+        opts.utterances = dg.get("utterances").and_then(serde_json::Value::as_bool);
+        opts.utt_split = dg.get("uttSplit").and_then(serde_json::Value::as_f64);
+        opts.diarize = dg.get("diarize").and_then(serde_json::Value::as_bool);
     }
     opts
 }
@@ -182,6 +196,7 @@ pub struct DeepgramTranscriptionModel {
 }
 
 impl DeepgramTranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: DeepgramConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/docker_model_runner.rs
+++ b/aimux-providers/src/docker_model_runner.rs
@@ -30,6 +30,13 @@ impl DockerModelRunnerConfig {
         )
     }
 
+    /// Create from the `DOCKER_MODEL_RUNNER_BASE_URL` environment variable, falling
+    /// back to `http://model-runner.docker.internal/engines/llama.cpp/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl DockerModelRunnerConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl DockerModelRunnerConfig {
 pub struct DockerModelRunnerProvider(OpenAIProvider);
 
 impl DockerModelRunnerProvider {
+    #[must_use]
     pub fn new(config: DockerModelRunnerConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/elevenlabs.rs
+++ b/aimux-providers/src/elevenlabs.rs
@@ -50,18 +50,24 @@ impl ElevenLabsConfig {
     }
 
     /// Override the base URL (for testing or proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into().trim_end_matches('/').to_string();
         self
     }
 
     /// Attach extra headers merged into every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Create from environment variable `ELEVENLABS_API_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `ELEVENLABS_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "ELEVENLABS_API_KEY", "ElevenLabs")?;
         Ok(Self::new(api_key))
@@ -76,18 +82,21 @@ pub struct ElevenLabsProvider {
 }
 
 impl ElevenLabsProvider {
+    #[must_use]
     pub fn new(config: ElevenLabsConfig) -> Self {
         Self { config }
     }
 
     /// Create a speech (TTS) model instance for the given model name (e.g.
     /// `"eleven_multilingual_v2"`).
+    #[must_use]
     pub fn speech(&self, model_id: &str) -> ElevenLabsSpeechModel {
         ElevenLabsSpeechModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a transcription (STT) model instance for the given model name
     /// (e.g. `"scribe_v1"`). Uses the `/v1/speech-to-text` endpoint.
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> ElevenLabsTranscriptionModel {
         ElevenLabsTranscriptionModel::new(model_id.to_string(), self.config.clone())
     }
@@ -108,6 +117,7 @@ pub struct ElevenLabsSpeechModel {
 }
 
 impl ElevenLabsSpeechModel {
+    #[must_use]
     pub fn new(model_id: String, config: ElevenLabsConfig) -> Self {
         Self { model_id, config }
     }
@@ -153,7 +163,7 @@ impl SpeechModel for ElevenLabsSpeechModel {
         } else {
             let qs: Vec<String> = query_params
                 .iter()
-                .map(|(k, v)| format!("{}={}", k, v))
+                .map(|(k, v)| format!("{k}={v}"))
                 .collect();
             format!("{}?{}", self.endpoint(&voice_id), qs.join("&"))
         };
@@ -417,10 +427,14 @@ fn parse_elevenlabs_provider_options(
         .get("voiceSettings")
         .and_then(|vs| vs.as_object())
         .map(|vs| ElevenLabsVoiceSettings {
-            stability: vs.get("stability").and_then(|v| v.as_f64()),
-            similarity_boost: vs.get("similarityBoost").and_then(|v| v.as_f64()),
-            style: vs.get("style").and_then(|v| v.as_f64()),
-            use_speaker_boost: vs.get("useSpeakerBoost").and_then(|v| v.as_bool()),
+            stability: vs.get("stability").and_then(serde_json::Value::as_f64),
+            similarity_boost: vs
+                .get("similarityBoost")
+                .and_then(serde_json::Value::as_f64),
+            style: vs.get("style").and_then(serde_json::Value::as_f64),
+            use_speaker_boost: vs
+                .get("useSpeakerBoost")
+                .and_then(serde_json::Value::as_bool),
         });
 
     let pronunciation_dictionary_locators = opts
@@ -438,7 +452,7 @@ fn parse_elevenlabs_provider_options(
                     version_id: loc
                         .get("versionId")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                 })
                 .collect()
         });
@@ -447,25 +461,25 @@ fn parse_elevenlabs_provider_options(
         language_code: opts
             .get("languageCode")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         voice_settings,
         pronunciation_dictionary_locators,
-        seed: opts.get("seed").and_then(|v| v.as_u64()),
+        seed: opts.get("seed").and_then(serde_json::Value::as_u64),
         previous_text: opts
             .get("previousText")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         next_text: opts
             .get("nextText")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         previous_request_ids: opts
             .get("previousRequestIds")
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
                     .filter_map(|v| v.as_str())
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
                     .collect()
             }),
         next_request_ids: opts
@@ -474,17 +488,19 @@ fn parse_elevenlabs_provider_options(
             .map(|arr| {
                 arr.iter()
                     .filter_map(|v| v.as_str())
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
                     .collect()
             }),
         apply_text_normalization: opts
             .get("applyTextNormalization")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         apply_language_text_normalization: opts
             .get("applyLanguageTextNormalization")
-            .and_then(|v| v.as_bool()),
-        enable_logging: opts.get("enableLogging").and_then(|v| v.as_bool()),
+            .and_then(serde_json::Value::as_bool),
+        enable_logging: opts
+            .get("enableLogging")
+            .and_then(serde_json::Value::as_bool),
     })
 }
 
@@ -532,6 +548,7 @@ pub struct ElevenLabsTranscriptionModel {
 }
 
 impl ElevenLabsTranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: ElevenLabsConfig) -> Self {
         Self { model_id, config }
     }
@@ -596,16 +613,19 @@ impl TranscriptionModel for ElevenLabsTranscriptionModel {
         if let Some(ref po) = options.provider_options
             && let Some(el) = po.get("elevenlabs")
         {
-            if let Some(v) = el.get("diarize").and_then(|v| v.as_bool()) {
+            if let Some(v) = el.get("diarize").and_then(serde_json::Value::as_bool) {
                 form.text("diarize", &v.to_string())?;
             }
             if let Some(v) = el.get("languageCode").and_then(|v| v.as_str()) {
                 form.text("language_code", v)?;
             }
-            if let Some(v) = el.get("tagAudioEvents").and_then(|v| v.as_bool()) {
+            if let Some(v) = el
+                .get("tagAudioEvents")
+                .and_then(serde_json::Value::as_bool)
+            {
                 form.text("tag_audio_events", &v.to_string())?;
             }
-            if let Some(v) = el.get("numSpeakers").and_then(|v| v.as_u64()) {
+            if let Some(v) = el.get("numSpeakers").and_then(serde_json::Value::as_u64) {
                 form.text("num_speakers", &v.to_string())?;
             }
             if let Some(v) = el.get("timestampsGranularity").and_then(|v| v.as_str()) {

--- a/aimux-providers/src/exa_ai.rs
+++ b/aimux-providers/src/exa_ai.rs
@@ -37,11 +37,18 @@ impl ExaAiConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    /// Create from the `EXA_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "EXA_API_KEY", "Exa AI")?;
         Ok(Self::new(api_key))
@@ -54,10 +61,12 @@ pub struct ExaAiProvider {
 }
 
 impl ExaAiProvider {
+    #[must_use]
     pub fn new(config: ExaAiConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn search_model(&self) -> ExaAiSearchModel {
         ExaAiSearchModel::new(self.config.clone())
     }
@@ -121,6 +130,7 @@ pub struct ExaAiSearchModel {
 }
 
 impl ExaAiSearchModel {
+    #[must_use]
     pub fn new(config: ExaAiConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/fal.rs
+++ b/aimux-providers/src/fal.rs
@@ -42,16 +42,24 @@ impl FalConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Create from the `FAL_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "FAL_KEY", "Fal")?;
         Ok(Self::new(api_key))
@@ -63,22 +71,26 @@ pub struct FalProvider {
 }
 
 impl FalProvider {
+    #[must_use]
     pub fn new(config: FalConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> FalTranscriptionModel {
         FalTranscriptionModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a video generation model instance for the given model name
     /// (e.g. `"fal-ai/kling-video"`).
+    #[must_use]
     pub fn video(&self, model_id: &str) -> FalVideoModel {
         FalVideoModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create an image generation model instance for the given model name
     /// (e.g. `"fal-ai/flux/schnell"`).
+    #[must_use]
     pub fn image(&self, model_id: &str) -> FalImageModel {
         FalImageModel::new(model_id.to_string(), self.config.clone())
     }
@@ -125,6 +137,7 @@ pub struct FalTranscriptionModel {
 }
 
 impl FalTranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: FalConfig) -> Self {
         Self { model_id, config }
     }
@@ -201,7 +214,7 @@ impl TranscriptionModel for FalTranscriptionModel {
             if let Some(v) = fal.get("numSpeakers") {
                 body.insert("num_speakers".to_string(), v.clone());
             }
-            if let Some(v) = fal.get("diarize").and_then(|v| v.as_bool()) {
+            if let Some(v) = fal.get("diarize").and_then(serde_json::Value::as_bool) {
                 body.insert("diarize".to_string(), json!(v));
             }
             if let Some(v) = fal.get("chunkLevel") {
@@ -356,6 +369,7 @@ pub struct FalImageModel {
 }
 
 impl FalImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: FalConfig) -> Self {
         Self { model_id, config }
     }
@@ -453,7 +467,7 @@ impl ImageModel for FalImageModel {
         {
             let multi = fal_opts
                 .and_then(|o| o.get("useMultipleImages"))
-                .and_then(|v| v.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false);
             if multi {
                 let uris: Result<Vec<String>, _> =
@@ -634,6 +648,7 @@ pub struct FalVideoModel {
 }
 
 impl FalVideoModel {
+    #[must_use]
     pub fn new(model_id: String, config: FalConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/firecrawl.rs
+++ b/aimux-providers/src/firecrawl.rs
@@ -43,11 +43,18 @@ impl FirecrawlConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    /// Create from the `FIRECRAWL_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "FIRECRAWL_API_KEY", "Firecrawl")?;
         Ok(Self::new(api_key))
@@ -60,10 +67,12 @@ pub struct FirecrawlProvider {
 }
 
 impl FirecrawlProvider {
+    #[must_use]
     pub fn new(config: FirecrawlConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn search_model(&self) -> FirecrawlSearchModel {
         FirecrawlSearchModel::new(self.config.clone())
     }
@@ -134,6 +143,7 @@ pub struct FirecrawlSearchModel {
 }
 
 impl FirecrawlSearchModel {
+    #[must_use]
     pub fn new(config: FirecrawlConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/gaudi.rs
+++ b/aimux-providers/src/gaudi.rs
@@ -30,6 +30,13 @@ impl GaudiConfig {
         )
     }
 
+    /// Create from the `GAUDI_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl GaudiConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl GaudiConfig {
 pub struct GaudiProvider(OpenAIProvider);
 
 impl GaudiProvider {
+    #[must_use]
     pub fn new(config: GaudiConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/gladia.rs
+++ b/aimux-providers/src/gladia.rs
@@ -44,16 +44,24 @@ impl GladiaConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Create from the `GLADIA_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "GLADIA_API_KEY", "Gladia")?;
         Ok(Self::new(api_key))
@@ -65,10 +73,12 @@ pub struct GladiaProvider {
 }
 
 impl GladiaProvider {
+    #[must_use]
     pub fn new(config: GladiaConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> GladiaTranscriptionModel {
         GladiaTranscriptionModel::new(model_id.to_string(), self.config.clone())
     }
@@ -136,6 +146,7 @@ pub struct GladiaTranscriptionModel {
 }
 
 impl GladiaTranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: GladiaConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/google/convert.rs
+++ b/aimux-providers/src/google/convert.rs
@@ -58,6 +58,7 @@ pub struct GooglePrompt {
 /// Thought signatures: `ContentPart::ToolCall.thought_signature` is echoed
 /// back as a `thoughtSignature` sibling of the `functionCall` part (required
 /// by Gemini thinking models on follow-up turns).
+#[must_use]
 pub fn convert_to_google_messages(prompt: &LanguageModelPrompt) -> GooglePrompt {
     let mut system_parts: Vec<Value> = Vec::new();
     let mut contents: Vec<Value> = Vec::new();
@@ -264,6 +265,7 @@ pub struct PreparedTools {
 /// Mirrors the function-tools path of the TS `prepareTools`. Provider-defined
 /// tools (`google_search`, `code_execution`, …) are out of scope for the Rust
 /// port — only `FunctionTool`s are supported.
+#[must_use]
 pub fn prepare_tools(tools: &Option<Vec<FunctionTool>>, tool_choice: &ToolChoice) -> PreparedTools {
     // Coerce empty arrays to None (matches TS `tools?.length ? tools : undefined`).
     let non_empty = tools.as_ref().filter(|&t| !t.is_empty());
@@ -359,6 +361,7 @@ pub struct GoogleModelCapabilities {
 /// Mirrors `getGoogleModelCapabilities`. Unrecognized Gemini ids inherit the
 /// newest supported behaviour (matching the TS intent); only known older
 /// generations are downgraded.
+#[must_use]
 pub fn get_google_model_capabilities(model_id: &str) -> GoogleModelCapabilities {
     let lower = model_id.to_lowercase();
 
@@ -384,7 +387,7 @@ pub fn get_google_model_capabilities(model_id: &str) -> GoogleModelCapabilities 
 /// `/(^|\/)prefix/` — `prefix` appears at the start of `lower` or just after a
 /// `/`, with no requirement on what follows.
 fn contains_at_boundary(lower: &str, prefix: &str) -> bool {
-    lower.starts_with(prefix) || lower.contains(&format!("/{}", prefix))
+    lower.starts_with(prefix) || lower.contains(&format!("/{prefix}"))
 }
 
 /// `/(^|\/)prefix(?:[.-]|$)/` — `prefix` appears at the start of `lower` or
@@ -451,6 +454,7 @@ pub struct PreparedToolsWithWarnings {
 /// `Tool::Provider` entries (`google.google_search`, `google.code_execution`,
 /// `google.url_context`, `google.google_maps`, `google.enterprise_web_search`,
 /// `google.file_search`) and the Gemini 3 combined function+provider shape.
+#[must_use]
 pub fn prepare_all_tools(
     tools: &Option<Vec<Tool>>,
     tool_choice: &ToolChoice,
@@ -570,7 +574,7 @@ fn push_provider_tool(
 ) {
     let unsupported = |details: Option<&str>| Warning::Unsupported {
         feature: format!("provider-defined tool {}", tool.id),
-        details: details.map(|s| s.to_string()),
+        details: details.map(std::string::ToString::to_string),
     };
     match tool.id.as_str() {
         "google.google_search" => {
@@ -664,6 +668,7 @@ fn build_function_declaration(ft: &FunctionTool) -> Value {
 /// - `$schema` / `additionalProperties` / `definitions` etc. are dropped.
 /// - `type`, `description`, `required`, `properties`, `items`, `enum`,
 ///   `format`, `const`, `anyOf`/`oneOf`/`allOf` are preserved.
+#[must_use]
 pub fn convert_json_schema_to_openapi_schema(schema: &Value, is_root: bool) -> Value {
     if schema.is_null() {
         return Value::Null;
@@ -828,7 +833,7 @@ fn is_empty_object_schema(obj: &Map<String, Value>) -> bool {
             || obj
                 .get("properties")
                 .and_then(|p| p.as_object())
-                .map(|o| o.is_empty())
+                .map(serde_json::Map::is_empty)
                 .unwrap_or(true))
         && !obj.contains_key("additionalProperties")
 }
@@ -844,6 +849,7 @@ fn is_empty_object_schema(obj: &Map<String, Value>) -> bool {
 ///
 /// This is the request-body-only entry point; warnings about unsupported tools
 /// are discarded. Use [`build_request_body_with_warnings`] to surface them.
+#[must_use]
 pub fn build_request_body(model_id: &str, options: &CallOptions) -> Value {
     build_request_body_with_warnings(model_id, options).0
 }
@@ -851,6 +857,7 @@ pub fn build_request_body(model_id: &str, options: &CallOptions) -> Value {
 /// Build the Gemini `generateContent` request body **and** collect the tool
 /// warnings (e.g. unsupported provider-defined tools, mixed function+provider
 /// tools on pre-Gemini-3 models).
+#[must_use]
 pub fn build_request_body_with_warnings(
     model_id: &str,
     options: &CallOptions,
@@ -935,6 +942,7 @@ pub fn build_request_body_with_warnings(
 ///
 /// `STOP` maps to `ToolCalls` when `has_tool_calls` is true (mirroring the
 /// TS `mapGoogleFinishReason`).
+#[must_use]
 pub fn parse_finish_reason(reason: &str, has_tool_calls: bool) -> FinishReason {
     let unified = match reason {
         "STOP" => {
@@ -966,6 +974,7 @@ pub fn parse_finish_reason(reason: &str, has_tool_calls: bool) -> FinishReason {
 /// - `input.noCache = promptTokenCount - cachedContentTokenCount`
 /// - `input.cacheRead = cachedContentTokenCount`
 /// - `output.total = candidatesTokenCount + thoughtsTokenCount`
+#[must_use]
 pub fn convert_usage(usage: &super::types::GoogleUsageMetadata) -> aimux_core::types::Usage {
     use aimux_core::types::{TokenUsage, Usage};
 
@@ -1016,7 +1025,7 @@ pub fn extract_sources(
     };
 
     let next_id = |counter: &mut usize| -> String {
-        let id = format!("{}", counter);
+        let id = format!("{counter}");
         *counter += 1;
         id
     };
@@ -1029,11 +1038,11 @@ pub fn extract_sources(
                 url: web
                     .get("uri")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 title: web
                     .get("title")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 provider_metadata: None,
             });
         } else if let Some(image) = chunk.get("image") {
@@ -1043,11 +1052,11 @@ pub fn extract_sources(
                 url: image
                     .get("sourceUri")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 title: image
                     .get("title")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 provider_metadata: None,
             });
         } else if let Some(rc) = chunk.get("retrievedContext") {
@@ -1060,7 +1069,7 @@ pub fn extract_sources(
                         id: next_id(id_counter),
                         source_type: "url".to_string(),
                         url: Some(uri.to_string()),
-                        title: title.map(|s| s.to_string()),
+                        title: title.map(std::string::ToString::to_string),
                         provider_metadata: None,
                     });
                 } else {
@@ -1094,7 +1103,7 @@ pub fn extract_sources(
                 title: maps
                     .get("title")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 provider_metadata: None,
             });
         }

--- a/aimux-providers/src/google/embedding.rs
+++ b/aimux-providers/src/google/embedding.rs
@@ -39,6 +39,7 @@ pub struct GoogleEmbeddingModel {
 }
 
 impl GoogleEmbeddingModel {
+    #[must_use]
     pub fn new(model_id: String, config: GoogleConfig) -> Self {
         Self { model_id, config }
     }
@@ -272,11 +273,11 @@ fn parse_google_provider_options(
     GoogleEmbeddingProviderOptions {
         output_dimensionality: provider_opts
             .and_then(|o| o.get("outputDimensionality"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
         task_type: provider_opts
             .and_then(|o| o.get("taskType"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
     }
 }

--- a/aimux-providers/src/google/files.rs
+++ b/aimux-providers/src/google/files.rs
@@ -55,10 +55,16 @@ fn parse_google_files_options(
         if let Some(display_name) = google.get("displayName").and_then(|v| v.as_str()) {
             opts.display_name = Some(display_name.to_string());
         }
-        if let Some(interval) = google.get("pollIntervalMs").and_then(|v| v.as_u64()) {
+        if let Some(interval) = google
+            .get("pollIntervalMs")
+            .and_then(serde_json::Value::as_u64)
+        {
             opts.poll_interval_ms = Some(interval);
         }
-        if let Some(timeout) = google.get("pollTimeoutMs").and_then(|v| v.as_u64()) {
+        if let Some(timeout) = google
+            .get("pollTimeoutMs")
+            .and_then(serde_json::Value::as_u64)
+        {
             opts.poll_timeout_ms = Some(timeout);
         }
     }
@@ -116,6 +122,7 @@ pub struct GoogleFiles {
 }
 
 impl GoogleFiles {
+    #[must_use]
     pub fn new(config: GoogleConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/google/image.rs
+++ b/aimux-providers/src/google/image.rs
@@ -53,6 +53,7 @@ pub struct GoogleImageModel {
 }
 
 impl GoogleImageModel {
+    #[must_use]
     pub fn new(model_id: String, settings: GoogleImageSettings, config: GoogleConfig) -> Self {
         Self {
             model_id,
@@ -438,7 +439,7 @@ fn extract_imagen_metadata(response: &Value) -> SharedProviderMetadata {
     let predictions = response
         .get("predictions")
         .and_then(|p| p.as_array())
-        .map(|arr| arr.len())
+        .map(std::vec::Vec::len)
         .unwrap_or(0);
 
     let images: Vec<Value> = (0..predictions).map(|_| json!({})).collect();
@@ -485,15 +486,15 @@ fn extract_gemini_result(
     let usage = response.get("usageMetadata").map(|u| {
         let input = u
             .get("promptTokenCount")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|x| x as u32);
         let output = u
             .get("candidatesTokenCount")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|x| x as u32);
         let total = u
             .get("totalTokenCount")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|x| x as u32);
         ImageUsage {
             input_tokens: input,

--- a/aimux-providers/src/google/mod.rs
+++ b/aimux-providers/src/google/mod.rs
@@ -56,24 +56,32 @@ impl GoogleConfig {
     }
 
     /// Use a custom base URL (e.g. for Vertex AI or a proxy).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// Create from the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when
+    /// `GOOGLE_GENERATIVE_AI_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "GOOGLE_GENERATIVE_AI_API_KEY", "Google Generative AI")?;
         Ok(Self::new(api_key).with_api_key_source(Some("env:GOOGLE_GENERATIVE_AI_API_KEY")))
@@ -89,28 +97,33 @@ pub struct GoogleProvider {
 }
 
 impl GoogleProvider {
+    #[must_use]
     pub fn new(config: GoogleConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given model name (e.g. `"gemini-2.0-flash"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> model::GoogleModel {
         model::GoogleModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a Files interface for uploading files to Google.
+    #[must_use]
     pub fn files(&self) -> files::GoogleFiles {
         files::GoogleFiles::new(self.config.clone())
     }
 
     /// Create an embedding model instance for the given model name (e.g.
     /// `"gemini-embedding-001"`).
+    #[must_use]
     pub fn embedding_model(&self, model_id: &str) -> embedding::GoogleEmbeddingModel {
         embedding::GoogleEmbeddingModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create an image generation model instance for the given model name
     /// (e.g. `"imagen-3.0-generate-002"` or `"gemini-2.5-flash-image"`).
+    #[must_use]
     pub fn image(&self, model_id: &str) -> image::GoogleImageModel {
         image::GoogleImageModel::new(
             model_id.to_string(),
@@ -121,11 +134,13 @@ impl GoogleProvider {
 
     /// Create a video generation model instance for the given model name
     /// (e.g. `"veo-3.0-generate-001"`).
+    #[must_use]
     pub fn video(&self, model_id: &str) -> video::GoogleVideoModel {
         video::GoogleVideoModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create an image generation model instance with custom settings.
+    #[must_use]
     pub fn image_with_settings(
         &self,
         model_id: &str,

--- a/aimux-providers/src/google/model.rs
+++ b/aimux-providers/src/google/model.rs
@@ -362,7 +362,7 @@ impl LanguageModel for GoogleModel {
                                 if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
                                     if !text.is_empty() {
                                         if text_id.is_none() {
-                                            let id = format!("{}", block_counter);
+                                            let id = format!("{block_counter}");
                                             block_counter += 1;
                                             text_id = Some(id.clone());
                                             yield Ok(StreamPart::TextStart { id, provider_metadata: None});
@@ -385,14 +385,14 @@ impl LanguageModel for GoogleModel {
                                     let id = fc
                                         .get("id")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string())
-                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                        .map(std::string::ToString::to_string)
+                                        .unwrap_or_else(|| format!("call-{block_counter}"));
                                     block_counter += 1;
                                     let args = fc.get("args").cloned().unwrap_or(json!({}));
                                     let thought_signature = part
                                         .get("thoughtSignature")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string());
+                                        .map(std::string::ToString::to_string);
 
                                     yield Ok(StreamPart::ToolInputStart {
                                         id: id.clone(),
@@ -427,7 +427,7 @@ impl LanguageModel for GoogleModel {
                                         .map(|s| !s.is_empty())
                                         .unwrap_or(false);
                                     if has_code {
-                                        let id = format!("call-{}", block_counter);
+                                        let id = format!("call-{block_counter}");
                                         block_counter += 1;
                                         last_code_execution_tool_call_id = Some(id.clone());
                                         yield Ok(StreamPart::ToolCall {
@@ -452,7 +452,7 @@ impl LanguageModel for GoogleModel {
                                         let output = cer
                                             .get("output")
                                             .and_then(|v| v.as_str())
-                                            .map(|s| s.to_string())
+                                            .map(std::string::ToString::to_string)
                                             .unwrap_or_default();
                                         yield Ok(StreamPart::ToolResult {
                                             tool_call_id: call_id,
@@ -473,14 +473,14 @@ impl LanguageModel for GoogleModel {
                                     let id = tc
                                         .get("id")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string())
-                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                        .map(std::string::ToString::to_string)
+                                        .unwrap_or_else(|| format!("call-{block_counter}"));
                                     block_counter += 1;
                                     last_server_tool_call_id = Some(id.clone());
                                     let args = tc.get("args").cloned().unwrap_or(json!({}));
                                     yield Ok(StreamPart::ToolCall {
                                         tool_call_id: id,
-                                        tool_name: format!("server:{}", tool_type),
+                                        tool_name: format!("server:{tool_type}"),
                                         input: args,
                                         provider_executed: None,
                                         dynamic: None,
@@ -495,9 +495,9 @@ impl LanguageModel for GoogleModel {
                                         .or_else(|| {
                                             tr.get("id")
                                                 .and_then(|v| v.as_str())
-                                                .map(|s| s.to_string())
+                                                .map(std::string::ToString::to_string)
                                         })
-                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                        .unwrap_or_else(|| format!("call-{block_counter}"));
                                     block_counter += 1;
                                     let response =
                                         tr.get("response").cloned().unwrap_or(json!({}));
@@ -625,7 +625,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                 let thought_signature = part
                     .get("thoughtSignature")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                    .map(std::string::ToString::to_string);
                 content.push(GenerateContent::ToolCall {
                     tool_call_id: id,
                     tool_name: name,
@@ -670,7 +670,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
                 let input = tc.get("args").cloned().unwrap_or(json!({}));
                 content.push(GenerateContent::ToolCall {
                     tool_call_id: id,
-                    tool_name: format!("server:{}", tool_type),
+                    tool_name: format!("server:{tool_type}"),
                     input,
                     provider_executed: None,
                     dynamic: None,

--- a/aimux-providers/src/google/utils.rs
+++ b/aimux-providers/src/google/utils.rs
@@ -12,11 +12,12 @@ use serde_json::{Map, Value};
 /// - Ids that already contain a `/` (e.g. `models/foo`, `tunedModels/bar`) are
 ///   passed through unchanged.
 /// - Bare ids are prefixed with `models/`.
+#[must_use]
 pub fn get_model_path(model_id: &str) -> String {
     if model_id.contains('/') {
         model_id.to_string()
     } else {
-        format!("models/{}", model_id)
+        format!("models/{model_id}")
     }
 }
 
@@ -26,6 +27,7 @@ pub fn get_model_path(model_id: &str) -> String {
 /// - `https://generativelanguage.googleapis.com/v1beta/files/...` → true
 /// - YouTube watch / youtu.be URLs → true
 /// - everything else → false
+#[must_use]
 pub fn is_supported_file_url(url: &str) -> bool {
     if url.starts_with("https://generativelanguage.googleapis.com/v1beta/files/") {
         return true;
@@ -175,6 +177,7 @@ enum Segment {
 }
 
 impl GoogleJsonAccumulator {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             accumulated: Value::Object(Map::new()),
@@ -189,6 +192,11 @@ impl GoogleJsonAccumulator {
     /// already-accumulated structure (e.g. `$.a` was a string, then `$.a[0]`
     /// arrives). `partialArgs` is provider-controlled input, so such conflicts
     /// must not panic.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::JsonParse` when a partial-arg JSON path conflicts
+    /// with the already-accumulated structure.
     pub fn process_partial_args(
         &mut self,
         args: &[PartialArg],
@@ -216,7 +224,7 @@ impl GoogleJsonAccumulator {
                 // String continuation chunk.
                 let escaped = escape_json_string_inner(s);
                 let new_val = match existing_val {
-                    Value::String(prev) => Value::String(format!("{}{}", prev, s)),
+                    Value::String(prev) => Value::String(format!("{prev}{s}")),
                     _ => Value::String(s.clone()),
                 };
                 set_nested_value(&mut self.accumulated, &segments, new_val)?;
@@ -242,6 +250,7 @@ impl GoogleJsonAccumulator {
 
     /// Finalize the accumulator, producing the complete JSON string and the
     /// closing delta.
+    #[must_use]
     pub fn finalize(&self) -> FinalizeResult {
         let final_json = serde_json::to_string(&self.accumulated).unwrap_or_default();
         let closing_delta = if final_json.len() >= self.json_text.len() {
@@ -524,14 +533,14 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) -> Resu
                 .ok_or_else(|| parent_must_be(seg))?
                 .get_mut(k)
                 .ok_or_else(|| {
-                    AiMuxError::JsonParse(format!("partial args path conflict at {:?}", seg))
+                    AiMuxError::JsonParse(format!("partial args path conflict at {seg:?}"))
                 })?,
             Segment::Index(i) => current
                 .as_array_mut()
                 .ok_or_else(|| parent_must_be(seg))?
                 .get_mut(*i)
                 .ok_or_else(|| {
-                    AiMuxError::JsonParse(format!("partial args path conflict at {:?}", seg))
+                    AiMuxError::JsonParse(format!("partial args path conflict at {seg:?}"))
                 })?,
             Segment::Root => current,
         };
@@ -563,8 +572,7 @@ fn set_nested_value(obj: &mut Value, segments: &[Segment], value: Value) -> Resu
 /// does not match the path's expectation (e.g. an index into a string).
 fn parent_must_be(seg: &Segment) -> AiMuxError {
     AiMuxError::JsonParse(format!(
-        "partial args path type conflict at {:?}: accumulated value does not match the path",
-        seg
+        "partial args path type conflict at {seg:?}: accumulated value does not match the path"
     ))
 }
 

--- a/aimux-providers/src/google/video.rs
+++ b/aimux-providers/src/google/video.rs
@@ -39,6 +39,7 @@ pub struct GoogleVideoModel {
 }
 
 impl GoogleVideoModel {
+    #[must_use]
     pub fn new(model_id: String, config: GoogleConfig) -> Self {
         Self { model_id, config }
     }
@@ -186,13 +187,13 @@ impl VideoModel for GoogleVideoModel {
                     provider_code: err
                         .get("status")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                     message: msg.to_string(),
                     response_body: Some(String::from_utf8_lossy(&resp.body).into_owned()),
                     ..Default::default()
                 }));
             }
-            if raw_body.get("done").and_then(|v| v.as_bool()) == Some(true) {
+            if raw_body.get("done").and_then(serde_json::Value::as_bool) == Some(true) {
                 break;
             }
         }

--- a/aimux-providers/src/google_pse.rs
+++ b/aimux-providers/src/google_pse.rs
@@ -56,12 +56,14 @@ impl GooglePseConfig {
     }
 
     /// Set the search-engine ID (`cx`).
+    #[must_use]
     pub fn with_cx(mut self, cx: impl Into<String>) -> Self {
         self.cx = Some(cx.into());
         self
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
@@ -70,6 +72,10 @@ impl GooglePseConfig {
     /// Create from the `GOOGLE_API_KEY` and (optional) `GOOGLE_CSE_ID`
     /// environment variables. `GOOGLE_API_KEY` is required; `GOOGLE_CSE_ID`
     /// may be omitted if `cx` is supplied per-call via `provider_options`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "GOOGLE_API_KEY", "Google PSE")?;
         let cx = std::env::var("GOOGLE_CSE_ID").ok();
@@ -90,11 +96,13 @@ pub struct GooglePseProvider {
 }
 
 impl GooglePseProvider {
+    #[must_use]
     pub fn new(config: GooglePseConfig) -> Self {
         Self { config }
     }
 
     /// Create a search model instance.
+    #[must_use]
     pub fn search_model(&self) -> GooglePseSearchModel {
         GooglePseSearchModel::new(self.config.clone())
     }
@@ -163,6 +171,7 @@ pub struct GooglePseSearchModel {
 }
 
 impl GooglePseSearchModel {
+    #[must_use]
     pub fn new(config: GooglePseConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/huggingface.rs
+++ b/aimux-providers/src/huggingface.rs
@@ -36,18 +36,25 @@ impl HuggingFaceConfig {
     }
 
     /// Create from the `HUGGINGFACE_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `HUGGINGFACE_API_KEY` is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let key = load_api_key(None, ENV_VAR, "Hugging Face")?;
         Ok(Self::new(key).with_api_key_source(Some("env:HUGGINGFACE_API_KEY")))
     }
 
     /// Override the base URL (useful for tests / self-hosted endpoints).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。透传到内部 `OpenAIConfig`。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
         self.0 = self.0.with_api_key_source(source);
         self
@@ -66,12 +73,14 @@ pub struct HuggingFaceProvider {
 }
 
 impl HuggingFaceProvider {
+    #[must_use]
     pub fn new(config: HuggingFaceConfig) -> Self {
         Self { config }
     }
 
     /// Create a chat model instance for the given Hugging Face model id
     /// (e.g. `"meta-llama/Llama-3.3-70B-Instruct"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         OpenAIModel::new(model_id.to_string(), self.config.0.clone())
     }
@@ -81,6 +90,7 @@ impl HuggingFaceProvider {
     /// The Hugging Face Responses API is the lightest Responses implementation:
     /// it supports function tools only (no built-in tools), and uses the
     /// `text.format` field for structured output.
+    #[must_use]
     pub fn responses_model(&self, model_id: &str) -> responses::HuggingFaceResponsesModel {
         responses::HuggingFaceResponsesModel::new(model_id.to_string(), self.config.clone())
     }

--- a/aimux-providers/src/huggingface/responses.rs
+++ b/aimux-providers/src/huggingface/responses.rs
@@ -57,6 +57,7 @@ pub struct HuggingFaceResponsesModel {
 }
 
 impl HuggingFaceResponsesModel {
+    #[must_use]
     pub fn new(model_id: String, config: HuggingFaceConfig) -> Self {
         Self { model_id, config }
     }
@@ -139,7 +140,7 @@ impl LanguageModel for HuggingFaceResponsesModel {
                     .get("code")
                     .or_else(|| error.get("type"))
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 message: message.to_string(),
                 response_body: Some(String::from_utf8_lossy(&resp.body).into_owned()),
                 ..Default::default()
@@ -153,15 +154,15 @@ impl LanguageModel for HuggingFaceResponsesModel {
         let response_id = response
             .get("id")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         let created_at = response
             .get("created_at")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(0);
         let model = response
             .get("model")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
 
         Ok(GenerateResult {
             content,
@@ -252,15 +253,15 @@ impl LanguageModel for HuggingFaceResponsesModel {
                                     response_id = resp
                                         .get("id")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string());
+                                        .map(std::string::ToString::to_string);
                                     let created_at = resp
                                         .get("created_at")
-                                        .and_then(|v| v.as_u64())
+                                        .and_then(serde_json::Value::as_u64)
                                         .unwrap_or(0);
                                     let model = resp
                                         .get("model")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string());
+                                        .map(std::string::ToString::to_string);
                                     yield Ok(StreamPart::ResponseMetadata {
                                         id: response_id.clone(),
                                         timestamp: format_timestamp(created_at),
@@ -450,7 +451,7 @@ impl LanguageModel for HuggingFaceResponsesModel {
                                     response_id = resp
                                         .get("id")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string());
+                                        .map(std::string::ToString::to_string);
 
                                     let incomplete_reason = resp
                                         .get("incomplete_details")
@@ -461,7 +462,7 @@ impl LanguageModel for HuggingFaceResponsesModel {
                                         unified: map_finish_reason(
                                             incomplete_reason.unwrap_or("stop"),
                                         ),
-                                        raw: incomplete_reason.map(|s| s.to_string()),
+                                        raw: incomplete_reason.map(std::string::ToString::to_string),
                                     };
 
                                     if let Some(usage) = resp.get("usage")
@@ -524,6 +525,11 @@ pub struct RequestBodyResult {
 ///
 /// Mirrors the TS `getArgs` + `doGenerate`/`doStream` body assembly. The
 /// `stream` flag controls the `stream` field in the body.
+///
+/// # Errors
+///
+/// Propagates prompt-conversion errors from
+/// `convert_to_huggingface_responses_messages`.
 pub fn build_request_body_with_warnings(
     model_id: &str,
     options: &CallOptions,
@@ -575,15 +581,15 @@ pub fn build_request_body_with_warnings(
     let instructions = hf_options
         .and_then(|o| o.get("instructions"))
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
     let strict_json_schema = hf_options
         .and_then(|o| o.get("strictJsonSchema"))
-        .and_then(|v| v.as_bool())
+        .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
     let reasoning_effort = hf_options
         .and_then(|o| o.get("reasoningEffort"))
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
 
     // Prepare tools.
     let (tools, tool_choice, tool_warnings) =
@@ -665,6 +671,11 @@ pub fn build_request_body_with_warnings(
 /// Mirrors the TS `convertToHuggingFaceResponsesMessages`. Returns an error
 /// for unsupported file part variants (provider references, non-image media
 /// types) — matching the TS `UnsupportedFunctionalityError`.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::UnsupportedFunctionality` for file parts with no
+/// Responses representation (provider references, non-image media types).
 pub fn convert_to_huggingface_responses_messages(
     prompt: &LanguageModelPrompt,
 ) -> Result<(Value, Vec<Warning>), AiMuxError> {
@@ -779,8 +790,7 @@ fn convert_file_part_base64(media_type: &str, data: &str) -> Result<Value, AiMux
         }))
     } else {
         Err(AiMuxError::UnsupportedFunctionality(format!(
-            "file part media type {}",
-            media_type
+            "file part media type {media_type}"
         )))
     }
 }
@@ -795,8 +805,7 @@ fn convert_file_part_url(media_type: &str, url: &str) -> Result<Value, AiMuxErro
         }))
     } else {
         Err(AiMuxError::UnsupportedFunctionality(format!(
-            "file part media type {}",
-            media_type
+            "file part media type {media_type}"
         )))
     }
 }
@@ -842,8 +851,7 @@ fn resolve_full_media_type_base64(media_type: &str, data: &str) -> Result<String
     }
 
     Err(AiMuxError::UnsupportedFunctionality(format!(
-        "file of media type \"{}\" must specify subtype since it could not be auto-detected",
-        media_type
+        "file of media type \"{media_type}\" must specify subtype since it could not be auto-detected"
     )))
 }
 
@@ -957,6 +965,7 @@ fn detect_media_type_from_base64(data: &str, top_level: &str) -> Option<String> 
 ///
 /// Returns `(tools, tool_choice, warnings)`. Only function tools are supported;
 /// provider-defined tools produce a warning.
+#[must_use]
 pub fn prepare_responses_tools(
     tools: &Option<Vec<Tool>>,
     tool_choice: &ToolChoice,
@@ -1041,10 +1050,10 @@ fn build_generate_content(response: &Value) -> Vec<GenerateContent> {
                             let url = ann.get("url").and_then(|v| v.as_str()).unwrap_or("");
                             let title = ann.get("title").and_then(|v| v.as_str());
                             content.push(GenerateContent::Source {
-                                id: format!("id-{}", source_id_counter),
+                                id: format!("id-{source_id_counter}"),
                                 source_type: "url".to_string(),
                                 url: Some(url.to_string()),
-                                title: title.map(|s| s.to_string()),
+                                title: title.map(std::string::ToString::to_string),
                                 provider_metadata: None,
                             });
                             source_id_counter += 1;
@@ -1143,7 +1152,7 @@ fn parse_finish_reason(response: &Value) -> FinishReason {
 
     FinishReason {
         unified: map_finish_reason(incomplete_reason.unwrap_or("stop")),
-        raw: incomplete_reason.map(|s| s.to_string()),
+        raw: incomplete_reason.map(std::string::ToString::to_string),
     }
 }
 
@@ -1173,17 +1182,23 @@ fn convert_usage(usage: Option<&Value>) -> Usage {
         Some(u) => u,
     };
 
-    let input_tokens = u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-    let output_tokens = u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    let input_tokens = u
+        .get("input_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0) as u32;
+    let output_tokens = u
+        .get("output_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0) as u32;
     let cached_tokens = u
         .get("input_tokens_details")
         .and_then(|d| d.get("cached_tokens"))
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .unwrap_or(0) as u32;
     let reasoning_tokens = u
         .get("output_tokens_details")
         .and_then(|d| d.get("reasoning_tokens"))
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .unwrap_or(0) as u32;
 
     Usage {

--- a/aimux-providers/src/hume.rs
+++ b/aimux-providers/src/hume.rs
@@ -52,18 +52,24 @@ impl HumeConfig {
     }
 
     /// Override the base URL (for testing or proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into().trim_end_matches('/').to_string();
         self
     }
 
     /// Attach extra headers merged into every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Create from environment variable `HUME_API_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `HUME_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "HUME_API_KEY", "Hume")?;
         Ok(Self::new(api_key))
@@ -78,12 +84,14 @@ pub struct HumeProvider {
 }
 
 impl HumeProvider {
+    #[must_use]
     pub fn new(config: HumeConfig) -> Self {
         Self { config }
     }
 
     /// Create a speech (TTS) model instance. Hume does not use model IDs for
     /// TTS, so the model ID is always an empty string.
+    #[must_use]
     pub fn speech(&self) -> HumeSpeechModel {
         HumeSpeechModel::new(self.config.clone())
     }
@@ -105,6 +113,7 @@ pub struct HumeSpeechModel {
 }
 
 impl HumeSpeechModel {
+    #[must_use]
     pub fn new(config: HumeConfig) -> Self {
         Self {
             model_id: String::new(),
@@ -236,8 +245,7 @@ fn build_request(
         warnings.push(Warning::Unsupported {
             feature: "outputFormat".to_string(),
             details: Some(format!(
-                "Unsupported output format: {}. Using mp3 instead.",
-                output_format
+                "Unsupported output format: {output_format}. Using mp3 instead."
             )),
         });
     }
@@ -255,8 +263,7 @@ fn build_request(
         warnings.push(Warning::Unsupported {
             feature: "language".to_string(),
             details: Some(format!(
-                "Hume speech models do not support language selection. Language parameter \"{}\" was ignored.",
-                language
+                "Hume speech models do not support language selection. Language parameter \"{language}\" was ignored."
             )),
         });
     }
@@ -301,10 +308,10 @@ fn parse_hume_provider_options(
                     if let Some(d) = u.get("description").and_then(|v| v.as_str()) {
                         m.insert("description".to_string(), json!(d));
                     }
-                    if let Some(s) = u.get("speed").and_then(|v| v.as_f64()) {
+                    if let Some(s) = u.get("speed").and_then(serde_json::Value::as_f64) {
                         m.insert("speed".to_string(), json!(s));
                     }
-                    if let Some(ts) = u.get("trailingSilence").and_then(|v| v.as_f64()) {
+                    if let Some(ts) = u.get("trailingSilence").and_then(serde_json::Value::as_f64) {
                         m.insert("trailing_silence".to_string(), json!(ts));
                     }
                     if let Some(v) = u.get("voice") {

--- a/aimux-providers/src/jina_ai.rs
+++ b/aimux-providers/src/jina_ai.rs
@@ -56,18 +56,24 @@ impl JinaAiConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Attach extra default headers sent with every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Create from the `JINA_AI_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `JINA_AI_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "JINA_AI_API_KEY", "Jina AI")?;
         Ok(Self::new(api_key))
@@ -82,12 +88,14 @@ pub struct JinaAiProvider {
 }
 
 impl JinaAiProvider {
+    #[must_use]
     pub fn new(config: JinaAiConfig) -> Self {
         Self { config }
     }
 
     /// Create a reranking model instance for the given model name (e.g.
     /// `"jina-reranker-v2-base-multilingual"` or `"jina-reranker-v3"`).
+    #[must_use]
     pub fn reranking_model(&self, model_id: &str) -> JinaAiRerankingModel {
         JinaAiRerankingModel::new(model_id.to_string(), self.config.clone())
     }
@@ -111,7 +119,9 @@ fn parse_jina_reranking_options(
     let mut opts = JinaRerankingOptions::default();
     if let Some(po) = provider_options
         && let Some(jina) = po.get("jina")
-        && let Some(v) = jina.get("returnDocuments").and_then(|v| v.as_bool())
+        && let Some(v) = jina
+            .get("returnDocuments")
+            .and_then(serde_json::Value::as_bool)
     {
         opts.return_documents = Some(v);
     }
@@ -135,7 +145,10 @@ fn build_request_body(
                 feature: "object documents".to_string(),
                 details: Some("Object documents are converted to strings.".to_string()),
             });
-            values.iter().map(|v| v.to_string()).collect()
+            values
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect()
         }
     };
 
@@ -178,6 +191,7 @@ pub struct JinaAiRerankingModel {
 }
 
 impl JinaAiRerankingModel {
+    #[must_use]
     pub fn new(model_id: String, config: JinaAiConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/jlama.rs
+++ b/aimux-providers/src/jlama.rs
@@ -30,6 +30,13 @@ impl JlamaConfig {
         )
     }
 
+    /// Create from the `JLAMA_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl JlamaConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl JlamaConfig {
 pub struct JlamaProvider(OpenAIProvider);
 
 impl JlamaProvider {
+    #[must_use]
     pub fn new(config: JlamaConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/klingai.rs
+++ b/aimux-providers/src/klingai.rs
@@ -44,16 +44,24 @@ impl KlingAIConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Create from the `KLINGAI_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "KLINGAI_API_KEY", "KlingAI")?;
         Ok(Self::new(api_key))
@@ -65,10 +73,12 @@ pub struct KlingAIProvider {
 }
 
 impl KlingAIProvider {
+    #[must_use]
     pub fn new(config: KlingAIConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn video(&self, model_id: &str) -> KlingAIVideoModel {
         KlingAIVideoModel::new(model_id.to_string(), self.config.clone())
     }
@@ -141,6 +151,7 @@ pub struct KlingAIVideoModel {
 }
 
 impl KlingAIVideoModel {
+    #[must_use]
     pub fn new(model_id: String, config: KlingAIConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/linkup.rs
+++ b/aimux-providers/src/linkup.rs
@@ -69,12 +69,17 @@ impl LinkupConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Create from the `LINKUP_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `LINKUP_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "LINKUP_API_KEY", "Linkup")?;
         Ok(Self::new(api_key))
@@ -89,11 +94,13 @@ pub struct LinkupProvider {
 }
 
 impl LinkupProvider {
+    #[must_use]
     pub fn new(config: LinkupConfig) -> Self {
         Self { config }
     }
 
     /// Create a search model instance.
+    #[must_use]
     pub fn search_model(&self) -> LinkupSearchModel {
         LinkupSearchModel::new(self.config.clone())
     }
@@ -174,6 +181,7 @@ pub struct LinkupSearchModel {
 }
 
 impl LinkupSearchModel {
+    #[must_use]
     pub fn new(config: LinkupConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/litellm_proxy.rs
+++ b/aimux-providers/src/litellm_proxy.rs
@@ -30,6 +30,13 @@ impl LitellmProxyConfig {
         )
     }
 
+    /// Create from the `LITELLM_PROXY_API_KEY` environment variable (which holds
+    /// a base URL), falling back to `http://127.0.0.1:4000/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl LitellmProxyConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl LitellmProxyConfig {
 pub struct LitellmProxyProvider(OpenAIProvider);
 
 impl LitellmProxyProvider {
+    #[must_use]
     pub fn new(config: LitellmProxyConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/llamacpp.rs
+++ b/aimux-providers/src/llamacpp.rs
@@ -30,6 +30,13 @@ impl LlamacppConfig {
         )
     }
 
+    /// Create from the `LLAMACPP_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl LlamacppConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl LlamacppConfig {
 pub struct LlamacppProvider(OpenAIProvider);
 
 impl LlamacppProvider {
+    #[must_use]
     pub fn new(config: LlamacppConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/llamafile.rs
+++ b/aimux-providers/src/llamafile.rs
@@ -49,6 +49,11 @@ impl LlamafileConfig {
     /// inference server that does not require authentication. When the variable
     /// is unset (or empty), the default local endpoint
     /// (`http://127.0.0.1:8080/v1`) is used.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset `LLAMAFILE_BASE_URL` falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -58,6 +63,7 @@ impl LlamafileConfig {
     }
 
     /// Override the base URL (useful for tests / non-default ports).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -68,12 +74,14 @@ impl LlamafileConfig {
 pub struct LlamafileProvider(OpenAIProvider);
 
 impl LlamafileProvider {
+    #[must_use]
     pub fn new(config: LlamafileConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given llamafile model id
     /// (e.g. `"llama3.2:latest"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/lmnt.rs
+++ b/aimux-providers/src/lmnt.rs
@@ -50,18 +50,24 @@ impl LMNTConfig {
     }
 
     /// Override the base URL (for testing or proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into().trim_end_matches('/').to_string();
         self
     }
 
     /// Attach extra headers merged into every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Create from environment variable `LMNT_API_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `LMNT_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "LMNT_API_KEY", "LMNT")?;
         Ok(Self::new(api_key))
@@ -76,12 +82,14 @@ pub struct LMNTProvider {
 }
 
 impl LMNTProvider {
+    #[must_use]
     pub fn new(config: LMNTConfig) -> Self {
         Self { config }
     }
 
     /// Create a speech (TTS) model instance for the given model name (e.g.
     /// `"aurora"`).
+    #[must_use]
     pub fn speech(&self, model_id: &str) -> LMNTSpeechModel {
         LMNTSpeechModel::new(model_id.to_string(), self.config.clone())
     }
@@ -102,6 +110,7 @@ pub struct LMNTSpeechModel {
 }
 
 impl LMNTSpeechModel {
+    #[must_use]
     pub fn new(model_id: String, config: LMNTConfig) -> Self {
         Self { model_id, config }
     }
@@ -216,8 +225,7 @@ fn build_request(
         warnings.push(Warning::Unsupported {
             feature: "outputFormat".to_string(),
             details: Some(format!(
-                "Unsupported output format: {}. Using mp3 instead.",
-                output_format
+                "Unsupported output format: {output_format}. Using mp3 instead."
             )),
         });
     }
@@ -283,19 +291,21 @@ fn parse_lmnt_provider_options(
     let opts = provider_opts.as_object()?;
 
     Some(LMNTSpeechProviderOptions {
-        conversational: opts.get("conversational").and_then(|v| v.as_bool()),
-        length: opts.get("length").and_then(|v| v.as_f64()),
-        seed: opts.get("seed").and_then(|v| v.as_u64()),
-        speed: opts.get("speed").and_then(|v| v.as_f64()),
-        temperature: opts.get("temperature").and_then(|v| v.as_f64()),
-        top_p: opts.get("topP").and_then(|v| v.as_f64()),
+        conversational: opts
+            .get("conversational")
+            .and_then(serde_json::Value::as_bool),
+        length: opts.get("length").and_then(serde_json::Value::as_f64),
+        seed: opts.get("seed").and_then(serde_json::Value::as_u64),
+        speed: opts.get("speed").and_then(serde_json::Value::as_f64),
+        temperature: opts.get("temperature").and_then(serde_json::Value::as_f64),
+        top_p: opts.get("topP").and_then(serde_json::Value::as_f64),
         sample_rate: opts
             .get("sampleRate")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|n| n as u32),
         format: opts
             .get("format")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
     })
 }

--- a/aimux-providers/src/lmstudio.rs
+++ b/aimux-providers/src/lmstudio.rs
@@ -49,6 +49,11 @@ impl LmStudioConfig {
     /// inference server that does not require authentication. When the variable
     /// is unset (or empty), the default local endpoint
     /// (`http://127.0.0.1:1234/v1`) is used.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset `LMSTUDIO_BASE_URL` falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -58,6 +63,7 @@ impl LmStudioConfig {
     }
 
     /// Override the base URL (useful for tests / non-default ports).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -68,12 +74,14 @@ impl LmStudioConfig {
 pub struct LmStudioProvider(OpenAIProvider);
 
 impl LmStudioProvider {
+    #[must_use]
     pub fn new(config: LmStudioConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given LM Studio model id
     /// (e.g. `"llama-3.2-3b-instruct"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/local.rs
+++ b/aimux-providers/src/local.rs
@@ -30,6 +30,13 @@ impl LocalConfig {
         )
     }
 
+    /// Create from the `LOCAL_LLM_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl LocalConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl LocalConfig {
 pub struct LocalProvider(OpenAIProvider);
 
 impl LocalProvider {
+    #[must_use]
     pub fn new(config: LocalConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/localai.rs
+++ b/aimux-providers/src/localai.rs
@@ -30,6 +30,13 @@ impl LocalaiConfig {
         )
     }
 
+    /// Create from the `LOCALAI_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl LocalaiConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl LocalaiConfig {
 pub struct LocalaiProvider(OpenAIProvider);
 
 impl LocalaiProvider {
+    #[must_use]
     pub fn new(config: LocalaiConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/luma.rs
+++ b/aimux-providers/src/luma.rs
@@ -42,14 +42,22 @@ impl LumaConfig {
             headers: None,
         }
     }
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
+    /// Create from the `LUMA_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "LUMA_API_KEY", "Luma")?;
         Ok(Self::new(api_key))
@@ -60,9 +68,11 @@ pub struct LumaProvider {
     config: LumaConfig,
 }
 impl LumaProvider {
+    #[must_use]
     pub fn new(config: LumaConfig) -> Self {
         Self { config }
     }
+    #[must_use]
     pub fn image(&self, model_id: &str) -> LumaImageModel {
         LumaImageModel::new(model_id.to_string(), self.config.clone())
     }
@@ -74,6 +84,7 @@ pub struct LumaImageModel {
     config: LumaConfig,
 }
 impl LumaImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: LumaConfig) -> Self {
         Self { model_id, config }
     }
@@ -147,11 +158,11 @@ impl ImageModel for LumaImageModel {
         // Extract non-request options
         let poll_interval = luma_opts
             .and_then(|o| o.get("pollIntervalMillis"))
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(DEFAULT_POLL_INTERVAL_MS);
         let max_poll_attempts = luma_opts
             .and_then(|o| o.get("maxPollAttempts"))
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(DEFAULT_MAX_POLL_ATTEMPTS);
         let reference_type = luma_opts
             .and_then(|o| o.get("referenceType"))
@@ -197,7 +208,7 @@ impl ImageModel for LumaImageModel {
                                 .as_ref()
                                 .and_then(|c| c.get(i))
                                 .and_then(|c| c.get("weight"))
-                                .and_then(|v| v.as_f64())
+                                .and_then(serde_json::Value::as_f64)
                                 .unwrap_or(default_weight);
                             json!({ "url": url, "weight": weight })
                         })
@@ -219,7 +230,7 @@ impl ImageModel for LumaImageModel {
                         .as_ref()
                         .and_then(|c| c.first())
                         .and_then(|c| c.get("weight"))
-                        .and_then(|v| v.as_f64())
+                        .and_then(serde_json::Value::as_f64)
                         .unwrap_or(default_weight);
                     editing_opts.insert(
                         "modify_image".into(),
@@ -246,7 +257,7 @@ impl ImageModel for LumaImageModel {
                                 .as_ref()
                                 .and_then(|c| c.get(i))
                                 .and_then(|c| c.get("weight"))
-                                .and_then(|v| v.as_f64())
+                                .and_then(serde_json::Value::as_f64)
                                 .unwrap_or(default_weight);
                             json!({ "url": url, "weight": weight })
                         })

--- a/aimux-providers/src/mistral/convert.rs
+++ b/aimux-providers/src/mistral/convert.rs
@@ -1,4 +1,4 @@
-﻿//! Conversion between `LanguageModelPrompt` and Mistral API format.
+//! Conversion between `LanguageModelPrompt` and Mistral API format.
 //!
 //! Mirrors the TS `convert-to-mistral-chat-messages.ts`,
 //! `mistral-prepare-tools.ts`, and `map-mistral-finish-reason.ts`.
@@ -26,6 +26,7 @@ pub struct PreparedTools {
 /// Key difference from OpenAI: `ToolChoice::Required` maps to `"any"` (not
 /// `"required"`), and `ToolChoice::Tool` filters the tools array and also uses
 /// `"any"`.
+#[must_use]
 pub fn prepare_tools(
     tools: &Option<Vec<FunctionTool>>,
     tool_choice: Option<&ToolChoice>,
@@ -100,6 +101,7 @@ pub fn prepare_tools(
 ///   message if it is an assistant message (continuation mode).
 /// - Tool messages include `tool_call_id` (no `name` — the Rust data model
 ///   does not carry the tool name on `ToolResult` parts).
+#[must_use]
 pub fn convert_prompt_to_mistral_messages(prompt: &LanguageModelPrompt) -> Vec<Value> {
     let mut result = Vec::new();
     let last_idx = prompt.len().saturating_sub(1);
@@ -278,6 +280,7 @@ fn convert_part_to_mistral(part: &ContentPart) -> Value {
 // ── Request body ────────────────────────────────────────────────────────────
 
 /// Convert `CallOptions` to a Mistral request body.
+#[must_use]
 pub fn build_request_body(model_id: &str, options: &CallOptions, stream: bool) -> Value {
     let messages = convert_prompt_to_mistral_messages(&options.prompt);
 
@@ -367,6 +370,7 @@ pub fn build_request_body(model_id: &str, options: &CallOptions, stream: bool) -
 /// Parse Mistral finish reason string into `FinishReason`.
 ///
 /// Differences from OpenAI: `model_length` is also mapped to `Length`.
+#[must_use]
 pub fn parse_finish_reason(s: &str) -> FinishReason {
     let unified = match s {
         "stop" => FinishReasonUnified::Stop,

--- a/aimux-providers/src/mistral/embedding.rs
+++ b/aimux-providers/src/mistral/embedding.rs
@@ -28,6 +28,7 @@ pub struct MistralEmbeddingModel {
 }
 
 impl MistralEmbeddingModel {
+    #[must_use]
     pub fn new(model_id: String, config: MistralConfig) -> Self {
         Self { model_id, config }
     }
@@ -138,7 +139,7 @@ impl EmbeddingModel for MistralEmbeddingModel {
         let usage = raw_value
             .get("usage")
             .and_then(|u| u.get("prompt_tokens"))
-            .and_then(|t| t.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|tokens| EmbeddingUsage {
                 tokens: tokens as u32,
             });
@@ -172,11 +173,11 @@ fn parse_mistral_provider_options(
         metadata: provider_opts.and_then(|o| o.get("metadata")).cloned(),
         output_dimension: provider_opts
             .and_then(|o| o.get("outputDimension"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
         output_dtype: provider_opts
             .and_then(|o| o.get("outputDtype"))
             .and_then(|d| d.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
     }
 }

--- a/aimux-providers/src/mistral/mod.rs
+++ b/aimux-providers/src/mistral/mod.rs
@@ -41,24 +41,31 @@ impl MistralConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// Create from environment variable `MISTRAL_API_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `MISTRAL_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "MISTRAL_API_KEY", "Mistral")?;
         Ok(Self::new(api_key).with_api_key_source(Some("env:MISTRAL_API_KEY")))
@@ -71,17 +78,20 @@ pub struct MistralProvider {
 }
 
 impl MistralProvider {
+    #[must_use]
     pub fn new(config: MistralConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given model name (e.g. `"mistral-small-latest"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> model::MistralModel {
         model::MistralModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create an embedding model instance for the given model name (e.g.
     /// `"mistral-embed"`).
+    #[must_use]
     pub fn embedding_model(&self, model_id: &str) -> embedding::MistralEmbeddingModel {
         embedding::MistralEmbeddingModel::new(model_id.to_string(), self.config.clone())
     }

--- a/aimux-providers/src/mistral/model.rs
+++ b/aimux-providers/src/mistral/model.rs
@@ -143,7 +143,7 @@ fn extract_text_content(content: &Option<Value>) -> Option<String> {
                     if part.get("type").and_then(|t| t.as_str()) == Some("text") {
                         part.get("text")
                             .and_then(|t| t.as_str())
-                            .map(|s| s.to_string())
+                            .map(std::string::ToString::to_string)
                     } else {
                         None
                     }
@@ -178,7 +178,7 @@ fn extract_reasoning_content(content: &Option<Value>) -> Option<String> {
                                             chunk
                                                 .get("text")
                                                 .and_then(|t| t.as_str())
-                                                .map(|s| s.to_string())
+                                                .map(std::string::ToString::to_string)
                                         } else {
                                             None
                                         }
@@ -447,7 +447,7 @@ impl LanguageModel for MistralModel {
                                         // End any active text before starting reasoning.
                                         if text_started {
                                             yield Ok(StreamPart::TextEnd {
-                                                id: format!("{}", text_id),
+                                                id: format!("{text_id}"),
                                                 provider_metadata: None,
                                             });
                                             text_started = false;
@@ -491,13 +491,13 @@ impl LanguageModel for MistralModel {
                                             reasoning_id = None;
                                         }
                                         yield Ok(StreamPart::TextStart {
-                                            id: format!("{}", text_id),
+                                            id: format!("{text_id}"),
                                             provider_metadata: None,
                                         });
                                         text_started = true;
                                     }
                                     yield Ok(StreamPart::TextDelta {
-                                        id: format!("{}", text_id),
+                                        id: format!("{text_id}"),
                                         delta: text_delta,
                                         provider_metadata: None,
                                     });
@@ -550,7 +550,7 @@ impl LanguageModel for MistralModel {
                             if let Some(reason) = choice.finish_reason {
                                 if text_started {
                                     yield Ok(StreamPart::TextEnd {
-                                        id: format!("{}", text_id),
+                                        id: format!("{text_id}"),
                                         provider_metadata: None,
                                     });
                                     text_started = false;
@@ -582,7 +582,7 @@ impl LanguageModel for MistralModel {
             // Close any remaining open segments.
             if text_started {
                 yield Ok(StreamPart::TextEnd {
-                    id: format!("{}", text_id),
+                    id: format!("{text_id}"),
                     provider_metadata: None,
                 });
             }

--- a/aimux-providers/src/mistralrs.rs
+++ b/aimux-providers/src/mistralrs.rs
@@ -49,6 +49,11 @@ impl MistralrsConfig {
     /// inference server that does not require authentication. When the variable
     /// is unset (or empty), the default local endpoint
     /// (`http://127.0.0.1:8080/v1`) is used.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset `MISTRALRS_BASE_URL` falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -58,6 +63,7 @@ impl MistralrsConfig {
     }
 
     /// Override the base URL (useful for tests / non-default ports).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -68,12 +74,14 @@ impl MistralrsConfig {
 pub struct MistralrsProvider(OpenAIProvider);
 
 impl MistralrsProvider {
+    #[must_use]
     pub fn new(config: MistralrsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given mistral.rs model id
     /// (e.g. `"Qwen/Qwen3-4B"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/mlx.rs
+++ b/aimux-providers/src/mlx.rs
@@ -30,6 +30,13 @@ impl MlxConfig {
         )
     }
 
+    /// Create from the `MLX_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl MlxConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl MlxConfig {
 pub struct MlxProvider(OpenAIProvider);
 
 impl MlxProvider {
+    #[must_use]
     pub fn new(config: MlxConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/ollama.rs
+++ b/aimux-providers/src/ollama.rs
@@ -52,6 +52,11 @@ impl OllamaConfig {
     /// inference server that does not require authentication. When the variable
     /// is unset (or empty), the default local endpoint
     /// (`http://127.0.0.1:11434/v1`) is used.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset `OLLAMA_BASE_URL` falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -61,6 +66,7 @@ impl OllamaConfig {
     }
 
     /// Override the base URL (useful for tests / non-default ports).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -71,12 +77,14 @@ impl OllamaConfig {
 pub struct OllamaProvider(OpenAIProvider);
 
 impl OllamaProvider {
+    #[must_use]
     pub fn new(config: OllamaConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Ollama model id
     /// (e.g. `"llama3.2"` or `"qwen3:4b"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/omlx.rs
+++ b/aimux-providers/src/omlx.rs
@@ -30,6 +30,13 @@ impl OmlxConfig {
         )
     }
 
+    /// Create from the `OMLX_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl OmlxConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl OmlxConfig {
 pub struct OmlxProvider(OpenAIProvider);
 
 impl OmlxProvider {
+    #[must_use]
     pub fn new(config: OmlxConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/onnx.rs
+++ b/aimux-providers/src/onnx.rs
@@ -30,6 +30,13 @@ impl OnnxConfig {
         )
     }
 
+    /// Create from the `ONNX_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl OnnxConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl OnnxConfig {
 pub struct OnnxProvider(OpenAIProvider);
 
 impl OnnxProvider {
+    #[must_use]
     pub fn new(config: OnnxConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/oobabooba.rs
+++ b/aimux-providers/src/oobabooba.rs
@@ -30,6 +30,13 @@ impl OobaboobaConfig {
         )
     }
 
+    /// Create from the `OOBABOOBA_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:5000/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl OobaboobaConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl OobaboobaConfig {
 pub struct OobaboobaProvider(OpenAIProvider);
 
 impl OobaboobaProvider {
+    #[must_use]
     pub fn new(config: OobaboobaConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/open_responses.rs
+++ b/aimux-providers/src/open_responses.rs
@@ -90,13 +90,14 @@ impl OpenResponsesConfig {
                 use std::sync::atomic::{AtomicU64, Ordering};
                 static COUNTER: AtomicU64 = AtomicU64::new(0);
                 let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-                format!("id-{}", n)
+                format!("id-{n}")
             }),
             api_key_source: None,
         }
     }
 
     /// Set a header factory.
+    #[must_use]
     pub fn with_headers<F>(mut self, headers: F) -> Self
     where
         F: Fn() -> HashMap<String, String> + Send + Sync + 'static,
@@ -106,6 +107,7 @@ impl OpenResponsesConfig {
     }
 
     /// Set a generate-id factory.
+    #[must_use]
     pub fn with_generate_id<F>(mut self, generate_id: F) -> Self
     where
         F: Fn() -> String + Send + Sync + 'static,
@@ -117,8 +119,9 @@ impl OpenResponsesConfig {
     /// 标注凭证来源(RFC-0023 回放重建用)。Open Responses 的认证由调用方经
     /// `headers` 闭包管理;此 setter 让调用方显式标注来源(如 `env:VAR`),
     /// 覆盖 `config_snapshot` 对闭包的推断。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 }
@@ -131,11 +134,13 @@ pub struct OpenResponsesProvider {
 }
 
 impl OpenResponsesProvider {
+    #[must_use]
     pub fn new(config: OpenResponsesConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given model id.
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenResponsesModel {
         OpenResponsesModel::new(model_id.to_string(), &self.config)
     }
@@ -160,6 +165,7 @@ pub struct OpenResponsesModel {
 }
 
 impl OpenResponsesModel {
+    #[must_use]
     pub fn new(model_id: String, config: &OpenResponsesConfig) -> Self {
         Self {
             model_id,
@@ -296,7 +302,7 @@ impl LanguageModel for OpenResponsesModel {
                     .get("code")
                     .or_else(|| error.get("type"))
                     .and_then(|c| c.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 message: message.to_string(),
                 response_body: Some(String::from_utf8_lossy(&resp.body).into_owned()),
                 ..Default::default()
@@ -305,14 +311,14 @@ impl LanguageModel for OpenResponsesModel {
 
         // Check for null/missing output.
         let output = raw.get("output");
-        if output.map(|o| o.is_null()).unwrap_or(true) {
+        if output.map(serde_json::Value::is_null).unwrap_or(true) {
             let detail = raw
                 .get("incomplete_details")
                 .and_then(|d| d.get("reason"))
                 .and_then(|r| r.as_str())
                 .or_else(|| raw.get("status").and_then(|s| s.as_str()));
             let message = match detail {
-                Some(d) => format!("Responses API returned no output ({})", d),
+                Some(d) => format!("Responses API returned no output ({d})"),
                 None => "Responses API returned no output".to_string(),
             };
             return Err(AiMuxError::InvalidResponseData(message));
@@ -393,22 +399,22 @@ impl LanguageModel for OpenResponsesModel {
 
         let finish_reason = FinishReason {
             unified: map_open_responses_finish_reason(incomplete_reason, has_tool_calls),
-            raw: incomplete_reason.map(|s| s.to_string()),
+            raw: incomplete_reason.map(std::string::ToString::to_string),
         };
 
         let response = ResponseMetadata {
             id: raw
                 .get("id")
                 .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
+                .map(std::string::ToString::to_string),
             timestamp: raw
                 .get("created_at")
-                .and_then(|v| v.as_u64())
-                .map(|ts| format!("{}", ts)),
+                .and_then(serde_json::Value::as_u64)
+                .map(|ts| format!("{ts}")),
             model_id: raw
                 .get("model")
                 .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
+                .map(std::string::ToString::to_string),
         };
 
         Ok(GenerateResult {
@@ -473,7 +479,7 @@ impl LanguageModel for OpenResponsesModel {
                     .get("code")
                     .or_else(|| err_obj.get("type"))
                     .and_then(|c| c.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 message: message.to_string(),
                 response_body: Some(event.data.clone()),
                 ..Default::default()
@@ -539,15 +545,15 @@ impl LanguageModel for OpenResponsesModel {
                                                     tool_name: item
                                                         .get("name")
                                                         .and_then(|v| v.as_str())
-                                                        .map(|s| s.to_string()),
+                                                        .map(std::string::ToString::to_string),
                                                     tool_call_id: item
                                                         .get("call_id")
                                                         .and_then(|v| v.as_str())
-                                                        .map(|s| s.to_string()),
+                                                        .map(std::string::ToString::to_string),
                                                     arguments: item
                                                         .get("arguments")
                                                         .and_then(|v| v.as_str())
-                                                        .map(|s| s.to_string()),
+                                                        .map(std::string::ToString::to_string),
                                                 },
                                             );
                                         }
@@ -640,7 +646,7 @@ impl LanguageModel for OpenResponsesModel {
                                                 .or_else(|| {
                                                     item.get("name")
                                                         .and_then(|v| v.as_str())
-                                                        .map(|s| s.to_string())
+                                                        .map(std::string::ToString::to_string)
                                                 })
                                                 .unwrap_or_default();
                                             let tool_call_id = accum
@@ -649,7 +655,7 @@ impl LanguageModel for OpenResponsesModel {
                                                 .or_else(|| {
                                                     item.get("call_id")
                                                         .and_then(|v| v.as_str())
-                                                        .map(|s| s.to_string())
+                                                        .map(std::string::ToString::to_string)
                                                 })
                                                 .unwrap_or_default();
                                             let arguments = accum
@@ -658,7 +664,7 @@ impl LanguageModel for OpenResponsesModel {
                                                 .or_else(|| {
                                                     item.get("arguments")
                                                         .and_then(|v| v.as_str())
-                                                        .map(|s| s.to_string())
+                                                        .map(std::string::ToString::to_string)
                                                 })
                                                 .unwrap_or_default();
                                             let input: Value =
@@ -746,7 +752,7 @@ impl LanguageModel for OpenResponsesModel {
                                             reason,
                                             has_tool_calls,
                                         ),
-                                        raw: reason.map(|s| s.to_string()),
+                                        raw: reason.map(std::string::ToString::to_string),
                                     };
                                     if let Some(usage_val) = response.get("usage") {
                                         final_usage = extract_usage_from_value(usage_val);
@@ -764,7 +770,7 @@ impl LanguageModel for OpenResponsesModel {
                                         });
                                     finish_reason = FinishReason {
                                         unified: FinishReasonUnified::Error,
-                                        raw: raw.map(|s| s.to_string()),
+                                        raw: raw.map(std::string::ToString::to_string),
                                     };
                                     if let Some(usage_val) = response.get("usage") {
                                         final_usage = extract_usage_from_value(usage_val);
@@ -821,6 +827,7 @@ struct ToolCallAccum {
 /// Map an Open Responses finish reason to the unified enum.
 ///
 /// Mirrors the TS `mapOpenResponsesFinishReason`.
+#[must_use]
 pub fn map_open_responses_finish_reason(
     finish_reason: Option<&str>,
     has_tool_calls: bool,
@@ -977,7 +984,7 @@ fn build_request_body(
         .and_then(|m| m.get(provider_options_name))
         .and_then(|o| o.get("reasoningSummary"))
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
 
     // Build reasoning object.
     let reasoning: Option<Value> =
@@ -1038,6 +1045,7 @@ fn build_request_body(
 ///
 /// Mirrors the TS `convertToOpenResponsesInput`. System messages become
 /// `instructions`; user/assistant/tool messages become `input` items.
+#[must_use]
 pub fn convert_to_open_responses_input(
     prompt: &LanguageModelPrompt,
 ) -> (Value, Option<String>, Vec<Warning>) {
@@ -1349,21 +1357,21 @@ fn extract_usage(raw: &Value) -> Usage {
 fn extract_usage_from_value(usage: &Value) -> Usage {
     let input_tokens = usage
         .get("input_tokens")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .map(|n| n as u32);
     let cached_input_tokens = usage
         .get("input_tokens_details")
         .and_then(|d| d.get("cached_tokens"))
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .map(|n| n as u32);
     let output_tokens = usage
         .get("output_tokens")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .map(|n| n as u32);
     let reasoning_tokens = usage
         .get("output_tokens_details")
         .and_then(|d| d.get("reasoning_tokens"))
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .map(|n| n as u32);
 
     Usage {

--- a/aimux-providers/src/openai/convert.rs
+++ b/aimux-providers/src/openai/convert.rs
@@ -44,6 +44,7 @@ pub struct PreparedTools {
 }
 
 /// Prepare `FunctionTool`s into the OpenAI `tools` / `tool_choice` JSON shape.
+#[must_use]
 pub fn prepare_tools(
     tools: &Option<Vec<FunctionTool>>,
     tool_choice: Option<&ToolChoice>,
@@ -211,6 +212,7 @@ fn prepare_tools_groq(
     since = "0.2.1",
     note = "panics on failure; use convert_prompt_to_openai_messages_with_mode_fallible instead (issue #90 R1)"
 )]
+#[must_use]
 pub fn convert_prompt_to_openai_messages(prompt: &LanguageModelPrompt) -> Vec<Value> {
     convert_prompt_to_openai_messages_with_mode_fallible(prompt, SystemMessageMode::System)
         .expect("convert_prompt_to_openai_messages: conversion failed")
@@ -218,6 +220,12 @@ pub fn convert_prompt_to_openai_messages(prompt: &LanguageModelPrompt) -> Vec<Va
 
 /// Convert a `LanguageModelPrompt` to OpenAI `messages` array with a system
 /// message mode.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` when a message part cannot be
+/// converted (e.g. an unsupported file part shape or a missing provider
+/// reference).
 pub fn convert_prompt_to_openai_messages_with_mode_fallible(
     prompt: &LanguageModelPrompt,
     system_message_mode: SystemMessageMode,
@@ -240,6 +248,7 @@ pub fn convert_prompt_to_openai_messages_with_mode_fallible(
     since = "0.2.1",
     note = "panics on failure; use convert_prompt_to_openai_messages_with_mode_fallible instead (issue #90 R1)"
 )]
+#[must_use]
 pub fn convert_prompt_to_openai_messages_with_mode(
     prompt: &LanguageModelPrompt,
     system_message_mode: SystemMessageMode,
@@ -250,6 +259,12 @@ pub fn convert_prompt_to_openai_messages_with_mode(
 
 /// Convert a `LanguageModelPrompt` to OpenAI `messages` array with a system
 /// message mode and provider name (for provider-specific message conversion).
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` when a message part cannot be
+/// converted (e.g. an unsupported file part shape or a missing provider
+/// reference).
 pub fn convert_prompt_to_openai_messages_with_provider(
     prompt: &LanguageModelPrompt,
     system_message_mode: SystemMessageMode,
@@ -398,7 +413,7 @@ fn convert_file_part_to_openai(
         let format = match full_mt.as_str() {
             "audio/wav" => "wav",
             "audio/mp3" | "audio/mpeg" => "mp3",
-            _ => return Err(format!("audio content parts with media type {}", full_mt)),
+            _ => return Err(format!("audio content parts with media type {full_mt}")),
         };
         let mut part = json!({
             "type": "input_audio",
@@ -418,7 +433,7 @@ fn convert_file_part_to_openai(
     };
 
     if full_mt != "application/pdf" {
-        return Err(format!("file part media type {}", full_mt));
+        return Err(format!("file part media type {full_mt}"));
     }
 
     if url.is_some() {
@@ -427,8 +442,8 @@ fn convert_file_part_to_openai(
 
     let b64 = data_b64.ok_or("PDF part has no data")?;
     let fname = filename
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| format!("part-{}.pdf", part_index));
+        .map(std::string::ToString::to_string)
+        .unwrap_or_else(|| format!("part-{part_index}.pdf"));
     let mut part = json!({
         "type": "file",
         "file": {
@@ -889,6 +904,11 @@ fn openai_option(
 
 /// Convert `CallOptions` to an OpenAI request body (without warnings), or an
 /// [`AiMuxError`] describing what failed.
+///
+/// # Errors
+///
+/// Returns the first conversion error from `build_request_body_with_warnings`
+/// (e.g. `InvalidArgument` for an unconvertible prompt part).
 pub fn build_request_body(
     model_id: &str,
     options: &CallOptions,
@@ -940,7 +960,11 @@ fn resolve_reasoning_effort(
     reasoning: &Option<ReasoningEffort>,
 ) -> Option<String> {
     provider_option(provider_opts, provider, "reasoningEffort")
-        .map(|v| v.as_str().map(|s| s.to_string()).unwrap_or(v.to_string()))
+        .map(|v| {
+            v.as_str()
+                .map(std::string::ToString::to_string)
+                .unwrap_or(v.to_string())
+        })
         .or_else(|| {
             if reasoning.is_some_and(ReasoningEffort::is_custom) {
                 reasoning.map(|r| r.to_string())
@@ -967,7 +991,7 @@ fn resolve_system_message_mode(
     caps: &ModelCapabilities,
 ) -> SystemMessageMode {
     provider_option(provider_opts, provider, "systemMessageMode")
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string))
         .map(|s| match s.as_str() {
             "developer" => SystemMessageMode::Developer,
             "remove" => SystemMessageMode::Remove,
@@ -1254,7 +1278,7 @@ fn apply_service_tier(
         return;
     }
     let service_tier = provider_option(provider_opts, provider, "serviceTier")
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string));
     if let Some(ref st) = service_tier {
         match st.as_str() {
             "flex" => {
@@ -1359,6 +1383,11 @@ fn apply_tools(
 /// Conversion errors propagate to the caller (fail-fast, issue H2): the old
 /// behaviour of silently returning `body: null` sent empty requests upstream
 /// and made conversion failures invisible.
+///
+/// # Errors
+///
+/// Propagates conversion errors, fail-fast: e.g. `InvalidArgument` for an
+/// unconvertible prompt part or an invalid option combination.
 pub fn build_request_body_with_warnings(
     model_id: &str,
     options: &CallOptions,
@@ -1485,6 +1514,7 @@ pub fn deep_merge_json(target: &mut Value, patch: &Value) {
 }
 
 /// Parse OpenAI finish reason string into `FinishReason`.
+#[must_use]
 pub fn parse_finish_reason(s: &str) -> FinishReason {
     let unified = match s {
         "stop" => FinishReasonUnified::Stop,

--- a/aimux-providers/src/openai/embedding.rs
+++ b/aimux-providers/src/openai/embedding.rs
@@ -31,6 +31,7 @@ pub struct OpenAIEmbeddingModel {
 }
 
 impl OpenAIEmbeddingModel {
+    #[must_use]
     pub fn new(model_id: String, config: OpenAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -163,7 +164,7 @@ impl EmbeddingModel for OpenAIEmbeddingModel {
         let usage = raw_value
             .get("usage")
             .and_then(|u| u.get("prompt_tokens"))
-            .and_then(|t| t.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|tokens| EmbeddingUsage {
                 tokens: tokens as u32,
             });
@@ -199,12 +200,12 @@ fn parse_openai_provider_options(
     OpenAIEmbeddingProviderOptions {
         dimensions: provider_opts
             .and_then(|o| o.get("dimensions"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
         user: provider_opts
             .and_then(|o| o.get("user"))
             .and_then(|u| u.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
     }
 }
 

--- a/aimux-providers/src/openai/files.rs
+++ b/aimux-providers/src/openai/files.rs
@@ -41,7 +41,10 @@ fn parse_openai_files_options(
         if let Some(purpose) = openai.get("purpose").and_then(|v| v.as_str()) {
             opts.purpose = Some(purpose.to_string());
         }
-        if let Some(expires_after) = openai.get("expiresAfter").and_then(|v| v.as_u64()) {
+        if let Some(expires_after) = openai
+            .get("expiresAfter")
+            .and_then(serde_json::Value::as_u64)
+        {
             opts.expires_after = Some(expires_after);
         }
     }
@@ -91,6 +94,7 @@ pub struct OpenAIFiles {
 }
 
 impl OpenAIFiles {
+    #[must_use]
     pub fn new(config: OpenAIConfig) -> Self {
         Self { config }
     }
@@ -144,7 +148,7 @@ impl Files for OpenAIFiles {
 
         // Build multipart/form-data body manually.
         let (body, content_type) = build_multipart_form(
-            &format!("form-data; name=\"file\"; filename=\"{}\"", filename),
+            &format!("form-data; name=\"file\"; filename=\"{filename}\""),
             &options.media_type,
             &file_bytes,
             &[("purpose", purpose.as_str())],

--- a/aimux-providers/src/openai/image.rs
+++ b/aimux-providers/src/openai/image.rs
@@ -70,6 +70,7 @@ pub struct OpenAIImageModel {
 }
 
 impl OpenAIImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: OpenAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -490,15 +491,15 @@ fn extract_usage(response: &Value) -> Option<ImageUsage> {
     response.get("usage").map(|u| ImageUsage {
         input_tokens: u
             .get("input_tokens")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|x| x as u32),
         output_tokens: u
             .get("output_tokens")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|x| x as u32),
         total_tokens: u
             .get("total_tokens")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|x| x as u32),
     })
 }
@@ -512,7 +513,10 @@ fn distribute_token_details(details: Option<&Value>, index: usize, total: usize)
     let details = details?;
     let mut result = Map::new();
 
-    if let Some(image_tokens) = details.get("image_tokens").and_then(|v| v.as_u64()) {
+    if let Some(image_tokens) = details
+        .get("image_tokens")
+        .and_then(serde_json::Value::as_u64)
+    {
         let total = total as u64;
         let base = image_tokens / total;
         let remainder = image_tokens - base * (total - 1);
@@ -524,7 +528,10 @@ fn distribute_token_details(details: Option<&Value>, index: usize, total: usize)
         result.insert("imageTokens".to_string(), json!(value));
     }
 
-    if let Some(text_tokens) = details.get("text_tokens").and_then(|v| v.as_u64()) {
+    if let Some(text_tokens) = details
+        .get("text_tokens")
+        .and_then(serde_json::Value::as_u64)
+    {
         let total = total as u64;
         let base = text_tokens / total;
         let remainder = text_tokens - base * (total - 1);
@@ -553,7 +560,7 @@ fn extract_provider_metadata(response: &Value) -> SharedProviderMetadata {
     let mut metadata = HashMap::new();
 
     let data = response.get("data").and_then(|d| d.as_array());
-    let created = response.get("created").and_then(|v| v.as_u64());
+    let created = response.get("created").and_then(serde_json::Value::as_u64);
     let size = response.get("size").and_then(|v| v.as_str());
     let quality = response.get("quality").and_then(|v| v.as_str());
     let background = response.get("background").and_then(|v| v.as_str());

--- a/aimux-providers/src/openai/mod.rs
+++ b/aimux-providers/src/openai/mod.rs
@@ -54,6 +54,7 @@ pub struct OpenAICompatProfile {
 impl OpenAICompatProfile {
     /// 默认 profile：支持全部能力，无特殊流式 usage key。
     /// 适用于 OpenAI 本身和大多数兼容厂商。
+    #[must_use]
     pub fn full() -> Self {
         Self {
             supports_top_k: true,
@@ -66,6 +67,7 @@ impl OpenAICompatProfile {
 
     /// Groq profile：不支持 top_k，流式 usage 在 x_groq 字段；
     /// `max_tokens` 已弃用，只发 `max_completion_tokens`（backlog B9）。
+    #[must_use]
     pub fn groq() -> Self {
         Self {
             supports_top_k: false,
@@ -78,6 +80,7 @@ impl OpenAICompatProfile {
 
     /// 设置 `max_tokens_key`（内部数据，非用户概念）：`"max_tokens"` 或
     /// `"max_completion_tokens"`。注册表薄封装行用此构建差异 profile。
+    #[must_use]
     pub fn with_max_tokens_key(mut self, key: &'static str) -> Self {
         self.max_tokens_key = Some(key);
         self
@@ -86,6 +89,7 @@ impl OpenAICompatProfile {
     /// DeepSeek profile：特化已退役（RFC-0017 阶段 2），回归 `full()`——
     /// thinking / effort 映射等厂商差异由用户 bodyOverrides 定义。
     /// 保留此薄封装以维持注册表与调用方结构不变。
+    #[must_use]
     pub fn deepseek() -> Self {
         Self::full()
     }
@@ -187,61 +191,74 @@ impl OpenAIConfig {
     }
 
     /// Use a custom base URL (for Azure, Groq, etc.).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_org_id(mut self, org_id: impl Into<String>) -> Self {
         self.org_id = Some(org_id.into());
         self
     }
 
     /// Set the OpenAI project ID (sent via the `OpenAI-Project` header).
+    #[must_use]
     pub fn with_project(mut self, project: impl Into<String>) -> Self {
         self.project = Some(project.into());
         self
     }
 
     /// Attach extra headers merged into every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Set the provider name (e.g. "groq") for provider-specific behaviour.
+    #[must_use]
     pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
         self.provider = provider.into();
         self
     }
 
     /// 设置厂商能力差异描述。
+    #[must_use]
     pub fn with_profile(mut self, profile: OpenAICompatProfile) -> Self {
         self.profile = profile;
         self
     }
 
     /// 设置重试配置。传入 `max_retries: 0` 可关闭重试。
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
     }
 
     /// 设置 provider 级请求体覆盖（RFC-0017）。
+    #[must_use]
     pub fn with_body_overrides(mut self, overrides: Value) -> Self {
         self.body_overrides = Some(overrides);
         self
     }
 
     /// Create from environment variable `OPENAI_API_KEY`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `OPENAI_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "OPENAI_API_KEY", "OpenAI")?;
         Ok(Self::new(api_key).with_api_key_source(Some("env:OPENAI_API_KEY")))
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 }
@@ -255,11 +272,13 @@ pub struct OpenAIProvider {
 }
 
 impl OpenAIProvider {
+    #[must_use]
     pub fn new(config: OpenAIConfig) -> Self {
         Self { config }
     }
 
     /// Create a model instance for the given model name (e.g. `"gpt-4o"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> model::OpenAIModel {
         model::OpenAIModel::new(model_id.to_string(), self.config.clone())
     }
@@ -267,23 +286,27 @@ impl OpenAIProvider {
     /// Create a Responses API model instance for the given model name (e.g.
     /// `"gpt-4o"`). Uses the `/v1/responses` endpoint instead of
     /// `/v1/chat/completions`.
+    #[must_use]
     pub fn responses_model(&self, model_id: &str) -> responses::OpenAIResponsesModel {
         responses::OpenAIResponsesModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a Files interface for uploading files to OpenAI.
+    #[must_use]
     pub fn files(&self) -> files::OpenAIFiles {
         files::OpenAIFiles::new(self.config.clone())
     }
 
     /// Create an embedding model instance for the given model name (e.g.
     /// `"text-embedding-3-large"`).
+    #[must_use]
     pub fn embedding_model(&self, model_id: &str) -> embedding::OpenAIEmbeddingModel {
         embedding::OpenAIEmbeddingModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a speech (TTS) model instance for the given model name (e.g.
     /// `"tts-1"`). Uses the `/audio/speech` endpoint.
+    #[must_use]
     pub fn speech(&self, model_id: &str) -> speech::OpenAISpeechModel {
         speech::OpenAISpeechModel::new(model_id.to_string(), self.config.clone())
     }
@@ -291,6 +314,7 @@ impl OpenAIProvider {
     /// Create an image generation model instance for the given model name
     /// (e.g. `"dall-e-3"` or `"gpt-image-1"`). Uses the `/images/generations`
     /// endpoint for generation and `/images/edits` for editing.
+    #[must_use]
     pub fn image(&self, model_id: &str) -> image::OpenAIImageModel {
         image::OpenAIImageModel::new(model_id.to_string(), self.config.clone())
     }
@@ -298,6 +322,7 @@ impl OpenAIProvider {
     /// Create a transcription (STT) model instance for the given model name
     /// (e.g. `"whisper-1"` or `"gpt-4o-transcribe"`). Uses the
     /// `/audio/transcriptions` endpoint.
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> transcription::OpenAITranscriptionModel {
         transcription::OpenAITranscriptionModel::new(model_id.to_string(), self.config.clone())
     }

--- a/aimux-providers/src/openai/model.rs
+++ b/aimux-providers/src/openai/model.rs
@@ -40,6 +40,7 @@ pub struct OpenAIModel {
 }
 
 impl OpenAIModel {
+    #[must_use]
     pub fn new(model_id: String, config: OpenAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -64,6 +65,7 @@ impl OpenAIModel {
 ///
 /// Shared by `OpenAIModel::build_headers` and the model-listing path
 /// ([`execute_list_models`]) so both use identical auth wiring.
+#[must_use]
 pub fn build_auth_headers(config: &super::OpenAIConfig) -> HashMap<String, String> {
     let mut headers = HashMap::new();
     headers.insert(
@@ -282,6 +284,12 @@ fn build_header_list(headers: &HashMap<String, String>) -> Vec<(String, String)>
 /// `endpoint` is the full chat-completions URL; `headers` carries the auth
 /// headers (and any extra/request headers); `model_id` is placed in the
 /// request body's `model` field.
+///
+/// # Errors
+///
+/// Returns request-build conversion errors, `ApiCall` for HTTP/transport
+/// failures, `JsonParse` for a malformed body, and `InvalidResponseData` when
+/// `choices` is empty.
 pub async fn execute_generate(
     endpoint: &str,
     headers: &HashMap<String, String>,
@@ -371,16 +379,16 @@ pub async fn execute_generate(
                 && let Some(uc) = ann.get("url_citation")
             {
                 content.push(GenerateContent::Source {
-                    id: format!("annotation-{}", i),
+                    id: format!("annotation-{i}"),
                     source_type: "url".to_string(),
                     url: uc
                         .get("url")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                     title: uc
                         .get("title")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                     provider_metadata: None,
                 });
             }
@@ -440,6 +448,11 @@ pub async fn execute_generate(
 /// `endpoint` is the full chat-completions URL; `headers` carries the auth
 /// headers (and any extra/request headers); `model_id` is placed in the
 /// request body's `model` field.
+///
+/// # Errors
+///
+/// Returns request-build conversion errors and `ApiCall` when establishing the
+/// stream fails; transport errors surface as `Err` items in the stream.
 pub async fn execute_stream(
     endpoint: &str,
     headers: &HashMap<String, String>,
@@ -651,12 +664,12 @@ pub async fn execute_stream(
                             if !text_started {
                                 text_started = true;
                                 yield Ok(StreamPart::TextStart {
-                                    id: format!("{}", text_id),
+                                    id: format!("{text_id}"),
                                     provider_metadata: None,
                                 });
                             }
                             yield Ok(StreamPart::TextDelta {
-                                id: format!("{}", text_id),
+                                id: format!("{text_id}"),
                                 delta: content,
                                 provider_metadata: None,
                             });
@@ -733,7 +746,7 @@ pub async fn execute_stream(
                             // Close any open text segment.
                             if text_started {
                                 yield Ok(StreamPart::TextEnd {
-                                    id: format!("{}", text_id),
+                                    id: format!("{text_id}"),
                                     provider_metadata: None,
                                 });
                                 text_started = false;
@@ -788,7 +801,7 @@ pub async fn execute_stream(
         // Close any remaining open text segment.
         if text_started {
             yield Ok(StreamPart::TextEnd {
-                id: format!("{}", text_id),
+                id: format!("{text_id}"),
                 provider_metadata: None,
             });
         }
@@ -883,6 +896,11 @@ struct ModelEntry {
 ///
 /// `headers` carries the auth headers (Bearer key etc.); `base_url` is the
 /// provider's API base (e.g. `https://api.openai.com/v1`).
+///
+/// # Errors
+///
+/// Returns `ApiCall` for HTTP/transport failures and `JsonParse` when the
+/// body does not deserialize into the models list.
 pub async fn execute_list_models(
     base_url: &str,
     headers: &HashMap<String, String>,

--- a/aimux-providers/src/openai/responses/convert.rs
+++ b/aimux-providers/src/openai/responses/convert.rs
@@ -352,7 +352,7 @@ fn item_id(provider_options: &Option<Value>) -> Option<String> {
         .and_then(|v| v.get("openai"))
         .and_then(|o| o.get("itemId"))
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
 }
 
 /// Read the `phase` from a content part's `providerOptions.openai.phase`.
@@ -362,7 +362,7 @@ fn phase_from_provider_options(provider_options: &Option<Value>) -> Option<Strin
         .and_then(|v| v.get("openai"))
         .and_then(|o| o.get("phase"))
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
 }
 
 /// Read the `namespace` from a content part's `providerOptions.openai.namespace`.
@@ -372,7 +372,7 @@ fn namespace_from_provider_options(provider_options: &Option<Value>) -> Option<S
         .and_then(|v| v.get("openai"))
         .and_then(|o| o.get("namespace"))
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
 }
 
 /// Read a sub-key from `providerOptions.openai.<key>` on a content part.
@@ -399,6 +399,7 @@ pub struct PreparedResponsesTools {
 /// Mirrors the function-tool path of TS `prepareResponsesTools`. Built-in
 /// provider tools (web_search, file_search, etc.) are out of scope for the
 /// core implementation and emit an `unsupported` warning.
+#[must_use]
 pub fn prepare_responses_tools(
     tools: &Option<Vec<Tool>>,
     tool_choice: Option<&ToolChoice>,
@@ -519,7 +520,7 @@ fn resolve_responses_reasoning(
     let resolved_reasoning_effort: Option<String> = openai_option(provider_opts, "reasoningEffort")
         .map(|v| {
             v.as_str()
-                .map(|s| s.to_string())
+                .map(std::string::ToString::to_string)
                 .unwrap_or_else(|| v.to_string())
         })
         .or_else(|| {
@@ -534,7 +535,7 @@ fn resolve_responses_reasoning(
         openai_option(provider_opts, "reasoningSummary")
             .map(|v| {
                 v.as_str()
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
                     .unwrap_or_else(|| v.to_string())
             })
             .or_else(|| {
@@ -582,7 +583,7 @@ fn resolve_responses_system_message_mode(
     caps: &ModelCapabilities,
 ) -> SystemMessageMode {
     openai_option(provider_opts, "systemMessageMode")
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string))
         .map(|s| match s.as_str() {
             "developer" => SystemMessageMode::Developer,
             "remove" => SystemMessageMode::Remove,
@@ -763,8 +764,8 @@ fn apply_responses_service_tier(
     caps: &ModelCapabilities,
     warnings: &mut Vec<Warning>,
 ) {
-    if let Some(st) =
-        openai_option(provider_opts, "serviceTier").and_then(|v| v.as_str().map(|s| s.to_string()))
+    if let Some(st) = openai_option(provider_opts, "serviceTier")
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string))
     {
         match st.as_str() {
             "flex" if !caps.supports_flex_processing => {
@@ -803,9 +804,9 @@ fn apply_responses_reasoning_block(
     let effort = resolved_reasoning_effort.as_ref();
     let summary = resolved_reasoning_summary.as_ref();
     let mode = openai_option(provider_opts, "reasoningMode")
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string));
     let context = openai_option(provider_opts, "reasoningContext")
-        .and_then(|v| v.as_str().map(|s| s.to_string()));
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string));
 
     if effort.is_some() || summary.is_some() || mode.is_some() || context.is_some() {
         let mut reasoning = json!({});
@@ -829,6 +830,7 @@ fn apply_responses_reasoning_block(
 ///
 /// Splits the original ~380-line function into focused helpers (issue M11);
 /// behavior is unchanged.
+#[must_use]
 pub fn build_responses_request_body(
     model_id: &str,
     options: &CallOptions,
@@ -946,6 +948,7 @@ pub fn build_responses_request_body(
 /// - `output.total = output_tokens`
 /// - `output.text = output_tokens - reasoning_tokens`
 /// - `output.reasoning = reasoning_tokens`
+#[must_use]
 pub fn convert_responses_usage(usage: Option<&ResponsesUsage>) -> Usage {
     let Some(usage) = usage else {
         return Usage::default();
@@ -992,6 +995,7 @@ pub fn convert_responses_usage(usage: Option<&ResponsesUsage>) -> Usage {
 }
 
 /// Helper: build a `ResponsesUsage` from a raw JSON `usage` object.
+#[must_use]
 pub fn parse_usage(raw: &Value) -> Option<ResponsesUsage> {
     serde_json::from_value(raw.clone()).ok()
 }
@@ -1005,6 +1009,7 @@ pub fn parse_usage(raw: &Value) -> Option<ResponsesUsage> {
 /// calls, else `stop`. `"max_output_tokens"` -> `length`,
 /// `"content_filter"` -> `content-filter`; otherwise `tool-calls` if there
 /// were function calls, else `other`.
+#[must_use]
 pub fn map_responses_finish_reason(
     finish_reason: Option<&str>,
     has_function_call: bool,
@@ -1029,6 +1034,6 @@ pub fn map_responses_finish_reason(
     };
     FinishReason {
         unified,
-        raw: finish_reason.map(|s| s.to_string()),
+        raw: finish_reason.map(std::string::ToString::to_string),
     }
 }

--- a/aimux-providers/src/openai/responses/mod.rs
+++ b/aimux-providers/src/openai/responses/mod.rs
@@ -63,6 +63,7 @@ pub struct OpenAIResponsesModel {
 }
 
 impl OpenAIResponsesModel {
+    #[must_use]
     pub fn new(model_id: String, config: OpenAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -169,7 +170,7 @@ impl LanguageModel for OpenAIResponsesModel {
             .as_ref()
             .and_then(|m| m.get("openai"))
             .and_then(|o| o.get("store"))
-            .and_then(|v| v.as_bool())
+            .and_then(serde_json::Value::as_bool)
             == Some(true);
 
         let resp = send_stream_timed(

--- a/aimux-providers/src/openai/responses/responses_convert.rs
+++ b/aimux-providers/src/openai/responses/responses_convert.rs
@@ -41,6 +41,7 @@ pub type ResponsesEventStream = Pin<Box<dyn Stream<Item = Result<StreamPart, AiM
 ///
 /// Byte-identical copies previously lived in the OpenAI, HuggingFace and xAI
 /// responses modules; they now route through this single implementation.
+#[must_use]
 pub fn build_header_list(headers: &HashMap<String, String>) -> Vec<(String, String)> {
     let mut list: Vec<(String, String)> = headers
         .iter()
@@ -62,6 +63,12 @@ pub fn build_header_list(headers: &HashMap<String, String>) -> Vec<(String, Stri
 /// the observed HTTP `status` and full `raw_body` (evidence for in-band 2xx
 /// errors), the request `body`/`response_headers` to attach, and the
 /// provider-metadata namespace `provider_key` ("openai" / "azure").
+///
+/// # Errors
+///
+/// Returns `ApiCall` for in-band 2xx errors (top-level `error` object, error
+/// status, `incomplete_details`) and `InvalidResponseData` when required
+/// fields such as `output` are missing.
 pub fn build_responses_generate_result(
     data: &Value,
     status: u16,
@@ -83,7 +90,7 @@ pub fn build_responses_generate_result(
             .get("type")
             .or_else(|| err_obj.get("code"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         return Err(AiMuxError::ApiCall(ApiCallError {
             // Provider-declared in-band failure: keep the observed 2xx
             // envelope status and the full raw body (§2.2).
@@ -106,7 +113,7 @@ pub fn build_responses_generate_result(
         AiMuxError::InvalidResponseData(if detail.is_empty() {
             "Responses API returned no output".to_string()
         } else {
-            format!("Responses API returned no output ({})", detail)
+            format!("Responses API returned no output ({detail})")
         })
     })?;
 
@@ -138,16 +145,16 @@ pub fn build_responses_generate_result(
                                 if ann.get("type").and_then(|v| v.as_str()) == Some("url_citation")
                                 {
                                     content.push(GenerateContent::Source {
-                                        id: format!("annotation-{}", i),
+                                        id: format!("annotation-{i}"),
                                         source_type: "url".to_string(),
                                         url: ann
                                             .get("url")
                                             .and_then(|v| v.as_str())
-                                            .map(|s| s.to_string()),
+                                            .map(std::string::ToString::to_string),
                                         title: ann
                                             .get("title")
                                             .and_then(|v| v.as_str())
-                                            .map(|s| s.to_string()),
+                                            .map(std::string::ToString::to_string),
                                         provider_metadata: None,
                                     });
                                 }
@@ -260,14 +267,14 @@ pub fn build_responses_generate_result(
     let response_id = data
         .get("id")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
     let model = data
         .get("model")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
     let timestamp = data
         .get("created_at")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .and_then(|secs| chrono::DateTime::from_timestamp(secs as i64, 0))
         .map(|dt| dt.to_rfc3339());
 
@@ -321,6 +328,11 @@ enum SummaryStatus {
 /// The caller performs the HTTP send (`send_stream`) and hands the peeked
 /// `first_event` plus the remainder `sse_stream` to this reducer; an early
 /// `error` / `response.failed` surfaces as a clean `Err` here.
+///
+/// # Errors
+///
+/// An early `error` / `response.failed` event yields an `ApiCall` error item
+/// in the returned stream; malformed events yield parse-error items.
 pub fn build_responses_event_stream<S>(
     first_event: Option<Result<SseEvent, SseError>>,
     sse_stream: S,
@@ -359,7 +371,7 @@ where
                     .or_else(|| val.get("error"))
                     .and_then(|e| e.get("type").or_else(|| e.get("code")))
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 message: message.to_string(),
                 response_body: Some(event.data.clone()),
                 ..Default::default()
@@ -420,14 +432,14 @@ where
                                 response_id = resp_obj
                                     .get("id")
                                     .and_then(|v| v.as_str())
-                                    .map(|s| s.to_string());
+                                    .map(std::string::ToString::to_string);
                                 let model_id = resp_obj
                                     .get("model")
                                     .and_then(|v| v.as_str())
-                                    .map(|s| s.to_string());
+                                    .map(std::string::ToString::to_string);
                                 let timestamp = resp_obj
                                     .get("created_at")
-                                    .and_then(|v| v.as_u64())
+                                    .and_then(serde_json::Value::as_u64)
                                     .and_then(|secs| {
                                         chrono::DateTime::from_timestamp(secs as i64, 0)
                                     })
@@ -444,7 +456,7 @@ where
                         "response.output_item.added" => {
                             let output_index = parsed
                                 .get("output_index")
-                                .and_then(|v| v.as_u64())
+                                .and_then(serde_json::Value::as_u64)
                                 .unwrap_or(0) as usize;
                             if let Some(item) = parsed.get("item") {
                                 let item_type = item
@@ -523,7 +535,7 @@ where
                                         let encrypted = item
                                             .get("encrypted_content")
                                             .and_then(|v| v.as_str())
-                                            .map(|s| s.to_string());
+                                            .map(std::string::ToString::to_string);
                                         active_reasoning.insert(
                                             id.clone(),
                                             ReasoningState {
@@ -535,7 +547,7 @@ where
                                             },
                                         );
                                         yield Ok(StreamPart::ReasoningStart {
-                                            id: format!("{}:0", id),
+                                            id: format!("{id}:0"),
                                             provider_metadata: None,
                                         });
                                     }
@@ -564,7 +576,7 @@ where
                         | "response.custom_tool_call_input.delta" => {
                             let output_index = parsed
                                 .get("output_index")
-                                .and_then(|v| v.as_u64())
+                                .and_then(serde_json::Value::as_u64)
                                 .unwrap_or(0) as usize;
                             let delta = parsed
                                 .get("delta")
@@ -589,7 +601,7 @@ where
                                 .to_string();
                             let summary_index = parsed
                                 .get("summary_index")
-                                .and_then(|v| v.as_u64())
+                                .and_then(serde_json::Value::as_u64)
                                 .unwrap_or(0) as usize;
 
                             if summary_index > 0
@@ -605,7 +617,7 @@ where
                                 for idx in to_conclude {
                                     state.summary_parts.insert(idx, SummaryStatus::Concluded);
                                     yield Ok(StreamPart::ReasoningEnd {
-                                        id: format!("{}:{}", item_id, idx),
+                                        id: format!("{item_id}:{idx}"),
                                         provider_metadata: None,
                                     });
                                 }
@@ -614,7 +626,7 @@ where
                                     .insert(summary_index, SummaryStatus::Active);
                                 let encrypted = state.encrypted_content.clone();
                                 yield Ok(StreamPart::ReasoningStart {
-                                    id: format!("{}:{}", item_id, summary_index),
+                                    id: format!("{item_id}:{summary_index}"),
                                     provider_metadata: None,
                                 });
                                 let _ = encrypted;
@@ -630,7 +642,7 @@ where
                                 .to_string();
                             let summary_index = parsed
                                 .get("summary_index")
-                                .and_then(|v| v.as_u64())
+                                .and_then(serde_json::Value::as_u64)
                                 .unwrap_or(0) as usize;
                             let delta = parsed
                                 .get("delta")
@@ -638,7 +650,7 @@ where
                                 .unwrap_or("")
                                 .to_string();
                             yield Ok(StreamPart::ReasoningDelta {
-                                id: format!("{}:{}", item_id, summary_index),
+                                id: format!("{item_id}:{summary_index}"),
                                 delta,
                                 provider_metadata: None,
                             });
@@ -653,7 +665,7 @@ where
                                 .to_string();
                             let summary_index = parsed
                                 .get("summary_index")
-                                .and_then(|v| v.as_u64())
+                                .and_then(serde_json::Value::as_u64)
                                 .unwrap_or(0) as usize;
                             if let Some(state) = active_reasoning.get_mut(&item_id) {
                                 if store_flag {
@@ -661,7 +673,7 @@ where
                                         .summary_parts
                                         .insert(summary_index, SummaryStatus::Concluded);
                                     yield Ok(StreamPart::ReasoningEnd {
-                                        id: format!("{}:{}", item_id, summary_index),
+                                        id: format!("{item_id}:{summary_index}"),
                                         provider_metadata: None,
                                     });
                                 } else {
@@ -676,7 +688,7 @@ where
                         "response.output_item.done" => {
                             let output_index = parsed
                                 .get("output_index")
-                                .and_then(|v| v.as_u64())
+                                .and_then(serde_json::Value::as_u64)
                                 .unwrap_or(0) as usize;
                             if let Some(item) = parsed.get("item") {
                                 let item_type = item
@@ -785,7 +797,7 @@ where
                                                     .summary_parts
                                                     .insert(idx, SummaryStatus::Concluded);
                                                 yield Ok(StreamPart::ReasoningEnd {
-                                                    id: format!("{}:{}", id, idx),
+                                                    id: format!("{id}:{idx}"),
                                                     provider_metadata: None,
                                                 });
                                             }
@@ -845,7 +857,7 @@ where
                                                 .get("error")
                                                 .and_then(|e| e.get("type").or_else(|| e.get("code")))
                                                 .and_then(|v| v.as_str())
-                                                .map(|s| s.to_string()),
+                                                .map(std::string::ToString::to_string),
                                             message: message.to_string(),
                                             response_body: Some(sse_event.data.clone()),
                                             ..Default::default()
@@ -874,7 +886,7 @@ where
                                         .get("error")
                                         .and_then(|e| e.get("type").or_else(|| e.get("code")))
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string()),
+                                        .map(std::string::ToString::to_string),
                                     message: message.to_string(),
                                     response_body: Some(sse_event.data.clone()),
                                     ..Default::default()

--- a/aimux-providers/src/openai/speech.rs
+++ b/aimux-providers/src/openai/speech.rs
@@ -38,6 +38,7 @@ pub struct OpenAISpeechModel {
 }
 
 impl OpenAISpeechModel {
+    #[must_use]
     pub fn new(model_id: String, config: OpenAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -172,8 +173,7 @@ fn build_request_body_and_warnings(
         warnings.push(Warning::Unsupported {
             feature: "outputFormat".to_string(),
             details: Some(format!(
-                "Unsupported output format: {}. Using mp3 instead.",
-                output_format
+                "Unsupported output format: {output_format}. Using mp3 instead."
             )),
         });
     }
@@ -182,8 +182,7 @@ fn build_request_body_and_warnings(
         warnings.push(Warning::Unsupported {
             feature: "language".to_string(),
             details: Some(format!(
-                "OpenAI speech models do not support language selection. Language parameter \"{}\" was ignored.",
-                language
+                "OpenAI speech models do not support language selection. Language parameter \"{language}\" was ignored."
             )),
         });
     }

--- a/aimux-providers/src/openai/transcription.rs
+++ b/aimux-providers/src/openai/transcription.rs
@@ -133,7 +133,7 @@ fn parse_openai_options(
             opts.include = Some(
                 include
                     .iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                     .collect(),
             );
         }
@@ -143,7 +143,10 @@ fn parse_openai_options(
         if let Some(prompt) = openai.get("prompt").and_then(|v| v.as_str()) {
             opts.prompt = Some(prompt.to_string());
         }
-        if let Some(temp) = openai.get("temperature").and_then(|v| v.as_f64()) {
+        if let Some(temp) = openai
+            .get("temperature")
+            .and_then(serde_json::Value::as_f64)
+        {
             opts.temperature = Some(temp);
         }
         if let Some(tg) = openai
@@ -152,7 +155,7 @@ fn parse_openai_options(
         {
             opts.timestamp_granularities = Some(
                 tg.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                     .collect(),
             );
         }
@@ -221,6 +224,7 @@ pub struct OpenAITranscriptionModel {
 }
 
 impl OpenAITranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: OpenAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -365,7 +369,7 @@ impl TranscriptionModel for OpenAITranscriptionModel {
             .language
             .as_deref()
             .and_then(language_name_to_code)
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
 
         // Segments: prefer `segments`, fall back to `words`.
         let segments: Vec<TranscriptionSegment> = if let Some(segs) = parsed.segments {
@@ -604,7 +608,7 @@ impl TranscriptionModel for OpenAITranscriptionModel {
                                 match event_type {
                                     "conversation.item.input_audio_transcription.delta" => {
                                         yield Ok(TranscriptionStreamPart::TranscriptDelta {
-                                            id: value.get("item_id").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                                            id: value.get("item_id").and_then(|v| v.as_str()).map(std::string::ToString::to_string),
                                             delta: value.get("delta").and_then(|v| v.as_str()).unwrap_or("").to_string(),
                                             provider_metadata: None,
                                         });
@@ -613,7 +617,7 @@ impl TranscriptionModel for OpenAITranscriptionModel {
                                         let transcript = value.get("transcript")
                                             .and_then(|v| v.as_str()).unwrap_or("").to_string();
                                         let item_id = value.get("item_id")
-                                            .and_then(|v| v.as_str()).map(|s| s.to_string());
+                                            .and_then(|v| v.as_str()).map(std::string::ToString::to_string);
                                         yield Ok(TranscriptionStreamPart::TranscriptFinal {
                                             id: item_id.clone(),
                                             text: transcript.clone(),

--- a/aimux-providers/src/openrouter.rs
+++ b/aimux-providers/src/openrouter.rs
@@ -33,12 +33,18 @@ impl OpenRouterConfig {
     }
 
     /// Create from the `OPENROUTER_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `OPENROUTER_API_KEY` is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let key = load_api_key(None, ENV_VAR, "OpenRouter")?;
         Ok(Self::new(key))
     }
 
     /// Override the base URL (useful for tests / self-hosted endpoints).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -49,12 +55,14 @@ impl OpenRouterConfig {
 pub struct OpenRouterProvider(OpenAIProvider);
 
 impl OpenRouterProvider {
+    #[must_use]
     pub fn new(config: OpenRouterConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given OpenRouter model id
     /// (e.g. `"openai/gpt-4o-mini"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }
@@ -63,6 +71,7 @@ impl OpenRouterProvider {
     ///
     /// OpenRouter exposes an OpenAI-compatible Responses API at `/v1/responses`.
     /// This delegates to the underlying [`OpenAIProvider::responses_model`].
+    #[must_use]
     pub fn responses_model(&self, model_id: &str) -> OpenAIResponsesModel {
         self.0.responses_model(model_id)
     }

--- a/aimux-providers/src/openvino.rs
+++ b/aimux-providers/src/openvino.rs
@@ -30,6 +30,13 @@ impl OpenvinoConfig {
         )
     }
 
+    /// Create from the `OPENVINO_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8080/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl OpenvinoConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl OpenvinoConfig {
 pub struct OpenvinoProvider(OpenAIProvider);
 
 impl OpenvinoProvider {
+    #[must_use]
     pub fn new(config: OpenvinoConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/parallel_ai.rs
+++ b/aimux-providers/src/parallel_ai.rs
@@ -44,12 +44,17 @@ impl ParallelAiConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Create from the `PARALLEL_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `PARALLEL_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "PARALLEL_API_KEY", "Parallel AI")?;
         Ok(Self::new(api_key))
@@ -64,11 +69,13 @@ pub struct ParallelAiProvider {
 }
 
 impl ParallelAiProvider {
+    #[must_use]
     pub fn new(config: ParallelAiConfig) -> Self {
         Self { config }
     }
 
     /// Create a search model instance.
+    #[must_use]
     pub fn search_model(&self) -> ParallelAiSearchModel {
         ParallelAiSearchModel::new(self.config.clone())
     }
@@ -137,6 +144,7 @@ pub struct ParallelAiSearchModel {
 }
 
 impl ParallelAiSearchModel {
+    #[must_use]
     pub fn new(config: ParallelAiConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/prodia.rs
+++ b/aimux-providers/src/prodia.rs
@@ -38,14 +38,22 @@ impl ProdiaConfig {
             headers: None,
         }
     }
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
+    /// Create from the `PRODIA_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "PRODIA_API_KEY", "Prodia")?;
         Ok(Self::new(api_key))
@@ -56,13 +64,16 @@ pub struct ProdiaProvider {
     config: ProdiaConfig,
 }
 impl ProdiaProvider {
+    #[must_use]
     pub fn new(config: ProdiaConfig) -> Self {
         Self { config }
     }
+    #[must_use]
     pub fn image(&self, model_id: &str) -> ProdiaImageModel {
         ProdiaImageModel::new(model_id.to_string(), self.config.clone())
     }
     /// Create a video generation model instance.
+    #[must_use]
     pub fn video(&self, model_id: &str) -> ProdiaVideoModel {
         ProdiaVideoModel::new(model_id.to_string(), self.config.clone())
     }
@@ -74,6 +85,7 @@ pub struct ProdiaImageModel {
     config: ProdiaConfig,
 }
 impl ProdiaImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: ProdiaConfig) -> Self {
         Self { model_id, config }
     }
@@ -102,7 +114,7 @@ impl ProdiaImageModel {
 
 /// Parse a multipart body into parts (name, content_type, body).
 fn parse_multipart(body: &[u8], boundary: &str) -> Vec<(String, String, Vec<u8>)> {
-    let delimiter = format!("--{}", boundary);
+    let delimiter = format!("--{boundary}");
     let mut parts = Vec::new();
     let mut idx = 0;
 
@@ -122,7 +134,7 @@ fn parse_multipart(body: &[u8], boundary: &str) -> Vec<(String, String, Vec<u8>)
         };
 
         // Find next boundary
-        let next_delimiter = format!("\r\n{}", delimiter);
+        let next_delimiter = format!("\r\n{delimiter}");
         let end = body[content_start..]
             .windows(next_delimiter.len())
             .position(|w| w == next_delimiter.as_bytes())
@@ -315,6 +327,7 @@ pub struct ProdiaVideoModel {
 }
 
 impl ProdiaVideoModel {
+    #[must_use]
     pub fn new(model_id: String, config: ProdiaConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/provider.rs
+++ b/aimux-providers/src/provider.rs
@@ -151,6 +151,12 @@ pub struct ProviderOptions {
 /// - Unknown names return [`AiMuxError::NoSuchProvider`] naming the requested
 ///   provider; built-in names are enumerated by the generated `ProviderName`
 ///   (overlay-registered names are not).
+///
+/// # Errors
+///
+/// Returns [`AiMuxError::NoSuchProvider`] for unknown names,
+/// `InvalidArgument` for invalid entries/options, and key-resolution errors
+/// from the registry env var.
 pub fn provider(
     name: impl AsRef<str>,
     api_key: Option<String>,
@@ -229,6 +235,11 @@ pub(crate) fn clear_overlay(name: &str) {
 ///
 /// Validation failures (empty name, non-`http(s)://` base_url, unsupported
 /// protocol) return [`AiMuxError::InvalidArgument`] — they never panic.
+///
+/// # Errors
+///
+/// Returns [`AiMuxError::InvalidArgument`] when entry validation fails (empty
+/// name, non-`http(s)://` base URL, unsupported protocol).
 pub fn register_provider(entry: ExternalProviderEntry) -> Result<(), AiMuxError> {
     validate_external_entry(&entry)?;
     let mut overlays = overlays().write().unwrap();
@@ -239,12 +250,18 @@ pub fn register_provider(entry: ExternalProviderEntry) -> Result<(), AiMuxError>
 /// Whether `name` was registered at runtime via [`register_provider`] /
 /// [`load_providers_from_json`] (RFC-0020 overlay). Used by the replay path
 /// to recognize externally-registered OpenAI-compatible providers.
+#[must_use]
 pub fn is_external_provider(name: &str) -> bool {
     overlays().read().unwrap().contains_key(name)
 }
 
 /// Load and register multiple external providers from a JSON string
 /// (`{ "providers": [ ... ] }`). Useful for binding-layer pass-through.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::JsonParse` for malformed JSON and propagates each
+/// entry's `register_provider` validation error.
 pub fn load_providers_from_json(json: &str) -> Result<(), AiMuxError> {
     let config: ProvidersConfig = serde_json::from_str(json).map_err(|e| {
         AiMuxError::JsonParse(format!("failed to parse external providers config: {e}"))
@@ -354,6 +371,12 @@ impl ResolvedEntry {
 /// [`Provider::language_model`] on a chosen id.
 ///
 /// Same key/options semantics as [`provider`].
+///
+/// # Errors
+///
+/// Returns [`AiMuxError::NoSuchProvider`] for unknown names, `InvalidArgument`
+/// for an unexpanded templated base URL or invalid options, and key-resolution
+/// errors.
 pub fn provider_handle(
     name: impl AsRef<str>,
     api_key: Option<String>,
@@ -525,6 +548,11 @@ fn profile_from_registry(p: &ProviderProfile) -> OpenAICompatProfile {
 }
 
 /// Convenience: build from the env-var key of the registry entry.
+///
+/// # Errors
+///
+/// Propagates the errors of [`provider`] (unknown provider, missing env-var
+/// key, invalid options).
 pub fn provider_from_env(
     name: impl AsRef<str>,
     model_id: &str,
@@ -536,6 +564,7 @@ pub fn provider_from_env(
 /// Public lookup of a registered provider's runtime profile — used by tests
 /// that assert registry wiring (e.g. `max_tokens_key`) without constructing a
 /// model. Returns `None` for unknown provider names.
+#[must_use]
 pub fn provider_registry_entry(name: &str) -> Option<OpenAICompatProfile> {
     registry()
         .iter()

--- a/aimux-providers/src/provider_name.rs
+++ b/aimux-providers/src/provider_name.rs
@@ -515,6 +515,7 @@ impl ProviderName {
     ];
 
     /// The registry name (snake_case), e.g. `ProviderName::Groq -> "groq"`.
+    #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Abacus => "abacus",
@@ -772,6 +773,7 @@ impl ProviderName {
     }
 
     /// All registry names (for error messages / docs).
+    #[must_use]
     pub const fn all_names() -> &'static str {
         "abacus,abliteration_ai,ai21,ai302,ai_router,aiand,aibadgr,aigc2d,aihubmix,ails,aiml,aki_io,albert,alibaba,alibaba_coding_plan,alibaba_coding_plan_cn,alibaba_token_plan,alibaba_token_plan_cn,ambient,anyapi,anyscale,apertis,api2d,api2gpt,apiserpent,atlascloud,atomic_chat,auriko,azure_ai,baichuan,baidu,baidu_v2,bailing,baseten,berget,bigmodel,blueclaw,bytedance,byteplus,bytez,canopywave,cerebras,chatgpt,cherryin,chutes,clarifai,claudinio,cline_pass,closeai,cloudferro_sherlock,cloudflare,cloudflare_workers_ai,codestral,cometapi,commandcode,compactifai,copilot,cortecs,coze,crof,crossmodel,crusoe,daoxe,darkbloom,databricks,datarobot,deepbricks,deepinfra,deepseek,digitalocean,dinference,doubao,doubleword,drun,ebcloud,embercloud,empiriolabs,evroc,fastcrw,fastgpt,fastrouter,featherless_ai,firepass,fireworks,freemodel,friendliai,frogbot,galadriel,gdc,gigachat,github,gmi,gmicloud,gonka24,gradient_ai,groq,helicone,heroku,hetzner,hosted_vllm,hpc_ai,hyperbolic,iflowcn,inception,inceptron,inference_net,inferencehub,inferx,infinity,io_net,jiekou,kenari,kilo,kimi,kimi_for_coding,kiro,kluster_ai,krutrim,kuae_cloud_coding_plan,lambda_ai,lemonade,lemonfox_ai,libertai,lilac,lingyiwanwu,llama,llamagate,llmgateway,llmtr,longcat,lucidquery,lynkr,matterai,meganova,merge_gateway,meta,meta_llama,mimo,minimax,minimax_cn,minimax_cn_coding_plan,minimax_coding_plan,mira,mixlayer,moark,modal,model_oracle_ai,modelscope,moonshotai,moonshotai_cn,morph,nanogpt,ncompass,nearai,nebius,neon,neuralwatt,nextbit,nlp_cloud,nous_research,novita,nscale,nvidia_nim,oci,ofox,ohmygpt,ollama_cloud,openaimax,openaisb,opencode,opencode_go,opencode_zen,orcarouter,ovhcloud,parasail,perfxcloud,perplexity,perplexity_agent,petals,pinstripes,pioneer,poe,poolside,portkey,ppinfra,predibase,privatemode_ai,publicai,qihang_ai,qihoo360,qiniu_ai,regolo_ai,reka_ai,requesty,reve,routing_run,sakana,sambanova,sarvam,scaleway,scx_ai,siliconflow,snowflake,snowflake_cortex,stackit,stepfun,stepfun_ai_step_plan,stepfun_step_plan,subconscious,submodel,synthetic,tencent,tencent_coding_plan,tencent_token_plan,tencent_token_plan_enterprise_auto,tencent_token_plan_enterprise_pro,tencent_token_plan_general_personal,tencent_token_plan_hy_personal,tencent_tokenhub,tensormesh,the_grid_ai,thinkingmachines,tinfoil,togetherai,tokenflux,tokenpony,trustedrouter,tundra,umans_ai,unorouter,upstage,v0,venice,vercel,vivgrid,volc_engine,vultr,wafer,wandb,xiaomi_token_plan_ams,xiaomi_token_plan_cn,xiaomi_token_plan_sgp,xiaomimimo,xpersona,xunfei,zai,zai_coding_plan,zeldoc,zenmux,zhipu_v4,zhipuai_coding_plan"
     }

--- a/aimux-providers/src/recraft.rs
+++ b/aimux-providers/src/recraft.rs
@@ -48,18 +48,24 @@ impl RecraftConfig {
     }
 
     /// Override the base URL (useful for tests / self-hosted endpoints).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Set additional static HTTP headers sent with every request.
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Create from the `RECRAFT_API_TOKEN` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `RECRAFT_API_TOKEN` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, ENV_VAR, "Recraft")?;
         Ok(Self::new(api_key))
@@ -72,11 +78,13 @@ pub struct RecraftProvider {
 }
 
 impl RecraftProvider {
+    #[must_use]
     pub fn new(config: RecraftConfig) -> Self {
         Self { config }
     }
 
     /// Create an image generation model instance (e.g. `"recraftv3"`).
+    #[must_use]
     pub fn image(&self, model_id: &str) -> RecraftImageModel {
         RecraftImageModel::new(model_id.to_string(), self.config.clone())
     }
@@ -95,6 +103,7 @@ pub struct RecraftImageModel {
 }
 
 impl RecraftImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: RecraftConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/replay.rs
+++ b/aimux-providers/src/replay.rs
@@ -33,6 +33,11 @@ use crate::provider::ProviderOptions;
 ///   中的 org/project/headers/body_overrides 一并恢复;`profile` 从录制恢复。
 /// - 注意:录制的 headers 已脱敏,真实头无法从此恢复——需要时调用方重建后
 ///   再通过 `ProviderOptions.headers` 补。
+///
+/// # Errors
+///
+/// Returns `Unsupported` for non-OpenAI-compatible recordings,
+/// `InvalidArgument` for a missing `base_url`, and key-resolution errors.
 pub fn rebuild_provider(
     p: &ProviderRecord,
     api_key: Option<&str>,

--- a/aimux-providers/src/replicate.rs
+++ b/aimux-providers/src/replicate.rs
@@ -37,16 +37,24 @@ impl ReplicateConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Create from the `REPLICATE_API_TOKEN` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "REPLICATE_API_TOKEN", "Replicate")?;
         Ok(Self::new(api_key))
@@ -59,16 +67,19 @@ pub struct ReplicateProvider {
 }
 
 impl ReplicateProvider {
+    #[must_use]
     pub fn new(config: ReplicateConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn image(&self, model_id: &str) -> ReplicateImageModel {
         ReplicateImageModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a video generation model instance for the given model name
     /// (e.g. `"wan-lab/wan-2.1-t2v-14b"`).
+    #[must_use]
     pub fn video(&self, model_id: &str) -> ReplicateVideoModel {
         ReplicateVideoModel::new(model_id.to_string(), self.config.clone())
     }
@@ -85,6 +96,7 @@ pub struct ReplicateImageModel {
 }
 
 impl ReplicateImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: ReplicateConfig) -> Self {
         Self { model_id, config }
     }
@@ -165,7 +177,7 @@ impl ImageModel for ReplicateImageModel {
         let replicate_opts = options.provider_options.get("replicate");
         let max_wait = replicate_opts
             .and_then(|o| o.get("maxWaitTimeInSeconds"))
-            .and_then(|v| v.as_u64());
+            .and_then(serde_json::Value::as_u64);
 
         // Build image inputs
         let mut image_inputs = Map::new();
@@ -186,7 +198,7 @@ impl ImageModel for ReplicateImageModel {
                     image_inputs.insert(key, json!(Self::file_to_data_uri(file)?));
                 }
                 if files.len() > MAX_FLUX_2_INPUT_IMAGES as usize {
-                    warnings.push(Warning::Other { message: format!("Flux-2 models support up to {} input images. Additional images are ignored.", MAX_FLUX_2_INPUT_IMAGES) });
+                    warnings.push(Warning::Other { message: format!("Flux-2 models support up to {MAX_FLUX_2_INPUT_IMAGES} input images. Additional images are ignored.") });
                 }
             } else {
                 image_inputs.insert("image".into(), json!(Self::file_to_data_uri(&files[0])?));
@@ -343,6 +355,7 @@ pub struct ReplicateVideoModel {
 }
 
 impl ReplicateVideoModel {
+    #[must_use]
     pub fn new(model_id: String, config: ReplicateConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/revai.rs
+++ b/aimux-providers/src/revai.rs
@@ -45,16 +45,24 @@ impl RevaiConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Create from the `REVAI_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "REVAI_API_KEY", "Rev.ai")?;
         Ok(Self::new(api_key))
@@ -66,10 +74,12 @@ pub struct RevaiProvider {
 }
 
 impl RevaiProvider {
+    #[must_use]
     pub fn new(config: RevaiConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn transcription(&self, model_id: &str) -> RevaiTranscriptionModel {
         RevaiTranscriptionModel::new(model_id.to_string(), self.config.clone())
     }
@@ -127,6 +137,7 @@ pub struct RevaiTranscriptionModel {
 }
 
 impl RevaiTranscriptionModel {
+    #[must_use]
     pub fn new(model_id: String, config: RevaiConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/runwayml.rs
+++ b/aimux-providers/src/runwayml.rs
@@ -65,28 +65,38 @@ impl RunwaymlConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
 
     /// Override the interval between status polls.
+    #[must_use]
     pub fn with_poll_interval(mut self, interval: Duration) -> Self {
         self.poll_interval = interval;
         self
     }
 
     /// Override the maximum time to wait for a task to finish.
+    #[must_use]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
     }
 
+    /// Create from the `RUNWAYML_API_SECRET` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, ENV_VAR, "RunwayML")?;
         Ok(Self::new(api_key))
@@ -100,11 +110,13 @@ pub struct RunwaymlProvider {
 }
 
 impl RunwaymlProvider {
+    #[must_use]
     pub fn new(config: RunwaymlConfig) -> Self {
         Self { config }
     }
 
     /// Create a video generation model instance for the given model ID.
+    #[must_use]
     pub fn video(&self, model_id: &str) -> RunwaymlVideoModel {
         RunwaymlVideoModel::new(model_id.to_string(), self.config.clone())
     }
@@ -156,6 +168,7 @@ pub struct RunwaymlVideoModel {
 }
 
 impl RunwaymlVideoModel {
+    #[must_use]
     pub fn new(model_id: String, config: RunwaymlConfig) -> Self {
         Self { model_id, config }
     }

--- a/aimux-providers/src/searxng.rs
+++ b/aimux-providers/src/searxng.rs
@@ -45,12 +45,17 @@ impl SearxngConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Create from the `SEARXNG_URL` environment variable (required).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `SEARXNG_URL` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let base_url = std::env::var("SEARXNG_URL").map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -69,11 +74,13 @@ pub struct SearxngProvider {
 }
 
 impl SearxngProvider {
+    #[must_use]
     pub fn new(config: SearxngConfig) -> Self {
         Self { config }
     }
 
     /// Create a search model instance.
+    #[must_use]
     pub fn search_model(&self) -> SearxngSearchModel {
         SearxngSearchModel::new(self.config.clone())
     }
@@ -127,6 +134,7 @@ pub struct SearxngSearchModel {
 }
 
 impl SearxngSearchModel {
+    #[must_use]
     pub fn new(config: SearxngConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/serper.rs
+++ b/aimux-providers/src/serper.rs
@@ -37,11 +37,18 @@ impl SerperConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    /// Create from the `SERPER_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "SERPER_API_KEY", "Serper")?;
         Ok(Self::new(api_key))
@@ -54,10 +61,12 @@ pub struct SerperProvider {
 }
 
 impl SerperProvider {
+    #[must_use]
     pub fn new(config: SerperConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn search_model(&self) -> SerperSearchModel {
         SerperSearchModel::new(self.config.clone())
     }
@@ -115,6 +124,7 @@ pub struct SerperSearchModel {
 }
 
 impl SerperSearchModel {
+    #[must_use]
     pub fn new(config: SerperConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/sglang.rs
+++ b/aimux-providers/src/sglang.rs
@@ -30,6 +30,13 @@ impl SglangConfig {
         )
     }
 
+    /// Create from the `SGLANG_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:30000/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl SglangConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl SglangConfig {
 pub struct SglangProvider(OpenAIProvider);
 
 impl SglangProvider {
+    #[must_use]
     pub fn new(config: SglangConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/stability.rs
+++ b/aimux-providers/src/stability.rs
@@ -66,14 +66,22 @@ impl StabilityConfig {
             headers: None,
         }
     }
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
+    #[must_use]
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = Some(headers);
         self
     }
+    /// Create from the `STABILITY_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "STABILITY_API_KEY", "Stability")?;
         Ok(Self::new(api_key))
@@ -85,9 +93,11 @@ pub struct StabilityProvider {
 }
 
 impl StabilityProvider {
+    #[must_use]
     pub fn new(config: StabilityConfig) -> Self {
         Self { config }
     }
+    #[must_use]
     pub fn image(&self, model_id: &str) -> StabilityImageModel {
         StabilityImageModel::new(model_id.to_string(), self.config.clone())
     }
@@ -106,6 +116,7 @@ pub struct StabilityImageModel {
 }
 
 impl StabilityImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: StabilityConfig) -> Self {
         Self { model_id, config }
     }
@@ -204,7 +215,7 @@ impl ImageModel for StabilityImageModel {
         let seed = options.seed.or_else(|| {
             stability_opts
                 .and_then(|o| o.get("seed"))
-                .and_then(|v| v.as_u64())
+                .and_then(serde_json::Value::as_u64)
         });
 
         // Resolve output format (defaults to png).

--- a/aimux-providers/src/tavily.rs
+++ b/aimux-providers/src/tavily.rs
@@ -42,11 +42,18 @@ impl TavilyConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
+    /// Create from the `TAVILY_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when the environment variable is not
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "TAVILY_API_KEY", "Tavily")?;
         Ok(Self::new(api_key))
@@ -59,10 +66,12 @@ pub struct TavilyProvider {
 }
 
 impl TavilyProvider {
+    #[must_use]
     pub fn new(config: TavilyConfig) -> Self {
         Self { config }
     }
 
+    #[must_use]
     pub fn search_model(&self) -> TavilySearchModel {
         TavilySearchModel::new(self.config.clone())
     }
@@ -136,6 +145,7 @@ pub struct TavilySearchModel {
 }
 
 impl TavilySearchModel {
+    #[must_use]
     pub fn new(config: TavilyConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/tinyfish.rs
+++ b/aimux-providers/src/tinyfish.rs
@@ -56,12 +56,17 @@ impl TinyfishConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Create from the `TINYFISH_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `TINYFISH_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "TINYFISH_API_KEY", "TinyFish")?;
         Ok(Self::new(api_key))
@@ -87,11 +92,13 @@ pub struct TinyfishProvider {
 }
 
 impl TinyfishProvider {
+    #[must_use]
     pub fn new(config: TinyfishConfig) -> Self {
         Self { config }
     }
 
     /// Create a search model instance.
+    #[must_use]
     pub fn search_model(&self) -> TinyfishSearchModel {
         TinyfishSearchModel::new(self.config.clone())
     }
@@ -158,6 +165,7 @@ pub struct TinyfishSearchModel {
 }
 
 impl TinyfishSearchModel {
+    #[must_use]
     pub fn new(config: TinyfishConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/src/vertex/anthropic_model.rs
+++ b/aimux-providers/src/vertex/anthropic_model.rs
@@ -79,6 +79,7 @@ pub struct VertexAnthropicModel {
 }
 
 impl VertexAnthropicModel {
+    #[must_use]
     pub fn new(model_id: String, config: VertexAnthropicConfig) -> Self {
         Self { model_id, config }
     }
@@ -105,7 +106,7 @@ impl VertexAnthropicModel {
         let mut headers = vec![("Content-Type".to_string(), "application/json".to_string())];
         match &self.config.auth {
             VertexAuth::BearerToken(token) => {
-                headers.push(("Authorization".to_string(), format!("Bearer {}", token)));
+                headers.push(("Authorization".to_string(), format!("Bearer {token}")));
             }
             VertexAuth::ApiKey(key) => {
                 headers.push(("x-goog-api-key".to_string(), key.clone()));

--- a/aimux-providers/src/vertex/embedding.rs
+++ b/aimux-providers/src/vertex/embedding.rs
@@ -41,6 +41,7 @@ pub struct VertexEmbeddingModel {
 }
 
 impl VertexEmbeddingModel {
+    #[must_use]
     pub fn new(model_id: String, config: VertexConfig) -> Self {
         Self { model_id, config }
     }
@@ -49,7 +50,7 @@ impl VertexEmbeddingModel {
         let mut headers = vec![("Content-Type".to_string(), "application/json".to_string())];
         match &self.config.auth {
             VertexAuth::BearerToken(token) => {
-                headers.push(("Authorization".to_string(), format!("Bearer {}", token)));
+                headers.push(("Authorization".to_string(), format!("Bearer {token}")));
             }
             VertexAuth::ApiKey(key) => {
                 headers.push(("x-goog-api-key".to_string(), key.clone()));
@@ -175,7 +176,7 @@ impl EmbeddingModel for VertexEmbeddingModel {
             let usage = raw_value
                 .get("usageMetadata")
                 .and_then(|u| u.get("promptTokenCount"))
-                .and_then(|t| t.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .map(|tokens| EmbeddingUsage {
                     tokens: tokens as u32,
                 });
@@ -268,7 +269,7 @@ impl EmbeddingModel for VertexEmbeddingModel {
                         pred.get("embeddings")
                             .and_then(|e| e.get("statistics"))
                             .and_then(|s| s.get("token_count"))
-                            .and_then(|t| t.as_u64())
+                            .and_then(serde_json::Value::as_u64)
                     })
                     .map(|t| t as u32)
                     .sum();
@@ -316,18 +317,18 @@ fn parse_vertex_provider_options(
     VertexEmbeddingProviderOptions {
         output_dimensionality: provider_opts
             .and_then(|o| o.get("outputDimensionality"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
         task_type: provider_opts
             .and_then(|o| o.get("taskType"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         title: provider_opts
             .and_then(|o| o.get("title"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         auto_truncate: provider_opts
             .and_then(|o| o.get("autoTruncate"))
-            .and_then(|v| v.as_bool()),
+            .and_then(serde_json::Value::as_bool),
     }
 }

--- a/aimux-providers/src/vertex/image.rs
+++ b/aimux-providers/src/vertex/image.rs
@@ -43,6 +43,7 @@ pub struct VertexImageModel {
 }
 
 impl VertexImageModel {
+    #[must_use]
     pub fn new(model_id: String, config: VertexConfig) -> Self {
         Self { model_id, config }
     }
@@ -51,7 +52,7 @@ impl VertexImageModel {
         let mut h = vec![("Content-Type".into(), "application/json".into())];
         match &self.config.auth {
             VertexAuth::BearerToken(token) => {
-                h.push(("Authorization".into(), format!("Bearer {}", token)));
+                h.push(("Authorization".into(), format!("Bearer {token}")));
             }
             VertexAuth::ApiKey(key) => {
                 h.push(("x-goog-api-key".into(), key.clone()));
@@ -164,7 +165,7 @@ impl VertexImageModel {
                 if let Some(d) = mask_dilation {
                     mask_config.insert("dilation".into(), d.clone());
                 }
-                let file_count = options.files.as_ref().map_or(0, |f| f.len());
+                let file_count = options.files.as_ref().map_or(0, std::vec::Vec::len);
                 reference_images.push(json!({
                     "referenceType": "REFERENCE_TYPE_MASK",
                     "referenceId": file_count + 1,
@@ -383,15 +384,15 @@ impl VertexImageModel {
         let usage = rb.get("usageMetadata").map(|u| {
             let inp = u
                 .get("promptTokenCount")
-                .and_then(|v| v.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .map(|x| x as u32);
             let out = u
                 .get("candidatesTokenCount")
-                .and_then(|v| v.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .map(|x| x as u32);
             let tot = u
                 .get("totalTokenCount")
-                .and_then(|v| v.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .map(|x| x as u32);
             ImageUsage {
                 input_tokens: inp,

--- a/aimux-providers/src/vertex/mod.rs
+++ b/aimux-providers/src/vertex/mod.rs
@@ -99,18 +99,21 @@ impl VertexProviderConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// 标注凭证来源(RFC-0023 回放重建用)。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
-        self.api_key_source = source.map(|s| s.to_string());
+        self.api_key_source = source.map(std::string::ToString::to_string);
         self
     }
 
     /// Set the retry configuration. Pass `max_retries: 0` to disable retries.
+    #[must_use]
     pub fn with_retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
@@ -121,6 +124,12 @@ impl VertexProviderConfig {
     /// Checks for `GOOGLE_VERTEX_API_KEY` (Express mode) first, then falls
     /// back to `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when neither `GOOGLE_VERTEX_API_KEY`
+    /// nor the `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` pair is
+    /// set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         // Express mode with API key.
         if let Ok(key) = std::env::var("GOOGLE_VERTEX_API_KEY")
@@ -159,13 +168,10 @@ impl VertexProviderConfig {
 fn build_base_url(project: &str, location: &str, _endpoint: bool) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1beta1/projects/{}/locations/{}/publishers/google",
-        host, project, location
-    )
+    format!("https://{host}/v1beta1/projects/{project}/locations/{location}/publishers/google")
 }
 
 /// Google Vertex AI provider — creates [`VertexModel`] instances.
@@ -177,6 +183,7 @@ pub struct VertexProvider {
 }
 
 impl VertexProvider {
+    #[must_use]
     pub fn new(config: VertexProviderConfig) -> Self {
         Self { config }
     }
@@ -186,6 +193,12 @@ impl VertexProvider {
     ///
     /// Returns an error when Express Mode (API key auth) is used with a tuned
     /// model (`endpoints/…`), which the Vertex AI API does not support.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when Express Mode (API key auth) is
+    /// combined with a tuned model (`endpoints/…`), which the Vertex AI API does
+    /// not support.
     pub fn model(&self, model_id: &str) -> Result<VertexModel, AiMuxError> {
         if model_id.starts_with("endpoints/") && matches!(self.config.auth, VertexAuth::ApiKey(_)) {
             return Err(AiMuxError::InvalidArgument(
@@ -211,12 +224,17 @@ impl VertexProvider {
     /// `/publishers/google` suffix (if present) is stripped so the
     /// `/publishers/anthropic` suffix can be appended by the model. Auth is
     /// reused from this provider (Bearer token or API key).
+    ///
+    /// # Errors
+    ///
+    /// Propagates configuration errors of the underlying `VertexAnthropicModel`
+    /// construction (none in the current implementation).
     pub fn anthropic_model(&self, model_id: &str) -> Result<VertexAnthropicModel, AiMuxError> {
         let base_url = self
             .config
             .base_url
             .strip_suffix("/publishers/google")
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
             .unwrap_or_else(|| self.config.base_url.clone());
         Ok(VertexAnthropicModel::new(
             model_id.to_string(),
@@ -231,6 +249,7 @@ impl VertexProvider {
 
     /// Create an embedding model instance for the given Vertex AI model name
     /// (e.g. `"textembedding-gecko@001"`).
+    #[must_use]
     pub fn embedding_model(&self, model_id: &str) -> VertexEmbeddingModel {
         VertexEmbeddingModel::new(
             model_id.to_string(),
@@ -245,6 +264,7 @@ impl VertexProvider {
 
     /// Create an image generation model instance for the given Vertex AI model
     /// name (e.g. `"imagen-4.0-generate-001"` or `"gemini-2.5-flash-image"`).
+    #[must_use]
     pub fn image(&self, model_id: &str) -> VertexImageModel {
         VertexImageModel::new(
             model_id.to_string(),
@@ -260,6 +280,11 @@ impl VertexProvider {
     /// Create a transcription (STT) model instance for the given Speech-to-Text
     /// model name (e.g. `"chirp_3"`). Requires project and location to be set
     /// in the config (use [`VertexProviderConfig::new`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `project` is not set in the
+    /// config.
     pub fn transcription(&self, model_id: &str) -> Result<VertexTranscriptionModel, AiMuxError> {
         let project = self.config.project.clone().ok_or_else(|| {
             AiMuxError::InvalidArgument(
@@ -283,6 +308,11 @@ impl VertexProvider {
 
     /// Create a video generation model instance for the given Vertex AI model
     /// name (e.g. `"veo-3.0-generate-001"`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `project` is not set in the
+    /// config.
     pub fn video(&self, model_id: &str) -> Result<VertexVideoModel, AiMuxError> {
         let project = self.config.project.clone().ok_or_else(|| {
             AiMuxError::InvalidArgument(

--- a/aimux-providers/src/vertex/model.rs
+++ b/aimux-providers/src/vertex/model.rs
@@ -57,6 +57,7 @@ pub struct VertexModel {
 }
 
 impl VertexModel {
+    #[must_use]
     pub fn new(model_id: String, config: VertexConfig) -> Self {
         Self { model_id, config }
     }
@@ -65,7 +66,7 @@ impl VertexModel {
         let mut headers = vec![("Content-Type".to_string(), "application/json".to_string())];
         match &self.config.auth {
             VertexAuth::BearerToken(token) => {
-                headers.push(("Authorization".to_string(), format!("Bearer {}", token)));
+                headers.push(("Authorization".to_string(), format!("Bearer {token}")));
             }
             VertexAuth::ApiKey(key) => {
                 headers.push(("x-goog-api-key".to_string(), key.clone()));
@@ -387,7 +388,7 @@ impl LanguageModel for VertexModel {
                                 if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
                                     if !text.is_empty() {
                                         if text_id.is_none() {
-                                            let id = format!("{}", block_counter);
+                                            let id = format!("{block_counter}");
                                             block_counter += 1;
                                             text_id = Some(id.clone());
                                             yield Ok(StreamPart::TextStart { id, provider_metadata: None});
@@ -408,14 +409,14 @@ impl LanguageModel for VertexModel {
                                     let id = fc
                                         .get("id")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string())
-                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                        .map(std::string::ToString::to_string)
+                                        .unwrap_or_else(|| format!("call-{block_counter}"));
                                     block_counter += 1;
                                     let args = fc.get("args").cloned().unwrap_or(json!({}));
                                     let thought_signature = part
                                         .get("thoughtSignature")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string());
+                                        .map(std::string::ToString::to_string);
 
                                     yield Ok(StreamPart::ToolInputStart {
                                         id: id.clone(),
@@ -450,7 +451,7 @@ impl LanguageModel for VertexModel {
                                         .map(|s| !s.is_empty())
                                         .unwrap_or(false);
                                     if has_code {
-                                        let id = format!("call-{}", block_counter);
+                                        let id = format!("call-{block_counter}");
                                         block_counter += 1;
                                         last_code_execution_tool_call_id = Some(id.clone());
                                         yield Ok(StreamPart::ToolCall {
@@ -475,7 +476,7 @@ impl LanguageModel for VertexModel {
                                         let output = cer
                                             .get("output")
                                             .and_then(|v| v.as_str())
-                                            .map(|s| s.to_string())
+                                            .map(std::string::ToString::to_string)
                                             .unwrap_or_default();
                                         yield Ok(StreamPart::ToolResult {
                                             tool_call_id: call_id,
@@ -496,14 +497,14 @@ impl LanguageModel for VertexModel {
                                     let id = tc
                                         .get("id")
                                         .and_then(|v| v.as_str())
-                                        .map(|s| s.to_string())
-                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                        .map(std::string::ToString::to_string)
+                                        .unwrap_or_else(|| format!("call-{block_counter}"));
                                     block_counter += 1;
                                     last_server_tool_call_id = Some(id.clone());
                                     let args = tc.get("args").cloned().unwrap_or(json!({}));
                                     yield Ok(StreamPart::ToolCall {
                                         tool_call_id: id,
-                                        tool_name: format!("server:{}", tool_type),
+                                        tool_name: format!("server:{tool_type}"),
                                         input: args,
                                         provider_executed: None,
                                         dynamic: None,
@@ -518,9 +519,9 @@ impl LanguageModel for VertexModel {
                                         .or_else(|| {
                                             tr.get("id")
                                                 .and_then(|v| v.as_str())
-                                                .map(|s| s.to_string())
+                                                .map(std::string::ToString::to_string)
                                         })
-                                        .unwrap_or_else(|| format!("call-{}", block_counter));
+                                        .unwrap_or_else(|| format!("call-{block_counter}"));
                                     block_counter += 1;
                                     let response =
                                         tr.get("response").cloned().unwrap_or(json!({}));
@@ -637,7 +638,7 @@ fn extract_content_from_candidate(candidate: &Candidate) -> (Vec<GenerateContent
             let thought_signature = part
                 .get("thoughtSignature")
                 .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
+                .map(std::string::ToString::to_string);
             content.push(GenerateContent::ToolCall {
                 tool_call_id: id,
                 tool_name: name,

--- a/aimux-providers/src/vertex/transcription.rs
+++ b/aimux-providers/src/vertex/transcription.rs
@@ -91,7 +91,7 @@ fn convert_bcp47_to_iso6391(value: &Option<String>) -> Option<String> {
         .as_ref()
         .and_then(|s| s.split('-').next())
         .filter(|s| s.len() == 2)
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
 }
 
 fn audio_input_to_base64(audio: &AudioInput) -> Result<String, AiMuxError> {
@@ -115,6 +115,7 @@ pub struct VertexTranscriptionModel {
 }
 
 impl VertexTranscriptionModel {
+    #[must_use]
     pub fn new(
         model_id: String,
         project: String,
@@ -208,15 +209,18 @@ impl TranscriptionModel for VertexTranscriptionModel {
                     if let Some(lc) = gv.get("languageCodes").and_then(|v| v.as_array()) {
                         language_codes = lc
                             .iter()
-                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                             .collect();
                     }
-                    if let Some(v) = gv.get("enableWordTimeOffsets").and_then(|v| v.as_bool()) {
+                    if let Some(v) = gv
+                        .get("enableWordTimeOffsets")
+                        .and_then(serde_json::Value::as_bool)
+                    {
                         enable_word_time_offsets = v;
                     }
                     if let Some(v) = gv
                         .get("enableAutomaticPunctuation")
-                        .and_then(|v| v.as_bool())
+                        .and_then(serde_json::Value::as_bool)
                     {
                         enable_automatic_punctuation = v;
                     }

--- a/aimux-providers/src/vertex/video.rs
+++ b/aimux-providers/src/vertex/video.rs
@@ -42,6 +42,7 @@ pub struct VertexVideoModel {
 }
 
 impl VertexVideoModel {
+    #[must_use]
     pub fn new(
         model_id: String,
         project: String,
@@ -218,13 +219,13 @@ impl VideoModel for VertexVideoModel {
                     provider_code: err
                         .get("status")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                     message: msg.to_string(),
                     response_body: Some(String::from_utf8_lossy(&resp.body).into_owned()),
                     ..Default::default()
                 }));
             }
-            if raw_body.get("done").and_then(|v| v.as_bool()) == Some(true) {
+            if raw_body.get("done").and_then(serde_json::Value::as_bool) == Some(true) {
                 break;
             }
         }

--- a/aimux-providers/src/vertex_ai_ai21_models.rs
+++ b/aimux-providers/src/vertex_ai_ai21_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiAi21ModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiAi21ModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiAi21ModelsConfig {
 pub struct VertexAiAi21ModelsProvider(OpenAIProvider);
 
 impl VertexAiAi21ModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiAi21ModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"ai21/jamba-1.5-large"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_anthropic_models.rs
+++ b/aimux-providers/src/vertex_ai_anthropic_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiAnthropicModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiAnthropicModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiAnthropicModelsConfig {
 pub struct VertexAiAnthropicModelsProvider(OpenAIProvider);
 
 impl VertexAiAnthropicModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiAnthropicModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"anthropic/claude-sonnet-4"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_deepseek_models.rs
+++ b/aimux-providers/src/vertex_ai_deepseek_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiDeepseekModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiDeepseekModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiDeepseekModelsConfig {
 pub struct VertexAiDeepseekModelsProvider(OpenAIProvider);
 
 impl VertexAiDeepseekModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiDeepseekModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"deepseek-ai/deepseek-v3.1-maas"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_llama_models.rs
+++ b/aimux-providers/src/vertex_ai_llama_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiLlamaModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiLlamaModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiLlamaModelsConfig {
 pub struct VertexAiLlamaModelsProvider(OpenAIProvider);
 
 impl VertexAiLlamaModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiLlamaModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"meta/llama-4-scout-17b-16e-instruct-maas"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_minimax_models.rs
+++ b/aimux-providers/src/vertex_ai_minimax_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiMinimaxModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiMinimaxModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiMinimaxModelsConfig {
 pub struct VertexAiMinimaxModelsProvider(OpenAIProvider);
 
 impl VertexAiMinimaxModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiMinimaxModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"minimax/minimax-m2-maas"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_mistral_models.rs
+++ b/aimux-providers/src/vertex_ai_mistral_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiMistralModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiMistralModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiMistralModelsConfig {
 pub struct VertexAiMistralModelsProvider(OpenAIProvider);
 
 impl VertexAiMistralModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiMistralModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"mistralai/mistral-large-2411"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_moonshot_models.rs
+++ b/aimux-providers/src/vertex_ai_moonshot_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiMoonshotModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiMoonshotModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiMoonshotModelsConfig {
 pub struct VertexAiMoonshotModelsProvider(OpenAIProvider);
 
 impl VertexAiMoonshotModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiMoonshotModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"moonshotai/kimi-k2-thinking-maas"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_openai_models.rs
+++ b/aimux-providers/src/vertex_ai_openai_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiOpenaiModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiOpenaiModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiOpenaiModelsConfig {
 pub struct VertexAiOpenaiModelsProvider(OpenAIProvider);
 
 impl VertexAiOpenaiModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiOpenaiModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"openai/gpt-oss-120b-maas"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_qwen_models.rs
+++ b/aimux-providers/src/vertex_ai_qwen_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiQwenModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiQwenModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiQwenModelsConfig {
 pub struct VertexAiQwenModelsProvider(OpenAIProvider);
 
 impl VertexAiQwenModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiQwenModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"qwen/qwen3-coder-480b-a35b-instruct-maas"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vertex_ai_zai_models.rs
+++ b/aimux-providers/src/vertex_ai_zai_models.rs
@@ -43,13 +43,10 @@ const DEFAULT_PROJECT: &str = "your-project";
 fn build_maas_base_url(project: &str, location: &str) -> String {
     let host = match location {
         "global" => "aiplatform.googleapis.com".to_string(),
-        "eu" | "us" => format!("aiplatform.{}.rep.googleapis.com", location),
-        _ => format!("{}-aiplatform.googleapis.com", location),
+        "eu" | "us" => format!("aiplatform.{location}.rep.googleapis.com"),
+        _ => format!("{location}-aiplatform.googleapis.com"),
     };
-    format!(
-        "https://{}/v1/projects/{}/locations/{}/endpoints/openapi",
-        host, project, location
-    )
+    format!("https://{host}/v1/projects/{project}/locations/{location}/endpoints/openapi")
 }
 
 /// Assemble the shared [`OpenAIConfig`] for the given token + project/location.
@@ -78,6 +75,11 @@ impl VertexAiZaiModelsConfig {
 
     /// Create from `GOOGLE_VERTEX_ACCESS_TOKEN` + `GOOGLE_VERTEX_PROJECT` +
     /// `GOOGLE_VERTEX_LOCATION` (location defaults to `global`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `GOOGLE_VERTEX_ACCESS_TOKEN` or
+    /// `GOOGLE_VERTEX_PROJECT` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let token = std::env::var(TOKEN_ENV_VAR).map_err(|_| {
             AiMuxError::InvalidArgument(
@@ -97,6 +99,7 @@ impl VertexAiZaiModelsConfig {
     }
 
     /// Override the base URL (useful for tests / proxies).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -108,12 +111,14 @@ impl VertexAiZaiModelsConfig {
 pub struct VertexAiZaiModelsProvider(OpenAIProvider);
 
 impl VertexAiZaiModelsProvider {
+    #[must_use]
     pub fn new(config: VertexAiZaiModelsConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
     /// Create a model instance for the given Vertex AI MaaS model id
     /// (e.g. `"zai-org/glm-4.7-maas"`).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/vllm.rs
+++ b/aimux-providers/src/vllm.rs
@@ -30,6 +30,13 @@ impl VllmConfig {
         )
     }
 
+    /// Create from the `VLLM_BASE_URL` environment variable, falling back to
+    /// `http://127.0.0.1:8000/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl VllmConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl VllmConfig {
 pub struct VllmProvider(OpenAIProvider);
 
 impl VllmProvider {
+    #[must_use]
     pub fn new(config: VllmConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/voyage/embedding.rs
+++ b/aimux-providers/src/voyage/embedding.rs
@@ -31,6 +31,7 @@ pub struct VoyageEmbeddingModel {
 }
 
 impl VoyageEmbeddingModel {
+    #[must_use]
     pub fn new(model_id: String, config: VoyageConfig) -> Self {
         Self { model_id, config }
     }
@@ -132,7 +133,10 @@ impl EmbeddingModel for VoyageEmbeddingModel {
                 let mut indexed: Vec<(u64, Vec<f32>)> = arr
                     .iter()
                     .map(|item| {
-                        let index = item.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
+                        let index = item
+                            .get("index")
+                            .and_then(serde_json::Value::as_u64)
+                            .unwrap_or(0);
                         let embedding = item
                             .get("embedding")
                             .and_then(|e| e.as_array())
@@ -154,7 +158,7 @@ impl EmbeddingModel for VoyageEmbeddingModel {
         let tokens = raw_value
             .get("usage")
             .and_then(|u| u.get("total_tokens"))
-            .and_then(|t| t.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(0) as u32;
 
         Ok(EmbeddingResult {
@@ -187,17 +191,17 @@ fn parse_voyage_provider_options(
         input_type: provider_opts
             .and_then(|o| o.get("inputType"))
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
         truncation: provider_opts
             .and_then(|o| o.get("truncation"))
-            .and_then(|v| v.as_bool()),
+            .and_then(serde_json::Value::as_bool),
         output_dimension: provider_opts
             .and_then(|o| o.get("outputDimension"))
-            .and_then(|d| d.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .map(|d| d as u32),
         output_dtype: provider_opts
             .and_then(|o| o.get("outputDtype"))
             .and_then(|d| d.as_str())
-            .map(|s| s.to_string()),
+            .map(std::string::ToString::to_string),
     }
 }

--- a/aimux-providers/src/voyage/mod.rs
+++ b/aimux-providers/src/voyage/mod.rs
@@ -30,12 +30,17 @@ impl VoyageConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Create from the `VOYAGE_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `VOYAGE_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "VOYAGE_API_KEY", "Voyage")?;
         Ok(Self::new(api_key))
@@ -48,18 +53,21 @@ pub struct VoyageProvider {
 }
 
 impl VoyageProvider {
+    #[must_use]
     pub fn new(config: VoyageConfig) -> Self {
         Self { config }
     }
 
     /// Create an embedding model instance for the given model name (e.g.
     /// `"voyage-3.5"`).
+    #[must_use]
     pub fn embedding_model(&self, model_id: &str) -> VoyageEmbeddingModel {
         VoyageEmbeddingModel::new(model_id.to_string(), self.config.clone())
     }
 
     /// Create a reranking model instance for the given model name (e.g.
     /// `"rerank-2.5"`).
+    #[must_use]
     pub fn reranking_model(&self, model_id: &str) -> reranking::VoyageRerankingModel {
         reranking::VoyageRerankingModel::new(model_id.to_string(), self.config.clone())
     }

--- a/aimux-providers/src/voyage/reranking.rs
+++ b/aimux-providers/src/voyage/reranking.rs
@@ -35,10 +35,16 @@ fn parse_voyage_reranking_options(
     if let Some(po) = provider_options
         && let Some(voyage) = po.get("voyage")
     {
-        if let Some(v) = voyage.get("returnDocuments").and_then(|v| v.as_bool()) {
+        if let Some(v) = voyage
+            .get("returnDocuments")
+            .and_then(serde_json::Value::as_bool)
+        {
             opts.return_documents = Some(v);
         }
-        if let Some(v) = voyage.get("truncation").and_then(|v| v.as_bool()) {
+        if let Some(v) = voyage
+            .get("truncation")
+            .and_then(serde_json::Value::as_bool)
+        {
             opts.truncation = Some(v);
         }
     }
@@ -64,6 +70,7 @@ pub struct VoyageRerankingModel {
 }
 
 impl VoyageRerankingModel {
+    #[must_use]
     pub fn new(model_id: String, config: VoyageConfig) -> Self {
         Self { model_id, config }
     }
@@ -113,7 +120,10 @@ impl RerankingModel for VoyageRerankingModel {
                     feature: "object documents".to_string(),
                     details: Some("Object documents are converted to strings.".to_string()),
                 });
-                values.iter().map(|v| v.to_string()).collect()
+                values
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect()
             }
         };
 

--- a/aimux-providers/src/xai/convert.rs
+++ b/aimux-providers/src/xai/convert.rs
@@ -1,4 +1,4 @@
-﻿//! Conversion between `LanguageModelPrompt` and xAI API format.
+//! Conversion between `LanguageModelPrompt` and xAI API format.
 //!
 //! Mirrors the TS xai package's `convert-to-xai-chat-messages.ts`,
 //! `convert-xai-chat-usage.ts`, `xai-prepare-tools.ts`,
@@ -22,6 +22,7 @@ use super::types::XaiUsageResponse;
 // ── Finish reason ────────────────────────────────────────────────────────────
 
 /// Map an xAI finish reason string to the unified enum.
+#[must_use]
 pub fn map_xai_finish_reason(s: &str) -> FinishReasonUnified {
     match s {
         "stop" => FinishReasonUnified::Stop,
@@ -32,6 +33,7 @@ pub fn map_xai_finish_reason(s: &str) -> FinishReasonUnified {
     }
 }
 
+#[must_use]
 pub fn parse_finish_reason(s: &str) -> FinishReason {
     FinishReason {
         unified: map_xai_finish_reason(s),
@@ -60,12 +62,14 @@ fn is_model_without_reasoning_effort(model_id: &str) -> bool {
 }
 
 /// Whether the model accepts the `reasoning_effort` parameter.
+#[must_use]
 pub fn supports_reasoning_effort(model_id: &str) -> bool {
     !is_model_without_reasoning_effort(model_id)
 }
 
 // ── Usage conversion ─────────────────────────────────────────────────────────
 
+#[must_use]
 pub fn convert_xai_usage(usage: &XaiUsageResponse) -> aimux_core::types::Usage {
     let prompt_tokens = usage.prompt_tokens.unwrap_or(0);
     let completion_tokens = usage.completion_tokens.unwrap_or(0);
@@ -120,6 +124,7 @@ pub struct PreparedTools {
     pub tool_warnings: Vec<Warning>,
 }
 
+#[must_use]
 pub fn prepare_tools(tools: &Option<Vec<Tool>>, tool_choice: Option<&ToolChoice>) -> PreparedTools {
     let non_empty = tools.as_ref().filter(|t| !t.is_empty());
     let mut tool_warnings: Vec<Warning> = Vec::new();
@@ -223,6 +228,7 @@ fn get_top_level_media_type(media_type: &str) -> &str {
     media_type.split('/').next().unwrap_or("")
 }
 
+#[must_use]
 pub fn resolve_full_media_type(media_type: &str, b64_data: &str) -> String {
     let top_level = get_top_level_media_type(media_type);
     if top_level == "image" && media_type != "image" && !media_type.ends_with("/*") {
@@ -246,6 +252,13 @@ pub fn resolve_full_media_type(media_type: &str, b64_data: &str) -> String {
     media_type.to_string()
 }
 
+/// Resolve the provider-specific reference string from a file part's
+/// `provider` map.
+///
+/// # Errors
+///
+/// Returns a `String` listing the available providers when the requested key
+/// is absent.
 pub fn resolve_provider_reference(reference: &Value, provider: &str) -> Result<String, String> {
     if let Some(val) = reference.get(provider) {
         if let Some(s) = val.as_str() {
@@ -266,6 +279,12 @@ pub fn resolve_provider_reference(reference: &Value, provider: &str) -> Result<S
 
 // ── Message conversion ───────────────────────────────────────────────────────
 
+/// Convert a [`LanguageModelPrompt`] into xAI `messages`, returning warnings.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` when a user part cannot be converted
+/// (e.g. invalid base64 data or an unsupported file part).
 pub fn convert_to_xai_messages(
     prompt: &LanguageModelPrompt,
 ) -> Result<(Vec<Value>, Vec<Warning>), AiMuxError> {
@@ -406,8 +425,7 @@ fn convert_image_part(
     let top_level = get_top_level_media_type(media_type);
     if top_level != "image" {
         return Err(AiMuxError::UnsupportedFunctionality(format!(
-            "file part media type {}",
-            media_type
+            "file part media type {media_type}"
         )));
     }
     let image_url = if let Some(url_str) = url {
@@ -433,6 +451,11 @@ pub struct RequestBodyResult {
     pub warnings: Vec<Warning>,
 }
 
+/// Convert `CallOptions` to an xAI request body, returning warnings.
+///
+/// # Errors
+///
+/// Propagates prompt-conversion errors from `convert_to_xai_messages`.
 pub fn build_request_body_with_warnings(
     model_id: &str,
     options: &CallOptions,
@@ -474,8 +497,11 @@ pub fn build_request_body_with_warnings(
         warnings.push(tw.clone());
     }
 
-    let mut reasoning_effort: Option<String> = xai_option(xai_opts, "reasoningEffort")
-        .map(|v| v.as_str().map(|s| s.to_string()).unwrap_or(v.to_string()));
+    let mut reasoning_effort: Option<String> = xai_option(xai_opts, "reasoningEffort").map(|v| {
+        v.as_str()
+            .map(std::string::ToString::to_string)
+            .unwrap_or(v.to_string())
+    });
 
     if reasoning_effort.is_none() && options.reasoning.is_some_and(ReasoningEffort::is_custom) {
         let reasoning = options.reasoning.unwrap();
@@ -483,8 +509,7 @@ pub fn build_request_body_with_warnings(
             warnings.push(Warning::Unsupported {
                 feature: "reasoning".to_string(),
                 details: Some(format!(
-                    "reasoning \"{}\" is not supported by this model.",
-                    reasoning
+                    "reasoning \"{reasoning}\" is not supported by this model."
                 )),
             });
         } else if reasoning == ReasoningEffort::None {

--- a/aimux-providers/src/xai/mod.rs
+++ b/aimux-providers/src/xai/mod.rs
@@ -37,12 +37,17 @@ impl XAIConfig {
     }
 
     /// Create from the `XAI_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `XAI_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let key = load_api_key(None, ENV_VAR, "xAI")?;
         Ok(Self::new(key).with_api_key_source(Some("env:XAI_API_KEY")))
     }
 
     /// 标注 api_key 来源(RFC-0023 回放重建用)。透传到内部 `OpenAIConfig`。
+    #[must_use]
     pub fn with_api_key_source(mut self, source: Option<&str>) -> Self {
         self.0 = self.0.with_api_key_source(source);
         self
@@ -54,6 +59,7 @@ impl XAIConfig {
     }
 
     /// Override the base URL (useful for tests / self-hosted endpoints).
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -84,6 +90,7 @@ pub struct XAIProvider {
 }
 
 impl XAIProvider {
+    #[must_use]
     pub fn new(config: XAIConfig) -> Self {
         Self { config }
     }
@@ -93,6 +100,7 @@ impl XAIProvider {
     /// Clones the provider config so the model inherits the same
     /// `api_key_source` / `retry_config` (M2b: previously reconstructed with
     /// `XAIConfig::new`, which dropped the credential source).
+    #[must_use]
     pub fn model(&self, model_id: &str) -> XaiModel {
         XaiModel::new(model_id.to_string(), self.config.clone())
     }
@@ -101,6 +109,7 @@ impl XAIProvider {
     ///
     /// Uses the xAI `/responses` endpoint with the Responses API wire format
     /// (input items, reasoning objects, provider-executed tools, etc.).
+    #[must_use]
     pub fn responses_model(&self, model_id: &str) -> XaiResponsesModel {
         XaiResponsesModel::new(model_id.to_string(), self.config.clone())
     }

--- a/aimux-providers/src/xai/model.rs
+++ b/aimux-providers/src/xai/model.rs
@@ -48,6 +48,7 @@ pub struct XaiModel {
 }
 
 impl XaiModel {
+    #[must_use]
     pub fn new(model_id: String, config: super::XAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -138,7 +139,7 @@ impl LanguageModel for XaiModel {
                 provider_code: raw_value
                     .get("code")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 message: error_msg.to_string(),
                 response_body: Some(String::from_utf8_lossy(&resp.body).into_owned()),
                 ..Default::default()
@@ -304,7 +305,7 @@ impl LanguageModel for XaiModel {
         // errors with 200 status and content-type application/json.
         let content_type = response_headers
             .get("content-type")
-            .map(|s| s.as_str())
+            .map(std::string::String::as_str)
             .unwrap_or("");
         if content_type.contains("application/json") {
             // Collect the (non-SSE) JSON body and check for an error object.
@@ -322,7 +323,7 @@ impl LanguageModel for XaiModel {
                     provider_code: val
                         .get("code")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                     message: err_msg.to_string(),
                     response_body: Some(String::from_utf8_lossy(&buf).into_owned()),
                     ..Default::default()
@@ -347,7 +348,7 @@ impl LanguageModel for XaiModel {
                     provider_code: val
                         .get("code")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                     message: err_msg.to_string(),
                     response_body: Some(event.data.clone()),
                     ..Default::default()
@@ -491,7 +492,7 @@ impl LanguageModel for XaiModel {
                                         == Some(text_content.as_str());
 
                                 if !is_dup {
-                                    let block_id = format!("text-{}", chunk_id);
+                                    let block_id = format!("text-{chunk_id}");
                                     if !content_blocks.contains_key(&block_id) {
                                         content_blocks.insert(block_id.clone(), false);
                                         yield Ok(StreamPart::TextStart {
@@ -511,10 +512,10 @@ impl LanguageModel for XaiModel {
                             if let Some(reasoning_content) = &delta.reasoning_content
                                 && !reasoning_content.is_empty()
                             {
-                                let block_id = format!("reasoning-{}", chunk_id);
+                                let block_id = format!("reasoning-{chunk_id}");
 
                                 // Skip if duplicates last delta.
-                                if last_reasoning_deltas.get(&block_id).map(|s| s.as_str())
+                                if last_reasoning_deltas.get(&block_id).map(std::string::String::as_str)
                                     != Some(reasoning_content.as_str())
                                 {
                                     last_reasoning_deltas

--- a/aimux-providers/src/xai/responses/convert.rs
+++ b/aimux-providers/src/xai/responses/convert.rs
@@ -24,6 +24,7 @@ use crate::xai::convert::{
 
 // ── Finish reason ────────────────────────────────────────────────────────────
 
+#[must_use]
 pub fn map_xai_responses_finish_reason(s: &str) -> FinishReasonUnified {
     match s {
         "stop" | "completed" => FinishReasonUnified::Stop,
@@ -37,6 +38,7 @@ pub fn map_xai_responses_finish_reason(s: &str) -> FinishReasonUnified {
 
 // ── Usage conversion ─────────────────────────────────────────────────────────
 
+#[must_use]
 pub fn convert_xai_responses_usage(usage: &XaiResponsesUsage) -> aimux_core::types::Usage {
     let cache_read = usage
         .input_tokens_details
@@ -91,6 +93,7 @@ pub struct PreparedResponsesTools {
     pub provider_tool_names: std::collections::HashMap<String, String>,
 }
 
+#[must_use]
 pub fn prepare_responses_tools(
     tools: &Option<Vec<Tool>>,
     tool_choice: Option<&ToolChoice>,
@@ -281,6 +284,12 @@ fn xai_option(
 
 // ── Input conversion ─────────────────────────────────────────────────────────
 
+/// Convert a [`LanguageModelPrompt`] into the xAI Responses `input` array,
+/// returning warnings.
+///
+/// # Errors
+///
+/// Returns `AiMuxError::InvalidArgument` when a part cannot be converted.
 pub fn convert_to_xai_responses_input(
     prompt: &LanguageModelPrompt,
 ) -> Result<(Vec<Value>, Vec<Warning>), AiMuxError> {
@@ -401,7 +410,7 @@ pub fn convert_to_xai_responses_input(
                                 .and_then(|po| po.get("xai"))
                                 .and_then(|x| x.get("itemId"))
                                 .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
+                                .map(std::string::ToString::to_string);
                             let mut msg_obj = json!({ "role": "assistant", "content": text });
                             if let Some(id) = id {
                                 msg_obj["id"] = json!(id);
@@ -420,7 +429,7 @@ pub fn convert_to_xai_responses_input(
                                 .as_ref()
                                 .and_then(|po| po.get("xai"))
                                 .and_then(|x| x.get("providerExecuted"))
-                                .and_then(|v| v.as_bool())
+                                .and_then(serde_json::Value::as_bool)
                                 .unwrap_or(false);
                             if is_provider_executed {
                                 continue;
@@ -430,7 +439,7 @@ pub fn convert_to_xai_responses_input(
                                 .and_then(|po| po.get("xai"))
                                 .and_then(|x| x.get("itemId"))
                                 .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
+                                .map(std::string::ToString::to_string);
                             let item_id = id.unwrap_or_else(|| tool_call_id.clone());
                             let arguments = if tool_input.is_null() {
                                 "{}".to_string()
@@ -457,13 +466,13 @@ pub fn convert_to_xai_responses_input(
                                 .and_then(|po| po.get("xai"))
                                 .and_then(|x| x.get("itemId"))
                                 .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
+                                .map(std::string::ToString::to_string);
                             let encrypted_content = provider_options
                                 .as_ref()
                                 .and_then(|po| po.get("xai"))
                                 .and_then(|x| x.get("reasoningEncryptedContent"))
                                 .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
+                                .map(std::string::ToString::to_string);
 
                             if item_id.is_some() || encrypted_content.is_some() {
                                 let mut summary: Vec<Value> = Vec::new();
@@ -530,7 +539,7 @@ fn convert_image_part(
         url_str.to_string()
     } else if let Some(b64) = b64_data {
         let full_mt = resolve_full_media_type(media_type, b64);
-        format!("data:{};base64,{}", full_mt, b64)
+        format!("data:{full_mt};base64,{b64}")
     } else {
         String::new()
     };
@@ -561,6 +570,12 @@ pub struct ResponsesRequestBodyResult {
     pub provider_tool_names: std::collections::HashMap<String, String>,
 }
 
+/// Build the xAI Responses request body, returning warnings and provider tool
+/// names.
+///
+/// # Errors
+///
+/// Propagates conversion errors from `convert_to_xai_responses_input`.
 pub fn build_responses_request_body(
     model_id: &str,
     options: &CallOptions,
@@ -585,8 +600,11 @@ pub fn build_responses_request_body(
     }
 
     // Reasoning effort.
-    let mut reasoning_effort: Option<String> = xai_option(xai_opts, "reasoningEffort")
-        .map(|v| v.as_str().map(|s| s.to_string()).unwrap_or(v.to_string()));
+    let mut reasoning_effort: Option<String> = xai_option(xai_opts, "reasoningEffort").map(|v| {
+        v.as_str()
+            .map(std::string::ToString::to_string)
+            .unwrap_or(v.to_string())
+    });
 
     if reasoning_effort.is_none() && options.reasoning.is_some_and(ReasoningEffort::is_custom) {
         let reasoning = options.reasoning.unwrap();
@@ -594,8 +612,7 @@ pub fn build_responses_request_body(
             warnings.push(Warning::Unsupported {
                 feature: "reasoning".to_string(),
                 details: Some(format!(
-                    "reasoning \"{}\" is not supported by this model.",
-                    reasoning
+                    "reasoning \"{reasoning}\" is not supported by this model."
                 )),
             });
         } else if reasoning == ReasoningEffort::None {
@@ -621,7 +638,7 @@ pub fn build_responses_request_body(
     let mut include: Option<Vec<String>> = xai_option(xai_opts, "include").and_then(|v| {
         v.as_array().map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
                 .collect()
         })
     });
@@ -636,8 +653,8 @@ pub fn build_responses_request_body(
         };
     }
 
-    let previous_response_id =
-        xai_option(xai_opts, "previousResponseId").and_then(|v| v.as_str().map(|s| s.to_string()));
+    let previous_response_id = xai_option(xai_opts, "previousResponseId")
+        .and_then(|v| v.as_str().map(std::string::ToString::to_string));
 
     // Logprobs.
     let logprobs = xai_option(xai_opts, "logprobs")
@@ -751,6 +768,7 @@ pub const X_SEARCH_SUB_TOOLS: &[&str] = &[
 
 /// Resolve the tool name for a server-side tool call, using the user-provided
 /// provider tool name if available, falling back to a default.
+#[must_use]
 pub fn resolve_tool_name(
     part_type: &str,
     part_name: Option<&str>,
@@ -799,6 +817,7 @@ pub fn resolve_tool_name(
 }
 
 /// Get the tool input for a server-side tool call.
+#[must_use]
 pub fn get_tool_input(part_type: &str, part: &Value) -> String {
     match part_type {
         "custom_tool_call" => part

--- a/aimux-providers/src/xai/responses/mod.rs
+++ b/aimux-providers/src/xai/responses/mod.rs
@@ -57,6 +57,7 @@ pub struct XaiResponsesModel {
 }
 
 impl XaiResponsesModel {
+    #[must_use]
     pub fn new(model_id: String, config: XAIConfig) -> Self {
         Self { model_id, config }
     }
@@ -133,7 +134,7 @@ impl LanguageModel for XaiResponsesModel {
                 provider_code: raw_value
                     .get("code")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
+                    .map(std::string::ToString::to_string),
                 message: error_msg.to_string(),
                 response_body: Some(String::from_utf8_lossy(&resp.body).into_owned()),
                 ..Default::default()
@@ -289,7 +290,7 @@ impl LanguageModel for XaiResponsesModel {
                                 .filter_map(|s| {
                                     s.get("text")
                                         .and_then(|v| v.as_str())
-                                        .map(|t| t.to_string())
+                                        .map(std::string::ToString::to_string)
                                 })
                                 .filter(|t| !t.is_empty())
                                 .collect()
@@ -300,7 +301,7 @@ impl LanguageModel for XaiResponsesModel {
                                         .filter_map(|s| {
                                             s.get("text")
                                                 .and_then(|v| v.as_str())
-                                                .map(|t| t.to_string())
+                                                .map(std::string::ToString::to_string)
                                         })
                                         .filter(|t| !t.is_empty())
                                         .collect()
@@ -407,7 +408,7 @@ impl LanguageModel for XaiResponsesModel {
         // Check for JSON error (200-status).
         let content_type = response_headers
             .get("content-type")
-            .map(|s| s.as_str())
+            .map(std::string::String::as_str)
             .unwrap_or("");
         if content_type.contains("application/json") {
             // Collect the (non-SSE) JSON body and check for an error object.
@@ -425,7 +426,7 @@ impl LanguageModel for XaiResponsesModel {
                     provider_code: val
                         .get("code")
                         .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                        .map(std::string::ToString::to_string),
                     message: err_msg.to_string(),
                     response_body: Some(String::from_utf8_lossy(&buf).into_owned()),
                     ..Default::default()
@@ -484,9 +485,9 @@ impl LanguageModel for XaiResponsesModel {
                             if is_first_chunk {
                                 is_first_chunk = false;
                                 let response = parsed.get("response").cloned().unwrap_or(Value::Null);
-                                let id = response.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
-                                let model = response.get("model").and_then(|v| v.as_str()).map(|s| s.to_string());
-                                let created_at = response.get("created_at").and_then(|v| v.as_u64());
+                                let id = response.get("id").and_then(|v| v.as_str()).map(std::string::ToString::to_string);
+                                let model = response.get("model").and_then(|v| v.as_str()).map(std::string::ToString::to_string);
+                                let created_at = response.get("created_at").and_then(serde_json::Value::as_u64);
                                 let timestamp = created_at.and_then(|c| {
                                     chrono::DateTime::from_timestamp(c as i64, 0).map(|dt| dt.to_rfc3339())
                                 });
@@ -498,7 +499,7 @@ impl LanguageModel for XaiResponsesModel {
                         // ── reasoning_summary_part.added ──
                         if event_type == "response.reasoning_summary_part.added" {
                             let item_id = parsed.get("item_id").and_then(|v| v.as_str()).unwrap_or("");
-                            let block_id = format!("reasoning-{}", item_id);
+                            let block_id = format!("reasoning-{item_id}");
                             if !active_reasoning.contains_key(item_id) {
                                 active_reasoning.insert(item_id.to_string(), ());
                                 yield Ok(StreamPart::ReasoningStart {
@@ -513,7 +514,7 @@ impl LanguageModel for XaiResponsesModel {
                         if event_type == "response.reasoning_summary_text.delta" {
                             let item_id = parsed.get("item_id").and_then(|v| v.as_str()).unwrap_or("");
                             let delta = parsed.get("delta").and_then(|v| v.as_str()).unwrap_or("");
-                            let block_id = format!("reasoning-{}", item_id);
+                            let block_id = format!("reasoning-{item_id}");
                             yield Ok(StreamPart::ReasoningDelta {
                                 id: block_id,
                                 delta: delta.to_string(),
@@ -531,7 +532,7 @@ impl LanguageModel for XaiResponsesModel {
                         if event_type == "response.reasoning_text.delta" {
                             let item_id = parsed.get("item_id").and_then(|v| v.as_str()).unwrap_or("");
                             let delta = parsed.get("delta").and_then(|v| v.as_str()).unwrap_or("");
-                            let block_id = format!("reasoning-{}", item_id);
+                            let block_id = format!("reasoning-{item_id}");
                             if !active_reasoning.contains_key(item_id) {
                                 active_reasoning.insert(item_id.to_string(), ());
                                 yield Ok(StreamPart::ReasoningStart {
@@ -556,7 +557,7 @@ impl LanguageModel for XaiResponsesModel {
                         if event_type == "response.output_text.delta" {
                             let item_id = parsed.get("item_id").and_then(|v| v.as_str()).unwrap_or("");
                             let delta = parsed.get("delta").and_then(|v| v.as_str()).unwrap_or("");
-                            let block_id = format!("text-{}", item_id);
+                            let block_id = format!("text-{item_id}");
                             if !content_blocks.contains_key(&block_id) {
                                 content_blocks.insert(block_id.clone(), false);
                                 yield Ok(StreamPart::TextStart { id: block_id.clone(), provider_metadata: None});
@@ -627,7 +628,7 @@ impl LanguageModel for XaiResponsesModel {
                                     unified: reason
                                         .map(map_xai_responses_finish_reason)
                                         .unwrap_or(FinishReasonUnified::Other),
-                                    raw: reason.map(|s| s.to_string()).or(Some("incomplete".to_string())),
+                                    raw: reason.map(std::string::ToString::to_string).or(Some("incomplete".to_string())),
                                 };
                             } else if let Some(status) = response.get("status").and_then(|v| v.as_str()) {
                                 final_finish_reason = FinishReason {
@@ -653,7 +654,7 @@ impl LanguageModel for XaiResponsesModel {
                                 unified: reason
                                     .map(map_xai_responses_finish_reason)
                                     .unwrap_or(FinishReasonUnified::Error),
-                                raw: reason.map(|s| s.to_string()).or(Some("error".to_string())),
+                                raw: reason.map(std::string::ToString::to_string).or(Some("error".to_string())),
                             };
                             if let Some(usage) = response.get("usage")
                                 && let Ok(u) = serde_json::from_value::<types::XaiResponsesUsage>(usage.clone()) {
@@ -667,7 +668,7 @@ impl LanguageModel for XaiResponsesModel {
                             let message = parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error");
                             yield Ok(StreamPart::Error {
                                 error: AiMuxError::ApiCall(ApiCallError {
-                                    provider_code: parsed.get("code").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                                    provider_code: parsed.get("code").and_then(|v| v.as_str()).map(std::string::ToString::to_string),
                                     message: message.to_string(),
                                     response_body: Some(sse_event.data.clone()),
                                     ..Default::default()
@@ -685,7 +686,7 @@ impl LanguageModel for XaiResponsesModel {
 
                         // ── function_call_arguments.delta ──
                         if event_type == "response.function_call_arguments.delta" {
-                            let output_index = parsed.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0);
+                            let output_index = parsed.get("output_index").and_then(serde_json::Value::as_u64).unwrap_or(0);
                             let delta = parsed.get("delta").and_then(|v| v.as_str()).unwrap_or("");
                             if let Some((tool_call_id, _)) = ongoing_tool_calls.get(&output_index) {
                                 yield Ok(StreamPart::ToolInputDelta {
@@ -708,13 +709,13 @@ impl LanguageModel for XaiResponsesModel {
                         {
                             let item = parsed.get("item").cloned().unwrap_or(Value::Null);
                             let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                            let output_index = parsed.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0);
+                            let output_index = parsed.get("output_index").and_then(serde_json::Value::as_u64).unwrap_or(0);
 
                             // ── reasoning item ──
                             if item_type == "reasoning" {
                                 if event_type == "response.output_item.done" {
                                     let part_id = item.get("id").and_then(|v| v.as_str()).unwrap_or("");
-                                    let block_id = format!("reasoning-{}", part_id);
+                                    let block_id = format!("reasoning-{part_id}");
                                     let encrypted = item.get("encrypted_content").and_then(|v| v.as_str());
 
                                     if !active_reasoning.contains_key(part_id) {
@@ -869,7 +870,7 @@ impl LanguageModel for XaiResponsesModel {
                                     if let Some(text) = cp.get("text").and_then(|v| v.as_str())
                                         && !text.is_empty() {
                                             let part_id = item.get("id").and_then(|v| v.as_str()).unwrap_or("");
-                                            let block_id = format!("text-{}", part_id);
+                                            let block_id = format!("text-{part_id}");
                                             if !content_blocks.contains_key(&block_id) {
                                                 content_blocks.insert(block_id.clone(), false);
                                                 yield Ok(StreamPart::TextStart { id: block_id.clone(), provider_metadata: None});

--- a/aimux-providers/src/xai/responses/types.rs
+++ b/aimux-providers/src/xai/responses/types.rs
@@ -63,6 +63,7 @@ pub struct XaiResponsesOutputTokensDetails {
 
 /// A streaming SSE event from the Responses API. The `event_type` field
 /// corresponds to the `type` field in the JSON payload.
+#[must_use]
 pub fn event_type(event: &serde_json::Value) -> &str {
     event.get("type").and_then(|v| v.as_str()).unwrap_or("")
 }

--- a/aimux-providers/src/xinference.rs
+++ b/aimux-providers/src/xinference.rs
@@ -30,6 +30,13 @@ impl XinferenceConfig {
         )
     }
 
+    /// Create from the `XINFERENCE_BASE_URL` environment variable, falling back
+    /// to `http://127.0.0.1:9997/v1`.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error; an unset or empty variable falls back to the
+    /// default local endpoint.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let config = Self::new(PLACEHOLDER_API_KEY);
         match std::env::var(ENV_VAR) {
@@ -38,6 +45,7 @@ impl XinferenceConfig {
         }
     }
 
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.0 = self.0.with_base_url(url);
         self
@@ -47,10 +55,12 @@ impl XinferenceConfig {
 pub struct XinferenceProvider(OpenAIProvider);
 
 impl XinferenceProvider {
+    #[must_use]
     pub fn new(config: XinferenceConfig) -> Self {
         Self(OpenAIProvider::new(config.0))
     }
 
+    #[must_use]
     pub fn model(&self, model_id: &str) -> OpenAIModel {
         self.0.model(model_id)
     }

--- a/aimux-providers/src/you_com.rs
+++ b/aimux-providers/src/you_com.rs
@@ -57,12 +57,17 @@ impl YouComConfig {
     }
 
     /// Use a custom base URL.
+    #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = without_trailing_slash(&url.into());
         self
     }
 
     /// Create from the `YDC_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AiMuxError::InvalidArgument` when `YDC_API_KEY` is not set.
     pub fn from_env() -> Result<Self, AiMuxError> {
         let api_key = load_api_key(None, "YDC_API_KEY", "You.com")?;
         Ok(Self::new(api_key))
@@ -88,11 +93,13 @@ pub struct YouComProvider {
 }
 
 impl YouComProvider {
+    #[must_use]
     pub fn new(config: YouComConfig) -> Self {
         Self { config }
     }
 
     /// Create a search model instance.
+    #[must_use]
     pub fn search_model(&self) -> YouComSearchModel {
         YouComSearchModel::new(self.config.clone())
     }
@@ -161,6 +168,7 @@ pub struct YouComSearchModel {
 }
 
 impl YouComSearchModel {
+    #[must_use]
     pub fn new(config: YouComConfig) -> Self {
         Self { config }
     }

--- a/aimux-providers/tests/alibaba_test.rs
+++ b/aimux-providers/tests/alibaba_test.rs
@@ -74,7 +74,7 @@ fn text_completion_body() -> Value {
 }
 
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 fn sse_body(events: &[&str]) -> String {
@@ -92,7 +92,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -481,7 +481,7 @@ async fn do_generate_returns_text() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
 }
@@ -533,7 +533,7 @@ async fn do_generate_extracts_tool_call() {
             assert_eq!(tool_name, "get-weather");
             assert_eq!(input, &json!({"city": "SF"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }
@@ -590,7 +590,7 @@ async fn do_stream_returns_text() {
         Some(StreamPart::Finish { finish_reason, .. }) => {
             assert_eq!(finish_reason.unified, FinishReasonUnified::Stop);
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 

--- a/aimux-providers/tests/anthropic_aws_model_test.rs
+++ b/aimux-providers/tests/anthropic_aws_model_test.rs
@@ -74,7 +74,7 @@ async fn mock_messages_sse(server: &MockServer, sse_body: &str) {
 }
 
 fn sse(data: &Value) -> String {
-    format!("data: {}\n\n", data)
+    format!("data: {data}\n\n")
 }
 
 fn sse_stream(events: &[Value]) -> String {
@@ -84,7 +84,7 @@ fn sse_stream(events: &[Value]) -> String {
 fn as_text(item: &GenerateContent) -> &str {
     match item {
         GenerateContent::Text { text, .. } => text,
-        _ => panic!("expected Text content, got {:?}", item),
+        _ => panic!("expected Text content, got {item:?}"),
     }
 }
 
@@ -96,7 +96,7 @@ fn as_tool_call(item: &GenerateContent) -> (&str, &str, &Value) {
             input,
             ..
         } => (tool_call_id, tool_name, input),
-        _ => panic!("expected ToolCall content, got {:?}", item),
+        _ => panic!("expected ToolCall content, got {item:?}"),
     }
 }
 
@@ -106,7 +106,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts

--- a/aimux-providers/tests/anthropic_convert_full_test.rs
+++ b/aimux-providers/tests/anthropic_convert_full_test.rs
@@ -54,15 +54,14 @@ fn assert_other_warning(warnings: &[Warning], message: &str) {
     });
     assert!(
         found,
-        "expected a Warning::Other with message {:?}, got {:?}",
-        message, warnings
+        "expected a Warning::Other with message {message:?}, got {warnings:?}"
     );
 }
 
 fn reasoning_part(text: &str, signature: Option<&str>) -> ContentPart {
     ContentPart::Reasoning {
         text: text.to_string(),
-        signature: signature.map(|s| s.to_string()),
+        signature: signature.map(std::string::ToString::to_string),
         provider_options: None,
     }
 }

--- a/aimux-providers/tests/anthropic_convert_test.rs
+++ b/aimux-providers/tests/anthropic_convert_test.rs
@@ -337,12 +337,11 @@ mod prepare_tools_tests {
             Warning::Unsupported { feature, details } => {
                 assert_eq!(feature, "strict");
                 let expected = format!(
-                    "Tool '{}' has strict: {}, but strict mode is not supported by this provider. The strict property will be ignored.",
-                    tool_name, strict_val
+                    "Tool '{tool_name}' has strict: {strict_val}, but strict mode is not supported by this provider. The strict property will be ignored."
                 );
                 assert_eq!(details.as_ref().unwrap(), &expected);
             }
-            other => panic!("expected Unsupported warning, got {:?}", other),
+            other => panic!("expected Unsupported warning, got {other:?}"),
         }
     }
 

--- a/aimux-providers/tests/anthropic_model_test.rs
+++ b/aimux-providers/tests/anthropic_model_test.rs
@@ -88,7 +88,7 @@ async fn mock_sse(server: &MockServer, sse_body: &str) {
 
 /// Format a single Anthropic SSE event as `data: {json}\n\n`.
 fn sse(data: &Value) -> String {
-    format!("data: {}\n\n", data)
+    format!("data: {data}\n\n")
 }
 
 /// Concatenate an ordered list of SSE events into one response body.
@@ -103,7 +103,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -127,7 +127,7 @@ fn text_response(text: &str) -> Value {
 fn as_text(item: &GenerateContent) -> &str {
     match item {
         GenerateContent::Text { text, .. } => text,
-        _ => panic!("expected Text content, got {:?}", item),
+        _ => panic!("expected Text content, got {item:?}"),
     }
 }
 
@@ -140,7 +140,7 @@ fn as_tool_call(item: &GenerateContent) -> (&str, &str, &Value) {
             input,
             ..
         } => (tool_call_id, tool_name, input),
-        _ => panic!("expected ToolCall content, got {:?}", item),
+        _ => panic!("expected ToolCall content, got {item:?}"),
     }
 }
 
@@ -831,7 +831,7 @@ mod do_stream {
 
         // Expected sequence: StreamStart, ResponseMetadata, TextStart,
         // TextDelta("Hello"), TextDelta("!"), TextEnd, Finish.
-        assert_eq!(parts.len(), 7, "parts = {:?}", parts);
+        assert_eq!(parts.len(), 7, "parts = {parts:?}");
 
         assert!(matches!(
             &parts[0],
@@ -842,36 +842,36 @@ mod do_stream {
                 assert_eq!(id.as_deref(), Some("msg_1"));
                 assert_eq!(model_id.as_deref(), Some("claude-3-haiku-20240307"));
             }
-            other => panic!("expected ResponseMetadata, got {:?}", other),
+            other => panic!("expected ResponseMetadata, got {other:?}"),
         }
         match &parts[2] {
             StreamPart::TextStart { id, .. } => assert_eq!(id, "0"),
-            other => panic!("expected TextStart, got {:?}", other),
+            other => panic!("expected TextStart, got {other:?}"),
         }
         match &parts[3] {
             StreamPart::TextDelta { id, delta, .. } => {
                 assert_eq!(id, "0");
                 assert_eq!(delta, "Hello");
             }
-            other => panic!("expected TextDelta Hello, got {:?}", other),
+            other => panic!("expected TextDelta Hello, got {other:?}"),
         }
         match &parts[4] {
             StreamPart::TextDelta { id, delta, .. } => {
                 assert_eq!(id, "0");
                 assert_eq!(delta, "!");
             }
-            other => panic!("expected TextDelta !, got {:?}", other),
+            other => panic!("expected TextDelta !, got {other:?}"),
         }
         match &parts[5] {
             StreamPart::TextEnd { id, .. } => assert_eq!(id, "0"),
-            other => panic!("expected TextEnd, got {:?}", other),
+            other => panic!("expected TextEnd, got {other:?}"),
         }
         match &parts[6] {
             StreamPart::Finish { finish_reason, .. } => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::Stop);
                 assert_eq!(finish_reason.raw.as_deref(), Some("end_turn"));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1093,7 +1093,10 @@ mod do_stream {
             .collect();
         assert_eq!(
             tool_deltas,
-            frags.iter().map(|s| s.to_string()).collect::<Vec<_>>()
+            frags
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<_>>()
         );
 
         // ToolInputStart.
@@ -1179,8 +1182,7 @@ mod do_stream {
             !parts
                 .iter()
                 .any(|p| matches!(p, StreamPart::ToolInputDelta { .. })),
-            "no tool-input-delta expected, parts = {:?}",
-            parts
+            "no tool-input-delta expected, parts = {parts:?}"
         );
 
         let tool_call = parts
@@ -1486,7 +1488,7 @@ mod do_stream {
         match &parts[error_idx] {
             StreamPart::Error { error } => {
                 let msg = error.to_string();
-                assert!(msg.contains("Overloaded"), "msg = {}", msg);
+                assert!(msg.contains("Overloaded"), "msg = {msg}");
             }
             _ => unreachable!(),
         }

--- a/aimux-providers/tests/anthropic_prepare_tools_test.rs
+++ b/aimux-providers/tests/anthropic_prepare_tools_test.rs
@@ -31,8 +31,7 @@ fn assert_unsupported_warning(warnings: &[Warning], feature: &str) {
     });
     assert!(
         found,
-        "expected Unsupported warning for {:?}, got {:?}",
-        feature, warnings
+        "expected Unsupported warning for {feature:?}, got {warnings:?}"
     );
 }
 

--- a/aimux-providers/tests/anthropic_remaining_test.rs
+++ b/aimux-providers/tests/anthropic_remaining_test.rs
@@ -212,10 +212,7 @@ async fn rejects_empty_base_url_option() {
         Err(AiMuxError::InvalidArgument(msg)) => {
             assert_eq!(msg, "baseURL must be a non-empty string.");
         }
-        other => panic!(
-            "expected InvalidArgument for empty baseURL, got {:?}",
-            other
-        ),
+        other => panic!("expected InvalidArgument for empty baseURL, got {other:?}"),
     }
 }
 
@@ -273,10 +270,9 @@ fn throws_when_both_api_key_and_auth_token_provided() {
                  Please use only one authentication method."
             );
         }
-        other => panic!(
-            "expected InvalidArgument for conflicting apiKey + authToken, got {:?}",
-            other
-        ),
+        other => {
+            panic!("expected InvalidArgument for conflicting apiKey + authToken, got {other:?}")
+        }
     }
 }
 
@@ -370,7 +366,7 @@ async fn warns_when_using_default_max_output_token_limit() {
                 )
             );
         }
-        other => panic!("expected Compatibility warning, got {:?}", other),
+        other => panic!("expected Compatibility warning, got {other:?}"),
     }
 }
 
@@ -428,7 +424,7 @@ async fn uses_current_gen_default_and_warns_for_unknown_claude_model() {
                 )
             );
         }
-        other => panic!("expected Compatibility warning, got {:?}", other),
+        other => panic!("expected Compatibility warning, got {other:?}"),
     }
 }
 
@@ -663,8 +659,7 @@ async fn sends_tool_change_blocks_and_beta_header() {
                 })
                 .unwrap_or(false)
         }),
-        "expected a system tool_removal block, got body: {}",
-        body
+        "expected a system tool_removal block, got body: {body}"
     );
 
     // The beta header should advertise mid-conversation tool changes.
@@ -675,7 +670,6 @@ async fn sends_tool_change_blocks_and_beta_header() {
         .unwrap_or("");
     assert!(
         beta.contains("mid-conversation-tool-changes-2026-07-01"),
-        "missing beta header, got: {}",
-        beta
+        "missing beta header, got: {beta}"
     );
 }

--- a/aimux-providers/tests/aws_polly_test.rs
+++ b/aimux-providers/tests/aws_polly_test.rs
@@ -42,7 +42,7 @@ async fn mock_audio_response(server: &MockServer, format: &str) {
         .and(path("/v1/speech"))
         .respond_with(
             ResponseTemplate::new(200)
-                .insert_header("content-type", format!("audio/{}", format))
+                .insert_header("content-type", format!("audio/{format}"))
                 .set_body_bytes(mock_audio_bytes()),
         )
         .mount(server)
@@ -138,8 +138,7 @@ async fn model_id_maps_to_engine() {
         let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
         assert_eq!(
             body["Engine"], expected_engine,
-            "model id {} should map to engine {}",
-            model_id, expected_engine
+            "model id {model_id} should map to engine {expected_engine}"
         );
     }
 }
@@ -167,14 +166,12 @@ async fn request_carries_sigv4_authorization_header() {
     let auth_str = auth.to_str().unwrap();
     assert!(
         auth_str.starts_with("AWS4-HMAC-SHA256 "),
-        "expected SigV4 Authorization header, got: {}",
-        auth_str
+        "expected SigV4 Authorization header, got: {auth_str}"
     );
     // The credential scope must reference the polly service.
     assert!(
         auth_str.contains("/polly/aws4_request"),
-        "expected polly service in credential scope, got: {}",
-        auth_str
+        "expected polly service in credential scope, got: {auth_str}"
     );
 }
 
@@ -361,11 +358,10 @@ async fn error_401_maps_to_auth_error() {
 
     assert!(
         matches!(err, ref e if e.status_code() == Some(401)),
-        "expected Auth error for 401, got: {:?}",
-        err
+        "expected Auth error for 401, got: {err:?}"
     );
     // The error must not leak the secret key.
-    let err_str = format!("{:?}", err);
+    let err_str = format!("{err:?}");
     assert!(
         !err_str.contains(TEST_SECRET_KEY),
         "error must not leak the secret key"
@@ -394,8 +390,7 @@ async fn error_403_keeps_the_observed_status() {
 
     assert!(
         matches!(err, ref e if e.status_code() == Some(403)),
-        "expected a 403 provider error, got: {:?}",
-        err
+        "expected a 403 provider error, got: {err:?}"
     );
 }
 
@@ -422,8 +417,7 @@ async fn error_404_maps_to_model_not_found() {
 
     assert!(
         matches!(err, ref e if e.status_code() == Some(404)),
-        "expected ModelNotFound error for 404, got: {:?}",
-        err
+        "expected ModelNotFound error for 404, got: {err:?}"
     );
 }
 

--- a/aimux-providers/tests/azure_model_test.rs
+++ b/aimux-providers/tests/azure_model_test.rs
@@ -114,7 +114,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -149,7 +149,7 @@ struct CountingToken {
 impl TokenProvider for CountingToken {
     async fn get_token(&self) -> Result<String, AiMuxError> {
         let n = self.count.fetch_add(1, Ordering::SeqCst) + 1;
-        Ok(format!("token-{}", n))
+        Ok(format!("token-{n}"))
     }
 }
 
@@ -437,7 +437,7 @@ async fn should_extract_text_response() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     // Finish reason + response metadata.
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
@@ -676,7 +676,7 @@ async fn should_extract_tool_call() {
             assert_eq!(tool_name, "get-weather");
             assert_eq!(input, &json!({"city": "SF"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }

--- a/aimux-providers/tests/azure_responses_test.rs
+++ b/aimux-providers/tests/azure_responses_test.rs
@@ -181,7 +181,7 @@ fn sse_body(events: &[&str]) -> String {
 
 /// Build an SSE event string from a JSON string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Collect all `StreamPart`s from a `StreamResult` into a `Vec`.
@@ -191,7 +191,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -235,7 +235,7 @@ struct CountingToken {
 impl TokenProvider for CountingToken {
     async fn get_token(&self) -> Result<String, AiMuxError> {
         let n = self.count.fetch_add(1, Ordering::SeqCst) + 1;
-        Ok(format!("token-{}", n))
+        Ok(format!("token-{n}"))
     }
 }
 
@@ -468,8 +468,7 @@ async fn should_pass_custom_headers() {
         .unwrap_or("");
     assert!(
         ua.contains("ai-sdk/azure"),
-        "user-agent should contain ai-sdk/azure, got: {}",
-        ua
+        "user-agent should contain ai-sdk/azure, got: {ua}"
     );
 }
 
@@ -678,7 +677,7 @@ async fn should_extract_response_headers() {
 
     let headers = result.response_headers.expect("response_headers");
     assert_eq!(
-        headers.get("test-header").map(|s| s.as_str()),
+        headers.get("test-header").map(std::string::String::as_str),
         Some("test-value")
     );
 }
@@ -975,8 +974,7 @@ async fn should_handle_error_status() {
     let msg = err.to_string().to_lowercase();
     assert!(
         msg.contains("rate limit"),
-        "error should mention rate limit, got: {}",
-        err
+        "error should mention rate limit, got: {err}"
     );
 }
 

--- a/aimux-providers/tests/bedrock_convert_test.rs
+++ b/aimux-providers/tests/bedrock_convert_test.rs
@@ -77,7 +77,7 @@ fn file_base64(
     ContentPart::FileBase64 {
         data: data.to_string(),
         media_type: media_type.to_string(),
-        filename: filename.map(|s| s.to_string()),
+        filename: filename.map(std::string::ToString::to_string),
         provider_options,
     }
 }
@@ -97,7 +97,7 @@ fn text_with_cache(text: &str, cache_type: &str, ttl: Option<&str>) -> ContentPa
 fn reasoning(text: &str, signature: Option<&str>) -> ContentPart {
     ContentPart::Reasoning {
         text: text.to_string(),
-        signature: signature.map(|s| s.to_string()),
+        signature: signature.map(std::string::ToString::to_string),
         provider_options: None,
     }
 }
@@ -953,7 +953,7 @@ fn media_type_route_to_document_text_plain() {
 fn func_tool(name: &str, description: Option<&str>, input_schema: Value) -> FunctionTool {
     FunctionTool {
         name: name.to_string(),
-        description: description.map(|s| s.to_string()),
+        description: description.map(std::string::ToString::to_string),
         input_schema,
         strict: None,
         provider_options: None,
@@ -969,7 +969,7 @@ fn func_tool_strict(
 ) -> FunctionTool {
     FunctionTool {
         name: name.to_string(),
-        description: description.map(|s| s.to_string()),
+        description: description.map(std::string::ToString::to_string),
         input_schema,
         strict,
         provider_options: None,

--- a/aimux-providers/tests/bedrock_embedding_test.rs
+++ b/aimux-providers/tests/bedrock_embedding_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK Amazon Bedrock embedding model tests.
+//! Rust translations of the AI SDK Amazon Bedrock embedding model tests.
 //!
 //! Source: `reference/ai/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts`
 //! (536 lines, 12 cases).
@@ -204,7 +204,10 @@ async fn should_send_multiple_values_cohere_v4() {
 
     let result = model
         .do_embed(&default_options(
-            TEST_VALUES.iter().map(|s| s.to_string()).collect(),
+            TEST_VALUES
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
         ))
         .await
         .expect("should succeed");

--- a/aimux-providers/tests/bedrock_model_test.rs
+++ b/aimux-providers/tests/bedrock_model_test.rs
@@ -61,7 +61,7 @@ async fn mock_converse_json(server: &MockServer, status: u16, body: Value) {
 fn as_text(item: &GenerateContent) -> &str {
     match item {
         GenerateContent::Text { text, .. } => text,
-        _ => panic!("expected Text content, got {:?}", item),
+        _ => panic!("expected Text content, got {item:?}"),
     }
 }
 
@@ -73,7 +73,7 @@ fn as_tool_call(item: &GenerateContent) -> (&str, &str, &Value) {
             input,
             ..
         } => (tool_call_id, tool_name, input),
-        _ => panic!("expected ToolCall content, got {:?}", item),
+        _ => panic!("expected ToolCall content, got {item:?}"),
     }
 }
 
@@ -83,7 +83,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -202,8 +202,7 @@ async fn bedrock_generate_error_status() {
     let err = result.unwrap_err().to_string();
     assert!(
         err.contains("invalid") || err.contains("ValidationException") || err.contains("model ID"),
-        "error should contain the error message, got: {}",
-        err
+        "error should contain the error message, got: {err}"
     );
 }
 
@@ -245,8 +244,7 @@ async fn bedrock_generate_request_body() {
     let temp = body["inferenceConfig"]["temperature"].as_f64().unwrap();
     assert!(
         (temp - 0.7).abs() < 0.001,
-        "temperature should be ~0.7, got {}",
-        temp
+        "temperature should be ~0.7, got {temp}"
     );
 }
 

--- a/aimux-providers/tests/bedrock_reasoning_test.rs
+++ b/aimux-providers/tests/bedrock_reasoning_test.rs
@@ -162,7 +162,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -171,7 +171,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
 fn as_text(item: &GenerateContent) -> &str {
     match item {
         GenerateContent::Text { text, .. } => text,
-        _ => panic!("expected Text content, got {:?}", item),
+        _ => panic!("expected Text content, got {item:?}"),
     }
 }
 
@@ -181,7 +181,7 @@ fn as_reasoning(item: &GenerateContent) -> (&str, &Option<Value>) {
             text,
             provider_metadata,
         } => (text.as_str(), provider_metadata),
-        _ => panic!("expected Reasoning content, got {:?}", item),
+        _ => panic!("expected Reasoning content, got {item:?}"),
     }
 }
 
@@ -242,7 +242,7 @@ fn tool_msg(content: Vec<ContentPart>) -> LanguageModelPromptMessage {
 fn reasoning(text: &str, signature: Option<&str>) -> ContentPart {
     ContentPart::Reasoning {
         text: text.to_string(),
-        signature: signature.map(|s| s.to_string()),
+        signature: signature.map(std::string::ToString::to_string),
         provider_options: None,
     }
 }

--- a/aimux-providers/tests/bedrock_remaining_test.rs
+++ b/aimux-providers/tests/bedrock_remaining_test.rs
@@ -93,7 +93,7 @@ fn ok_converse_body() -> Value {
 fn as_text(item: &GenerateContent) -> &str {
     match item {
         GenerateContent::Text { text, .. } => text,
-        _ => panic!("expected Text content, got {:?}", item),
+        _ => panic!("expected Text content, got {item:?}"),
     }
 }
 
@@ -105,7 +105,7 @@ fn as_tool_call(item: &GenerateContent) -> (&str, &str, &Value) {
             input,
             ..
         } => (tool_call_id, tool_name, input),
-        _ => panic!("expected ToolCall content, got {:?}", item),
+        _ => panic!("expected ToolCall content, got {item:?}"),
     }
 }
 
@@ -115,7 +115,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -574,7 +574,7 @@ async fn arn_model_id_encoded_generate_route() {
     let arn = "arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0";
     let encoded =
         percent_encoding::utf8_percent_encode(arn, percent_encoding::NON_ALPHANUMERIC).to_string();
-    let encoded_path = format!("/model/{}/converse", encoded);
+    let encoded_path = format!("/model/{encoded}/converse");
 
     Mock::given(method("POST"))
         .and(path(&encoded_path))
@@ -611,7 +611,7 @@ async fn arn_model_id_encoded_stream_route() {
     let arn = "arn:aws:bedrock:eu-west-1:474668406012:inference-profile/eu.amazon.nova-lite-v1:0";
     let encoded =
         percent_encoding::utf8_percent_encode(arn, percent_encoding::NON_ALPHANUMERIC).to_string();
-    let encoded_path = format!("/model/{}/converse-stream", encoded);
+    let encoded_path = format!("/model/{encoded}/converse-stream");
 
     let events: Vec<(&str, &str, &str)> = vec![
         ("event", "messageStart", r#"{"role":"assistant"}"#),
@@ -764,8 +764,7 @@ async fn temperature_not_clamped_in_range() {
     let temp = body["inferenceConfig"]["temperature"].as_f64().unwrap();
     assert!(
         (temp - 0.7).abs() < 1e-6,
-        "temperature should be 0.7, got {}",
-        temp
+        "temperature should be 0.7, got {temp}"
     );
     assert!(result.warnings.is_empty(), "no warnings expected");
 }

--- a/aimux-providers/tests/cartesia_speech_test.rs
+++ b/aimux-providers/tests/cartesia_speech_test.rs
@@ -27,7 +27,7 @@ async fn mock_audio_response(server: &MockServer, format: &str) {
         .and(path("/tts/bytes"))
         .respond_with(
             ResponseTemplate::new(200)
-                .insert_header("content-type", format!("audio/{}", format))
+                .insert_header("content-type", format!("audio/{format}"))
                 .set_body_bytes(mock_audio_bytes()),
         )
         .mount(server)
@@ -40,7 +40,7 @@ async fn mock_audio_response_with_headers(
     headers: &[(&str, &str)],
 ) {
     let mut template = ResponseTemplate::new(200)
-        .insert_header("content-type", format!("audio/{}", format))
+        .insert_header("content-type", format!("audio/{format}"))
         .set_body_bytes(mock_audio_bytes());
     for (k, v) in headers {
         template = template.insert_header(*k, *v);
@@ -110,8 +110,7 @@ async fn should_throw_when_no_voice_is_provided() {
     let err = result.unwrap_err();
     assert!(
         err.to_string().contains("require a `voice`"),
-        "expected voice-required error, got {}",
-        err
+        "expected voice-required error, got {err}"
     );
 }
 
@@ -242,7 +241,7 @@ async fn should_warn_and_ignore_an_out_of_range_generic_speed() {
             assert_eq!(feature, "speed");
             assert!(details.as_ref().unwrap().contains("between 0.6 and 1.5"));
         }
-        other => panic!("expected Unsupported warning, got {:?}", other),
+        other => panic!("expected Unsupported warning, got {other:?}"),
     }
 }
 
@@ -273,7 +272,7 @@ async fn should_warn_about_unsupported_instructions_parameter() {
                     .contains("do not support instructions")
             );
         }
-        other => panic!("expected Unsupported warning, got {:?}", other),
+        other => panic!("expected Unsupported warning, got {other:?}"),
     }
 }
 
@@ -351,7 +350,7 @@ async fn should_ignore_encoding_for_mp3_output() {
         Warning::Unsupported { feature, .. } => {
             assert_eq!(feature, "providerOptions.cartesia.encoding");
         }
-        other => panic!("expected Unsupported warning, got {:?}", other),
+        other => panic!("expected Unsupported warning, got {other:?}"),
     }
 }
 
@@ -381,7 +380,7 @@ async fn should_warn_about_an_unsupported_sample_rate_suffix() {
             assert_eq!(feature, "outputFormat");
             assert!(details.as_ref().unwrap().contains("wav_12345"));
         }
-        other => panic!("expected Unsupported warning, got {:?}", other),
+        other => panic!("expected Unsupported warning, got {other:?}"),
     }
 }
 

--- a/aimux-providers/tests/cassette_exhaustive_test.rs
+++ b/aimux-providers/tests/cassette_exhaustive_test.rs
@@ -77,7 +77,7 @@ fn load_all_cassettes() -> Vec<Cassette> {
             let req_body = req["body"].clone();
             let is_stream = req_body
                 .get("stream")
-                .and_then(|v| v.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false);
 
             let file_name = file_path.file_name().unwrap().to_string_lossy().to_string();

--- a/aimux-providers/tests/codex_test.rs
+++ b/aimux-providers/tests/codex_test.rs
@@ -57,7 +57,7 @@ fn weather_tool() -> FunctionTool {
 }
 
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 fn sse_body(events: &[&str]) -> String {
@@ -105,7 +105,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -199,7 +199,7 @@ async fn api_key_generates_text() {
         aimux_core::result::GenerateContent::Text { text, .. } => {
             assert_eq!(text, "answer text")
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(model.provider(), "codex");
     assert_eq!(model.model_id(), "gpt-5.2-codex");
@@ -237,15 +237,15 @@ async fn api_key_streams_text() {
     ));
     match &parts[2] {
         StreamPart::TextStart { id, .. } => assert_eq!(id, "msg_1"),
-        other => panic!("expected TextStart, got {:?}", other),
+        other => panic!("expected TextStart, got {other:?}"),
     }
     match &parts[3] {
         StreamPart::TextDelta { delta, .. } => assert_eq!(delta, "Hello,"),
-        other => panic!("expected TextDelta, got {:?}", other),
+        other => panic!("expected TextDelta, got {other:?}"),
     }
     match &parts[6] {
         StreamPart::Finish { usage, .. } => assert_eq!(usage.input_tokens.total, Some(543)),
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 
@@ -277,13 +277,13 @@ async fn api_key_streams_tool_calls() {
             assert_eq!(tool_name, "weather");
             assert_eq!(input["location"], "Rome");
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     match &parts[7] {
         StreamPart::Finish { finish_reason, .. } => {
             assert_eq!(finish_reason.unified, FinishReasonUnified::ToolCalls);
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 
@@ -316,7 +316,7 @@ async fn subscription_generate_forces_stream_and_assembles_result() {
         aimux_core::result::GenerateContent::Text { text, .. } => {
             assert_eq!(text, "answer text")
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
 
     // The request must be a *streaming* request with store disabled.

--- a/aimux-providers/tests/cohere_embedding_test.rs
+++ b/aimux-providers/tests/cohere_embedding_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK Cohere embedding model tests.
+//! Rust translations of the AI SDK Cohere embedding model tests.
 //!
 //! Source: `reference/ai/packages/cohere/src/cohere-embedding-model.test.ts`
 //! (185 lines, 6 cases).
@@ -31,7 +31,10 @@ fn embedding_response_body() -> Value {
 }
 
 fn test_values() -> Vec<String> {
-    TEST_VALUES.iter().map(|s| s.to_string()).collect()
+    TEST_VALUES
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect()
 }
 
 fn default_options(values: Vec<String>) -> EmbeddingCallOptions {
@@ -106,7 +109,7 @@ async fn should_expose_raw_response() {
         .and_then(|r| r.headers.as_ref())
         .expect("headers present");
     assert_eq!(
-        headers.get("test-header").map(|s| s.as_str()),
+        headers.get("test-header").map(std::string::String::as_str),
         Some("test-value")
     );
 }

--- a/aimux-providers/tests/cohere_model_test.rs
+++ b/aimux-providers/tests/cohere_model_test.rs
@@ -89,9 +89,9 @@ fn cohere_event(json_str: &str) -> String {
             .get("type")
             .and_then(|t| t.as_str())
             .unwrap_or("message");
-        format!("event: {}\ndata: {}\n\n", event_type, json_str)
+        format!("event: {event_type}\ndata: {json_str}\n\n")
     } else {
-        format!("event: unknown\ndata: {}\n\n", json_str)
+        format!("event: unknown\ndata: {json_str}\n\n")
     }
 }
 
@@ -110,7 +110,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -167,7 +167,7 @@ async fn should_extract_text_response() {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "The capital of France is Paris.");
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
     assert_eq!(result.finish_reason.raw.as_deref(), Some("COMPLETE"));
@@ -265,7 +265,7 @@ async fn should_extract_tool_calls() {
             assert_eq!(tool_name, "weather");
             assert_eq!(input, &json!({"location": "San Francisco"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::ToolCall {
@@ -274,7 +274,7 @@ async fn should_extract_tool_calls() {
             assert_eq!(tool_name, "cityAttractions");
             assert_eq!(input, &json!({"city": "San Francisco"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }
@@ -322,7 +322,7 @@ async fn should_handle_null_tool_call_arguments() {
             // "null" should be replaced with "{}".
             assert_eq!(input, &json!({}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
 }
 
@@ -504,7 +504,7 @@ async fn should_stream_text_deltas() {
             assert_eq!(usage.input_tokens.total, Some(507));
             assert_eq!(usage.output_tokens.total, Some(10));
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 
@@ -565,7 +565,7 @@ async fn should_stream_tool_call_deltas() {
         StreamPart::Finish { finish_reason, .. } => {
             assert_eq!(finish_reason.unified, FinishReasonUnified::ToolCalls);
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 
@@ -1037,7 +1037,7 @@ async fn should_extract_citations_from_response() {
                  3. Cost reduction"
             );
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     for (i, c) in result.content[1..].iter().enumerate() {
         match c {
@@ -1048,12 +1048,12 @@ async fn should_extract_citations_from_response() {
                 title,
                 ..
             } => {
-                assert_eq!(id, &format!("citation-{}", i));
+                assert_eq!(id, &format!("citation-{i}"));
                 assert_eq!(source_type, "document");
                 assert_eq!(url, &None);
                 assert_eq!(title, &Some("benefits.txt".to_string()));
             }
-            other => panic!("expected Source, got {:?}", other),
+            other => panic!("expected Source, got {other:?}"),
         }
     }
 
@@ -1464,7 +1464,7 @@ async fn should_stream_empty_tool_call_arguments() {
         StreamPart::Finish { finish_reason, .. } => {
             assert_eq!(finish_reason.unified, FinishReasonUnified::ToolCalls);
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 

--- a/aimux-providers/tests/cohere_remaining_test.rs
+++ b/aimux-providers/tests/cohere_remaining_test.rs
@@ -133,7 +133,7 @@ fn prepare_tools_provider_tool_warns() {
         aimux_core::types::Warning::Unsupported { feature, .. } => {
             assert_eq!(feature, "provider-defined tool provider.tool");
         }
-        other => panic!("expected Unsupported warning, got {:?}", other),
+        other => panic!("expected Unsupported warning, got {other:?}"),
     }
 }
 
@@ -593,13 +593,13 @@ async fn should_extract_reasoning_from_response() {
                 "Okay, so I need to figure out what 2 + 2 is. Let me start by recalling what addition means."
             );
         }
-        other => panic!("expected Reasoning, got {:?}", other),
+        other => panic!("expected Reasoning, got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "2 + 2 = 4");
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
 }

--- a/aimux-providers/tests/common/replay.rs
+++ b/aimux-providers/tests/common/replay.rs
@@ -1,4 +1,4 @@
-﻿//! Cassette replay infrastructure for offline provider tests.
+//! Cassette replay infrastructure for offline provider tests.
 //!
 //! Loads JSON cassette files (see RFC 0003) describing recorded HTTP exchanges
 //! and mounts them onto a [`wiremock`] `MockServer`. A provider under test is
@@ -221,7 +221,7 @@ fn load_cassettes(dir: &Path) -> Vec<Cassette> {
     };
 
     let mut files: Vec<_> = entries
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .map(|e| e.path())
         .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("json"))
         .collect();
@@ -233,29 +233,29 @@ fn load_cassettes(dir: &Path) -> Vec<Cassette> {
 
         let text = match fs::read_to_string(&f) {
             Ok(t) => t,
-            Err(e) => panic!("replay: cannot read {}: {}", label, e),
+            Err(e) => panic!("replay: cannot read {label}: {e}"),
         };
         let v: Value = match serde_json::from_str(&text) {
             Ok(v) => v,
-            Err(e) => panic!("replay: invalid JSON in {}: {}", label, e),
+            Err(e) => panic!("replay: invalid JSON in {label}: {e}"),
         };
 
         let req = v
             .get("request")
-            .unwrap_or_else(|| panic!("replay: {} missing `request` object", label));
+            .unwrap_or_else(|| panic!("replay: {label} missing `request` object"));
         let resp = v
             .get("response")
-            .unwrap_or_else(|| panic!("replay: {} missing `response` object", label));
+            .unwrap_or_else(|| panic!("replay: {label} missing `response` object"));
 
         let method = req
             .get("method")
             .and_then(|m| m.as_str())
-            .unwrap_or_else(|| panic!("replay: {} missing `request.method`", label))
+            .unwrap_or_else(|| panic!("replay: {label} missing `request.method`"))
             .to_ascii_uppercase();
         let req_path = req
             .get("path")
             .and_then(|p| p.as_str())
-            .unwrap_or_else(|| panic!("replay: {} missing `request.path`", label))
+            .unwrap_or_else(|| panic!("replay: {label} missing `request.path`"))
             // Percent-decode the recorded path so it matches the path the HTTP
             // client actually sends. Cassettes sourced from rig record paths
             // verbatim from the wire, where characters like `:` in Bedrock model
@@ -266,18 +266,17 @@ fn load_cassettes(dir: &Path) -> Vec<Cassette> {
         let req_path = percent_decode(&req_path);
         let status = resp
             .get("status")
-            .and_then(|s| s.as_u64())
-            .unwrap_or_else(|| panic!("replay: {} missing numeric `response.status`", label))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_else(|| panic!("replay: {label} missing numeric `response.status`"))
             as u16;
         let req_body = req.get("body").cloned().unwrap_or(Value::Null);
 
         let body_str = match resp.get("body") {
             None => "",
             Some(Value::String(s)) => s.as_str(),
-            Some(other) => panic!(
-                "replay: {} `response.body` must be a raw string, got {}",
-                label, other
-            ),
+            Some(other) => {
+                panic!("replay: {label} `response.body` must be a raw string, got {other}")
+            }
         };
 
         // `set_body_bytes` sets the body without forcing a content-type, so the

--- a/aimux-providers/tests/conformance_test.rs
+++ b/aimux-providers/tests/conformance_test.rs
@@ -52,7 +52,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -148,8 +148,7 @@ mod anthropic_conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }
@@ -183,8 +182,7 @@ mod anthropic_conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }
@@ -230,8 +228,7 @@ mod openai_conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }
@@ -262,8 +259,7 @@ mod openai_conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }
@@ -312,7 +308,7 @@ mod deepseek_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -355,7 +351,7 @@ mod xai_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -405,7 +401,7 @@ mod groq_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -448,7 +444,7 @@ mod mistral_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -496,7 +492,7 @@ mod perplexity_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -538,7 +534,7 @@ mod gemini_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -566,7 +562,7 @@ mod gemini_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -609,7 +605,7 @@ mod openrouter_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -660,7 +656,7 @@ mod copilot_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -711,7 +707,7 @@ mod doubleword_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -755,7 +751,7 @@ mod llamafile_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -799,7 +795,7 @@ mod mistralrs_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -843,7 +839,7 @@ mod bedrock_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -871,7 +867,7 @@ mod bedrock_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -921,7 +917,7 @@ mod cerebras_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -964,7 +960,7 @@ mod cohere_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -1009,7 +1005,7 @@ mod huggingface_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -1059,7 +1055,7 @@ mod zai_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -1086,7 +1082,7 @@ mod zai_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -1131,7 +1127,7 @@ mod ollama_conformance {
                     panic!("request did not match any cassette (404): {e:?}");
                 }
                 let msg = e.to_string();
-                assert!(!msg.contains("panic"), "unexpected error: {}", msg);
+                assert!(!msg.contains("panic"), "unexpected error: {msg}");
             }
         }
     }
@@ -1177,8 +1173,7 @@ mod chatgpt_conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }
@@ -1209,8 +1204,7 @@ mod chatgpt_conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }

--- a/aimux-providers/tests/dataforseo_test.rs
+++ b/aimux-providers/tests/dataforseo_test.rs
@@ -82,9 +82,9 @@ async fn mount_search_mock(server: &MockServer) {
 
 /// The expected `Authorization: Basic …` header value for the test credentials.
 fn expected_basic_auth() -> String {
-    let credentials = format!("{}:{}", LOGIN, PASSWORD);
+    let credentials = format!("{LOGIN}:{PASSWORD}");
     let encoded = base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes());
-    format!("Basic {}", encoded)
+    format!("Basic {encoded}")
 }
 
 // -- result mapping ----------------------------------------------------------

--- a/aimux-providers/tests/deepseek_chat_test.rs
+++ b/aimux-providers/tests/deepseek_chat_test.rs
@@ -110,7 +110,7 @@ async fn mock_sse(server: &MockServer, body: String) {
 
 /// Build a single SSE `data: <json>\n\n` event string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append the `[DONE]` sentinel.
@@ -130,7 +130,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -324,10 +324,9 @@ async fn should_extract_text_content() {
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert!(
             text.contains("Gratitude of Small Things Day"),
-            "expected the fixture text, got: {}",
-            text
+            "expected the fixture text, got: {text}"
         ),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Length);
     assert_eq!(result.finish_reason.raw.as_deref(), Some("length"));
@@ -420,7 +419,7 @@ async fn should_extract_tool_call_content() {
             assert_eq!(tool_name, "weather");
             assert_eq!(input, &json!({ "location": "San Francisco" }));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }
@@ -548,10 +547,9 @@ async fn should_extract_json_response_text_content() {
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert!(
             text.contains("San Francisco"),
-            "expected JSON content with 'San Francisco', got: {}",
-            text
+            "expected JSON content with 'San Francisco', got: {text}"
         ),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
 }
@@ -674,7 +672,7 @@ async fn should_stream_text() {
         Some(StreamPart::Finish { finish_reason, .. }) => {
             assert_eq!(finish_reason.unified, FinishReasonUnified::Stop);
         }
-        other => panic!("expected Finish as last part, got {:?}", other),
+        other => panic!("expected Finish as last part, got {other:?}"),
     }
 }
 
@@ -763,7 +761,7 @@ async fn should_stream_tool_call() {
         Some(StreamPart::Finish { finish_reason, .. }) => {
             assert_eq!(finish_reason.unified, FinishReasonUnified::ToolCalls);
         }
-        other => panic!("expected Finish as last part, got {:?}", other),
+        other => panic!("expected Finish as last part, got {other:?}"),
     }
 }
 
@@ -829,13 +827,11 @@ async fn should_convert_image_file_parts_to_image_url() {
     let messages_str = result.body["messages"].to_string();
     assert!(
         messages_str.contains("image_url"),
-        "messages should contain image_url: {}",
-        messages_str
+        "messages should contain image_url: {messages_str}"
     );
     assert!(
         messages_str.contains("data:image/png;base64,AAECAw=="),
-        "messages should contain base64 data URL: {}",
-        messages_str
+        "messages should contain base64 data URL: {messages_str}"
     );
 }
 
@@ -869,8 +865,7 @@ async fn should_accept_top_level_only_mediatype_without_error() {
     let messages_str = result.body["messages"].to_string();
     assert!(
         messages_str.contains("image_url"),
-        "messages should contain image_url for top-level image media type: {}",
-        messages_str
+        "messages should contain image_url for top-level image media type: {messages_str}"
     );
 }
 

--- a/aimux-providers/tests/deepseek_reasoning_test.rs
+++ b/aimux-providers/tests/deepseek_reasoning_test.rs
@@ -129,7 +129,7 @@ async fn mock_sse(server: &MockServer, body: String) {
 
 /// Build a single SSE `data: <json>\n\n` event string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append the `[DONE]` sentinel.
@@ -149,7 +149,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -249,13 +249,13 @@ async fn should_prefer_reasoning_content_over_reasoning_field_when_both_provided
     );
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Reasoning { text, .. } => {
             assert_eq!(text, "This is from reasoning_content")
         }
-        other => panic!("expected Reasoning from reasoning_content, got {:?}", other),
+        other => panic!("expected Reasoning from reasoning_content, got {other:?}"),
     }
 }
 
@@ -310,7 +310,7 @@ async fn should_extract_reasoning_from_reasoning_field_when_reasoning_content_no
     );
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-        other => panic!("expected Text only, got {:?}", other),
+        other => panic!("expected Text only, got {other:?}"),
     }
 }
 
@@ -370,18 +370,16 @@ async fn should_extract_reasoning_content_and_text_from_deepseek_reasoning_fixtu
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert!(
             text.contains("strawberry"),
-            "expected the fixture text, got: {}",
-            text
+            "expected the fixture text, got: {text}"
         ),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Reasoning { text, .. } => assert!(
             text.contains("How many"),
-            "expected the fixture reasoning_content, got: {}",
-            text
+            "expected the fixture reasoning_content, got: {text}"
         ),
-        other => panic!("expected Reasoning, got {:?}", other),
+        other => panic!("expected Reasoning, got {other:?}"),
     }
 }
 
@@ -585,8 +583,7 @@ async fn should_ignore_deepseek_provider_options_reasoning_effort() {
 
         assert!(
             body.get("reasoning_effort").is_none(),
-            "stage2-001: deepseek 特化退役,providerOptions.deepseek.reasoningEffort 被忽略,effort={} 不出现",
-            effort
+            "stage2-001: deepseek 特化退役,providerOptions.deepseek.reasoningEffort 被忽略,effort={effort} 不出现"
         );
     }
 }

--- a/aimux-providers/tests/e2e_test.rs
+++ b/aimux-providers/tests/e2e_test.rs
@@ -177,8 +177,7 @@ async fn e2e_openai_error_401() {
     let err = result.unwrap_err();
     assert!(
         matches!(err, ref e if e.status_code() == Some(401)),
-        "expected Auth error, got {:?}",
-        err
+        "expected Auth error, got {err:?}"
     );
 }
 
@@ -289,8 +288,7 @@ async fn e2e_anthropic_error_429() {
     let err = result.unwrap_err();
     assert!(
         matches!(err, ref e if e.status_code() == Some(429)),
-        "expected RateLimited error, got {:?}",
-        err
+        "expected RateLimited error, got {err:?}"
     );
 }
 
@@ -826,8 +824,7 @@ async fn e2e_openai_stream_tool_calls() {
     });
     assert!(
         has_tool_part,
-        "expected a tool-related StreamPart; got: {:?}",
-        parts
+        "expected a tool-related StreamPart; got: {parts:?}"
     );
 
     // Must contain a Finish part

--- a/aimux-providers/tests/elevenlabs_speech_test.rs
+++ b/aimux-providers/tests/elevenlabs_speech_test.rs
@@ -31,7 +31,7 @@ async fn mock_audio_response(server: &MockServer, format: &str) {
         .and(path_regex(r"^/v1/text-to-speech/.+$"))
         .respond_with(
             ResponseTemplate::new(200)
-                .insert_header("content-type", format!("audio/{}", format))
+                .insert_header("content-type", format!("audio/{format}"))
                 .set_body_bytes(mock_audio_bytes()),
         )
         .mount(server)
@@ -72,8 +72,7 @@ async fn should_generate_speech_with_required_parameters() {
     let url = &requests[0].url;
     assert!(
         url.as_str().contains("output_format=mp3_44100_128"),
-        "expected output_format=mp3_44100_128 in URL, got {}",
-        url
+        "expected output_format=mp3_44100_128 in URL, got {url}"
     );
 }
 
@@ -101,8 +100,7 @@ async fn should_handle_custom_output_format() {
     let url = &requests[0].url;
     assert!(
         url.as_str().contains("output_format=pcm_44100"),
-        "expected output_format=pcm_44100 in URL, got {}",
-        url
+        "expected output_format=pcm_44100 in URL, got {url}"
     );
 }
 
@@ -131,8 +129,7 @@ async fn should_handle_language_parameter() {
     let url = &requests[0].url;
     assert!(
         url.as_str().contains("output_format=mp3_44100_128"),
-        "expected output_format=mp3_44100_128 in URL, got {}",
-        url
+        "expected output_format=mp3_44100_128 in URL, got {url}"
     );
 }
 
@@ -186,7 +183,7 @@ async fn should_warn_about_unsupported_instructions_parameter() {
                     .contains("do not support instructions")
             );
         }
-        other => panic!("expected Unsupported warning, got {:?}", other),
+        other => panic!("expected Unsupported warning, got {other:?}"),
     }
 }
 
@@ -229,8 +226,7 @@ async fn should_pass_provider_specific_options() {
     let url = &requests[0].url;
     assert!(
         url.as_str().contains("output_format=mp3_44100_128"),
-        "expected output_format=mp3_44100_128 in URL, got {}",
-        url
+        "expected output_format=mp3_44100_128 in URL, got {url}"
     );
 }
 

--- a/aimux-providers/tests/google_embedding_test.rs
+++ b/aimux-providers/tests/google_embedding_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK Google embedding model tests.
+//! Rust translations of the AI SDK Google embedding model tests.
 //!
 //! Source: `reference/ai/packages/google/src/google-embedding-model.test.ts`
 //! (550 lines, 14 cases — text-only cases translated; multimodal `content`
@@ -30,7 +30,10 @@ fn single_response_body() -> Value {
 }
 
 fn test_values() -> Vec<String> {
-    TEST_VALUES.iter().map(|s| s.to_string()).collect()
+    TEST_VALUES
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect()
 }
 
 fn default_options(values: Vec<String>) -> EmbeddingCallOptions {
@@ -91,7 +94,7 @@ async fn should_expose_raw_response() {
         .and_then(|r| r.headers.as_ref())
         .expect("headers present");
     assert_eq!(
-        headers.get("test-header").map(|s| s.as_str()),
+        headers.get("test-header").map(std::string::String::as_str),
         Some("test-value")
     );
 }

--- a/aimux-providers/tests/google_image_test.rs
+++ b/aimux-providers/tests/google_image_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translation of the Google image model tests.
+//! Rust translation of the Google image model tests.
 //!
 //! Source: `reference/ai/packages/google/src/google-image-model.test.ts`
 //!
@@ -311,11 +311,13 @@ async fn should_include_response_data_with_timestamp_model_id_and_headers() {
     );
     let headers = result.response.headers.as_ref().unwrap();
     assert_eq!(
-        headers.get("request-id").map(|s| s.as_str()),
+        headers.get("request-id").map(std::string::String::as_str),
         Some("test-request-id")
     );
     assert_eq!(
-        headers.get("x-goog-quota-remaining").map(|s| s.as_str()),
+        headers
+            .get("x-goog-quota-remaining")
+            .map(std::string::String::as_str),
         Some("123")
     );
 }

--- a/aimux-providers/tests/google_model_test.rs
+++ b/aimux-providers/tests/google_model_test.rs
@@ -91,7 +91,7 @@ fn weather_tool() -> FunctionTool {
 /// Mock a JSON `generateContent` response.
 async fn mock_json_response(server: &MockServer, model: &str, body: Value) {
     Mock::given(method("POST"))
-        .and(path(format!("/models/{}:generateContent", model)))
+        .and(path(format!("/models/{model}:generateContent")))
         .respond_with(ResponseTemplate::new(200).set_body_json(body))
         .mount(server)
         .await;
@@ -100,7 +100,7 @@ async fn mock_json_response(server: &MockServer, model: &str, body: Value) {
 /// Mock a JSON `generateContent` response with a custom status code.
 async fn mock_json_error(server: &MockServer, model: &str, status: u16, body: Value) {
     Mock::given(method("POST"))
-        .and(path(format!("/models/{}:generateContent", model)))
+        .and(path(format!("/models/{model}:generateContent")))
         .respond_with(ResponseTemplate::new(status).set_body_json(body))
         .mount(server)
         .await;
@@ -109,7 +109,7 @@ async fn mock_json_error(server: &MockServer, model: &str, status: u16, body: Va
 /// Mock an SSE `streamGenerateContent` response.
 async fn mock_sse_response(server: &MockServer, model: &str, sse_body: &str) {
     Mock::given(method("POST"))
-        .and(path(format!("/models/{}:streamGenerateContent", model)))
+        .and(path(format!("/models/{model}:streamGenerateContent")))
         .and(query_param("alt", "sse"))
         .respond_with(
             ResponseTemplate::new(200)
@@ -122,7 +122,7 @@ async fn mock_sse_response(server: &MockServer, model: &str, sse_body: &str) {
 
 /// Build an SSE event string from a JSON value.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events (no `[DONE]` sentinel — Gemini doesn't use one).
@@ -141,7 +141,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -203,7 +203,7 @@ mod do_generate {
         assert_eq!(result.content.len(), 1);
         match &result.content[0] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
     }
 
@@ -428,7 +428,7 @@ mod do_generate {
                 assert_eq!(tool_name, "weather");
                 assert_eq!(input, &json!({ "location": "San Francisco" }));
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
         // STOP + has_tool_calls -> ToolCalls
         assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
@@ -488,7 +488,7 @@ mod do_generate {
                     Some("EuIDCt8DARFNMg/aRDRK3THWhBjzltCEy5/VM6ImWLJU8oHmnC75abdcZBMH")
                 );
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -880,7 +880,7 @@ mod do_generate {
                 assert_eq!(tool_name, "weather");
                 assert_eq!(input, &json!({ "location": "SF" }));
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
         assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
     }
@@ -927,7 +927,7 @@ mod do_generate {
                 assert_eq!(tool_call_id, "call-1");
                 assert_eq!(tool_name, "weather");
             }
-            other => panic!("expected first ToolCall, got {:?}", other),
+            other => panic!("expected first ToolCall, got {other:?}"),
         }
         match &result.content[1] {
             GenerateContent::ToolCall {
@@ -940,7 +940,7 @@ mod do_generate {
                 assert_eq!(tool_name, "calendar");
                 assert_eq!(input, &json!({ "date": "2024-01-01" }));
             }
-            other => panic!("expected second ToolCall, got {:?}", other),
+            other => panic!("expected second ToolCall, got {other:?}"),
         }
     }
 
@@ -979,11 +979,11 @@ mod do_generate {
         assert_eq!(result.content.len(), 2);
         match &result.content[0] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "Let me check the weather."),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
         match &result.content[1] {
             GenerateContent::ToolCall { tool_name, .. } => assert_eq!(tool_name, "weather"),
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1103,7 +1103,7 @@ mod do_stream {
             StreamPart::ResponseMetadata { id, .. } => {
                 assert_eq!(id.as_deref(), Some("resp-1"));
             }
-            other => panic!("expected ResponseMetadata, got {:?}", other),
+            other => panic!("expected ResponseMetadata, got {other:?}"),
         }
 
         // text-start
@@ -1128,7 +1128,7 @@ mod do_stream {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::Stop);
                 assert_eq!(finish_reason.raw.as_deref(), Some("STOP"));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1189,7 +1189,7 @@ mod do_stream {
             Some(StreamPart::Finish { finish_reason, .. }) => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::ToolCalls);
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1264,7 +1264,7 @@ mod do_stream {
                 assert_eq!(usage.input_tokens.total, Some(10));
                 assert_eq!(usage.output_tokens.total, Some(3));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1319,7 +1319,7 @@ mod do_stream {
                 assert_eq!(usage.input_tokens.total, Some(10));
                 assert_eq!(usage.output_tokens.total, Some(20));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1355,7 +1355,7 @@ mod do_stream {
             Some(StreamPart::Finish { usage, .. }) => {
                 assert_eq!(usage.input_tokens.total, Some(5));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1393,7 +1393,7 @@ mod do_stream {
                 assert_eq!(id.as_deref(), Some("resp-xyz"));
                 assert_eq!(model_id.as_deref(), Some("gemini-2.0-flash-001"));
             }
-            other => panic!("expected ResponseMetadata, got {:?}", other),
+            other => panic!("expected ResponseMetadata, got {other:?}"),
         }
     }
 
@@ -1573,7 +1573,7 @@ mod error_handling {
 
         match err {
             AiMuxError::ApiCall(d) => assert!(d.to_string().contains("Internal error")),
-            other => panic!("expected Provider, got {:?}", other),
+            other => panic!("expected Provider, got {other:?}"),
         }
     }
 
@@ -1625,9 +1625,9 @@ mod error_handling {
         match err {
             AiMuxError::ApiCall(msg_d) => {
                 let msg = msg_d.to_string();
-                assert!(msg.contains("Invalid request"), "msg was: {}", msg)
+                assert!(msg.contains("Invalid request"), "msg was: {msg}")
             }
-            other => panic!("expected Provider, got {:?}", other),
+            other => panic!("expected Provider, got {other:?}"),
         }
     }
 
@@ -1653,9 +1653,9 @@ mod error_handling {
         match err {
             AiMuxError::ApiCall(msg_d) => {
                 let msg = msg_d.to_string();
-                assert!(msg.contains("Permission denied"), "msg was: {}", msg)
+                assert!(msg.contains("Permission denied"), "msg was: {msg}")
             }
-            other => panic!("expected Provider, got {:?}", other),
+            other => panic!("expected Provider, got {other:?}"),
         }
     }
 
@@ -1684,9 +1684,9 @@ mod error_handling {
         match err {
             AiMuxError::ApiCall(msg_d) => {
                 let msg = msg_d.to_string();
-                assert!(msg.contains("Internal error"), "msg was: {}", msg)
+                assert!(msg.contains("Internal error"), "msg was: {msg}")
             }
-            other => panic!("expected Provider, got {:?}", other),
+            other => panic!("expected Provider, got {other:?}"),
         }
     }
 
@@ -2021,7 +2021,7 @@ mod request_body {
         assert_eq!(gc["temperature"], 0.5);
         // f32 -> f64 round-trip introduces tiny error; compare with tolerance.
         let top_p = gc["topP"].as_f64().unwrap();
-        assert!((top_p - 0.9).abs() < 1e-5, "topP was {}", top_p);
+        assert!((top_p - 0.9).abs() < 1e-5, "topP was {top_p}");
         assert_eq!(gc["topK"], 40.0);
         assert_eq!(gc["stopSequences"][0], "STOP");
     }
@@ -2073,11 +2073,11 @@ mod request_body {
         let pp = body["generationConfig"]["presencePenalty"]
             .as_f64()
             .unwrap();
-        assert!((pp - 0.5).abs() < 1e-5, "presencePenalty was {}", pp);
+        assert!((pp - 0.5).abs() < 1e-5, "presencePenalty was {pp}");
         let fp = body["generationConfig"]["frequencyPenalty"]
             .as_f64()
             .unwrap();
-        assert!((fp - 0.3).abs() < 1e-5, "frequencyPenalty was {}", fp);
+        assert!((fp - 0.3).abs() < 1e-5, "frequencyPenalty was {fp}");
     }
 
     // ── should omit generationConfig when no options set ─────────────────────

--- a/aimux-providers/tests/google_provider_tools_test.rs
+++ b/aimux-providers/tests/google_provider_tools_test.rs
@@ -100,7 +100,7 @@ fn provider_at(uri: &str) -> GoogleProvider {
 /// Mock a JSON `generateContent` response for `model`.
 async fn mock_json_response(server: &MockServer, model: &str, body: Value) {
     Mock::given(method("POST"))
-        .and(path(format!("/models/{}:generateContent", model)))
+        .and(path(format!("/models/{model}:generateContent")))
         .respond_with(ResponseTemplate::new(200).set_body_json(body))
         .mount(server)
         .await;
@@ -109,7 +109,7 @@ async fn mock_json_response(server: &MockServer, model: &str, body: Value) {
 /// Mock an SSE `streamGenerateContent` response for `model`.
 async fn mock_sse_response(server: &MockServer, model: &str, sse_body: String) {
     Mock::given(method("POST"))
-        .and(path(format!("/models/{}:streamGenerateContent", model)))
+        .and(path(format!("/models/{model}:streamGenerateContent")))
         .and(query_param("alt", "sse"))
         .respond_with(
             ResponseTemplate::new(200)
@@ -124,7 +124,7 @@ async fn mock_sse_response(server: &MockServer, model: &str, sse_body: String) {
 fn sse_body(chunks: &[Value]) -> String {
     let mut body = String::new();
     for chunk in chunks {
-        body.push_str(&format!("data: {}\n\n", chunk));
+        body.push_str(&format!("data: {chunk}\n\n"));
     }
     body
 }
@@ -136,7 +136,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -766,7 +766,7 @@ mod do_generate {
                 && url.as_deref() == Some("https://source.example.com")
                 && title.as_deref() == Some("Source Title")
         });
-        assert!(has_url, "expected a url source, got {:?}", sources);
+        assert!(has_url, "expected a url source, got {sources:?}");
     }
 
     #[tokio::test]
@@ -1107,8 +1107,7 @@ mod do_generate {
         });
         assert!(
             has_call,
-            "expected a code_execution tool-call, got {:?}",
-            calls
+            "expected a code_execution tool-call, got {calls:?}"
         );
         // NOTE: TS also asserts a tool-result content item { outcome, output }
         // with providerExecuted=true — not expressible until GenerateContent
@@ -1196,8 +1195,7 @@ mod do_generate {
         let has_call = calls.iter().any(|(_, name, _)| name == "code_execution");
         assert!(
             has_call,
-            "expected a code_execution tool-call, got {:?}",
-            calls
+            "expected a code_execution tool-call, got {calls:?}"
         );
         // NOTE: TS asserts the result's output defaults to "" when missing —
         // pending GenerateContent::ToolResult.
@@ -1740,8 +1738,7 @@ mod do_stream {
         });
         assert!(
             has_call,
-            "expected a code_execution tool-call, got {:?}",
-            calls
+            "expected a code_execution tool-call, got {calls:?}"
         );
 
         let results = stream_tool_results(&parts);
@@ -1750,8 +1747,7 @@ mod do_stream {
             .any(|(_, output)| *output == json!({ "outcome": "OUTCOME_OK", "output": "hello\n" }));
         assert!(
             has_result,
-            "expected a code_execution tool-result, got {:?}",
-            results
+            "expected a code_execution tool-result, got {results:?}"
         );
         // NOTE: TS also asserts toolName: "code_execution" on the result and
         // providerExecuted: true on the call — not expressible on current
@@ -1811,8 +1807,7 @@ mod do_stream {
             .any(|(_, output)| *output == json!({ "outcome": "OUTCOME_OK", "output": "" }));
         assert!(
             has_empty,
-            "expected a tool-result with empty output, got {:?}",
-            results
+            "expected a tool-result with empty output, got {results:?}"
         );
     }
 
@@ -1977,7 +1972,7 @@ mod do_stream {
                 && url.as_deref() == Some("https://source.example.com")
                 && title.as_deref() == Some("Source Title")
         });
-        assert!(has, "expected a url source event, got {:?}", sources);
+        assert!(has, "expected a url source event, got {sources:?}");
     }
 
     #[tokio::test]
@@ -2018,7 +2013,7 @@ mod do_stream {
                 && url.as_deref() == Some("https://example.com/article")
                 && title.as_deref() == Some("Image Source")
         });
-        assert!(has, "expected an image url source event, got {:?}", sources);
+        assert!(has, "expected an image url source event, got {sources:?}");
     }
 
     #[tokio::test]
@@ -2113,8 +2108,7 @@ mod do_stream {
         assert_eq!(
             example.len(),
             1,
-            "duplicate source should be emitted once, got {:?}",
-            sources
+            "duplicate source should be emitted once, got {sources:?}"
         );
         assert_eq!(example[0].3.as_deref(), Some("Example"));
 
@@ -2132,8 +2126,7 @@ mod do_stream {
         assert_eq!(
             sources.len(),
             3,
-            "expected 3 deduplicated sources, got {:?}",
-            sources
+            "expected 3 deduplicated sources, got {sources:?}"
         );
     }
 }

--- a/aimux-providers/tests/google_remaining_test.rs
+++ b/aimux-providers/tests/google_remaining_test.rs
@@ -84,7 +84,7 @@ mod is_supported_file_url_tests {
             "https://youtu.be/dQw4w9WgXcQ?t=42",
         ];
         for url in valid {
-            assert!(is_supported_file_url(url), "should be supported: {}", url);
+            assert!(is_supported_file_url(url), "should be supported: {url}");
         }
     }
 
@@ -100,8 +100,7 @@ mod is_supported_file_url_tests {
         for url in invalid {
             assert!(
                 !is_supported_file_url(url),
-                "should NOT be supported: {}",
-                url
+                "should NOT be supported: {url}"
             );
         }
     }
@@ -119,8 +118,7 @@ mod is_supported_file_url_tests {
         for url in cases {
             assert!(
                 !is_supported_file_url(url),
-                "should NOT be supported: {}",
-                url
+                "should NOT be supported: {url}"
             );
         }
     }
@@ -518,11 +516,7 @@ mod schema_conversion_tests {
             json!({ "type": "object", "properties": {} }),
         ];
         for schema in &cases {
-            assert!(
-                convert_root(schema).is_null(),
-                "expected null for {}",
-                schema
-            );
+            assert!(convert_root(schema).is_null(), "expected null for {schema}");
         }
     }
 

--- a/aimux-providers/tests/groq_test.rs
+++ b/aimux-providers/tests/groq_test.rs
@@ -160,7 +160,7 @@ fn groq_tool_call_body() -> Value {
 
 /// Build a single SSE `data: <json>\n\n` event string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append the `[DONE]` sentinel.
@@ -1859,7 +1859,7 @@ mod auth {
         assert!(result.is_err());
         match result {
             Err(ref e) if e.status_code() == Some(401) => {}
-            Err(e) => panic!("expected a 401, got {:?}", e),
+            Err(e) => panic!("expected a 401, got {e:?}"),
             Ok(_) => panic!("expected error, got Ok"),
         }
     }

--- a/aimux-providers/tests/huggingface_responses_test.rs
+++ b/aimux-providers/tests/huggingface_responses_test.rs
@@ -84,7 +84,7 @@ async fn mock_sse(server: &MockServer, body: String) {
 
 /// Build a single SSE `data: <json>\n\n` event string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events (no `[DONE]` sentinel — HF Responses SSE has none).
@@ -103,7 +103,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -172,7 +172,7 @@ async fn should_generate_text() {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "Hello! How can I help you today?");
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
 }
 
@@ -252,7 +252,7 @@ async fn should_extract_text_from_output_array_when_output_text_missing() {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "Extracted from output array");
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
 }
 
@@ -447,7 +447,7 @@ async fn should_generate_text_and_sources_from_annotations() {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "Here are some recent articles about AI.");
         }
-        other => panic!("expected Text at [0], got {:?}", other),
+        other => panic!("expected Text at [0], got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Source { id, url, title, .. } => {
@@ -455,7 +455,7 @@ async fn should_generate_text_and_sources_from_annotations() {
             assert_eq!(url.as_deref(), Some("https://example.com/article1"));
             assert_eq!(title.as_deref(), Some("AI Developments Article"));
         }
-        other => panic!("expected Source at [1], got {:?}", other),
+        other => panic!("expected Source at [1], got {other:?}"),
     }
     match &result.content[2] {
         GenerateContent::Source { id, url, title, .. } => {
@@ -463,7 +463,7 @@ async fn should_generate_text_and_sources_from_annotations() {
             assert_eq!(url.as_deref(), Some("https://test.com/article2"));
             assert_eq!(title.as_deref(), Some("Industry Trends Report"));
         }
-        other => panic!("expected Source at [2], got {:?}", other),
+        other => panic!("expected Source at [2], got {other:?}"),
     }
 }
 
@@ -544,19 +544,19 @@ async fn should_handle_mcp_tools_with_annotations() {
             assert_eq!(tool_name, "search");
             assert_eq!(input, &json!({ "query": "San Francisco tech events" }));
         }
-        other => panic!("expected ToolCall at [0], got {:?}", other),
+        other => panic!("expected ToolCall at [0], got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Based on the search results."),
-        other => panic!("expected Text at [1], got {:?}", other),
+        other => panic!("expected Text at [1], got {other:?}"),
     }
     match &result.content[2] {
         GenerateContent::Source { id, .. } => assert_eq!(id, "id-0"),
-        other => panic!("expected Source at [2], got {:?}", other),
+        other => panic!("expected Source at [2], got {other:?}"),
     }
     match &result.content[3] {
         GenerateContent::Source { id, .. } => assert_eq!(id, "id-1"),
-        other => panic!("expected Source at [3], got {:?}", other),
+        other => panic!("expected Source at [3], got {other:?}"),
     }
 }
 
@@ -614,12 +614,12 @@ async fn should_stream_text_deltas() {
             assert_eq!(id.as_deref(), Some("resp_test"));
             assert_eq!(model_id.as_deref(), Some("deepseek-ai/DeepSeek-V3-0324"));
         }
-        other => panic!("expected ResponseMetadata, got {:?}", other),
+        other => panic!("expected ResponseMetadata, got {other:?}"),
     }
 
     match &parts[2] {
         StreamPart::TextStart { id, .. } => assert_eq!(id, "msg_test"),
-        other => panic!("expected TextStart, got {:?}", other),
+        other => panic!("expected TextStart, got {other:?}"),
     }
 
     match &parts[3] {
@@ -627,18 +627,18 @@ async fn should_stream_text_deltas() {
             assert_eq!(id, "msg_test");
             assert_eq!(delta, "Hello,");
         }
-        other => panic!("expected TextDelta, got {:?}", other),
+        other => panic!("expected TextDelta, got {other:?}"),
     }
     match &parts[4] {
         StreamPart::TextDelta { id, delta, .. } => {
             assert_eq!(id, "msg_test");
             assert_eq!(delta, " World!");
         }
-        other => panic!("expected TextDelta, got {:?}", other),
+        other => panic!("expected TextDelta, got {other:?}"),
     }
     match &parts[5] {
         StreamPart::TextEnd { id, .. } => assert_eq!(id, "msg_test"),
-        other => panic!("expected TextEnd, got {:?}", other),
+        other => panic!("expected TextEnd, got {other:?}"),
     }
     match &parts[6] {
         StreamPart::Finish {
@@ -650,7 +650,7 @@ async fn should_stream_text_deltas() {
             assert_eq!(usage.input_tokens.total, Some(12));
             assert_eq!(usage.output_tokens.total, Some(25));
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 
@@ -892,8 +892,7 @@ async fn should_throw_for_file_parts_with_provider_references() {
     assert!(
         err.to_string()
             .contains("file parts with provider references"),
-        "error should mention provider references, got: {}",
-        err
+        "error should mention provider references, got: {err}"
     );
 }
 
@@ -1081,13 +1080,13 @@ async fn should_handle_function_call_tool_responses() {
             assert_eq!(tool_name, "getWeather");
             assert_eq!(input, &json!({ "location": "New York" }));
         }
-        other => panic!("expected ToolCall at [0], got {:?}", other),
+        other => panic!("expected ToolCall at [0], got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "The weather in New York is 72°F and sunny.");
         }
-        other => panic!("expected Text at [1], got {:?}", other),
+        other => panic!("expected Text at [1], got {other:?}"),
     }
 }
 
@@ -1138,7 +1137,7 @@ async fn should_stream_tool_calls() {
             assert_eq!(id.as_deref(), Some("resp_tool_stream"));
             assert_eq!(model_id.as_deref(), Some("deepseek-ai/DeepSeek-V3-0324"));
         }
-        other => panic!("expected ResponseMetadata, got {:?}", other),
+        other => panic!("expected ResponseMetadata, got {other:?}"),
     }
 
     match &parts[2] {
@@ -1146,11 +1145,11 @@ async fn should_stream_tool_calls() {
             assert_eq!(id, "call_456");
             assert_eq!(tool_name, "calculator");
         }
-        other => panic!("expected ToolInputStart, got {:?}", other),
+        other => panic!("expected ToolInputStart, got {other:?}"),
     }
     match &parts[3] {
         StreamPart::ToolInputEnd { id, .. } => assert_eq!(id, "call_456"),
-        other => panic!("expected ToolInputEnd, got {:?}", other),
+        other => panic!("expected ToolInputEnd, got {other:?}"),
     }
     match &parts[4] {
         StreamPart::ToolCall {
@@ -1163,7 +1162,7 @@ async fn should_stream_tool_calls() {
             assert_eq!(tool_name, "calculator");
             assert_eq!(input, &json!({ "operation": "add", "a": 5, "b": 3 }));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     match &parts[5] {
         StreamPart::ToolResult {
@@ -1174,7 +1173,7 @@ async fn should_stream_tool_calls() {
             assert_eq!(tool_call_id, "call_456");
             assert_eq!(result, &json!("8"));
         }
-        other => panic!("expected ToolResult, got {:?}", other),
+        other => panic!("expected ToolResult, got {other:?}"),
     }
     match &parts[6] {
         StreamPart::Finish {
@@ -1186,7 +1185,7 @@ async fn should_stream_tool_calls() {
             assert_eq!(usage.input_tokens.total, Some(20));
             assert_eq!(usage.output_tokens.total, Some(15));
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 
@@ -1393,11 +1392,11 @@ async fn should_handle_reasoning_content_in_responses() {
                 Some(&json!({ "huggingface": { "itemId": "reasoning_1" } }))
             );
         }
-        other => panic!("expected Reasoning at [0], got {:?}", other),
+        other => panic!("expected Reasoning at [0], got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "The answer is 42."),
-        other => panic!("expected Text at [1], got {:?}", other),
+        other => panic!("expected Text at [1], got {other:?}"),
     }
 }
 
@@ -1464,7 +1463,7 @@ async fn should_stream_reasoning_content() {
             assert_eq!(id.as_deref(), Some("resp_reasoning_stream"));
             assert_eq!(model_id.as_deref(), Some("deepseek-ai/DeepSeek-R1"));
         }
-        other => panic!("expected ResponseMetadata, got {:?}", other),
+        other => panic!("expected ResponseMetadata, got {other:?}"),
     }
 
     match &parts[2] {
@@ -1478,47 +1477,47 @@ async fn should_stream_reasoning_content() {
                 Some(&json!({ "huggingface": { "itemId": "reasoning_stream" } }))
             );
         }
-        other => panic!("expected ReasoningStart, got {:?}", other),
+        other => panic!("expected ReasoningStart, got {other:?}"),
     }
     match &parts[3] {
         StreamPart::ReasoningDelta { id, delta, .. } => {
             assert_eq!(id, "reasoning_stream");
             assert_eq!(delta, "Thinking about");
         }
-        other => panic!("expected ReasoningDelta, got {:?}", other),
+        other => panic!("expected ReasoningDelta, got {other:?}"),
     }
     match &parts[4] {
         StreamPart::ReasoningDelta { id, delta, .. } => {
             assert_eq!(id, "reasoning_stream");
             assert_eq!(delta, " the problem...");
         }
-        other => panic!("expected ReasoningDelta, got {:?}", other),
+        other => panic!("expected ReasoningDelta, got {other:?}"),
     }
     match &parts[5] {
         StreamPart::ReasoningEnd { id, .. } => assert_eq!(id, "reasoning_stream"),
-        other => panic!("expected ReasoningEnd, got {:?}", other),
+        other => panic!("expected ReasoningEnd, got {other:?}"),
     }
     match &parts[6] {
         StreamPart::TextStart { id, .. } => assert_eq!(id, "msg_stream"),
-        other => panic!("expected TextStart, got {:?}", other),
+        other => panic!("expected TextStart, got {other:?}"),
     }
     match &parts[7] {
         StreamPart::TextDelta { id, delta, .. } => {
             assert_eq!(id, "msg_stream");
             assert_eq!(delta, "The solution is");
         }
-        other => panic!("expected TextDelta, got {:?}", other),
+        other => panic!("expected TextDelta, got {other:?}"),
     }
     match &parts[8] {
         StreamPart::TextDelta { id, delta, .. } => {
             assert_eq!(id, "msg_stream");
             assert_eq!(delta, " simple.");
         }
-        other => panic!("expected TextDelta, got {:?}", other),
+        other => panic!("expected TextDelta, got {other:?}"),
     }
     match &parts[9] {
         StreamPart::TextEnd { id, .. } => assert_eq!(id, "msg_stream"),
-        other => panic!("expected TextEnd, got {:?}", other),
+        other => panic!("expected TextEnd, got {other:?}"),
     }
     match &parts[10] {
         StreamPart::Finish {
@@ -1530,7 +1529,7 @@ async fn should_stream_reasoning_content() {
             assert_eq!(usage.input_tokens.total, Some(10));
             assert_eq!(usage.output_tokens.total, Some(20));
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 

--- a/aimux-providers/tests/hume_speech_test.rs
+++ b/aimux-providers/tests/hume_speech_test.rs
@@ -31,7 +31,7 @@ async fn mock_audio_response(server: &MockServer, format: &str) {
         .and(path("/v0/tts/file"))
         .respond_with(
             ResponseTemplate::new(200)
-                .insert_header("content-type", format!("audio/{}", format))
+                .insert_header("content-type", format!("audio/{format}"))
                 .set_body_bytes(mock_audio_bytes()),
         )
         .mount(server)
@@ -44,7 +44,7 @@ async fn mock_audio_response_with_headers(
     headers: &[(&str, &str)],
 ) {
     let mut template = ResponseTemplate::new(200)
-        .insert_header("content-type", format!("audio/{}", format))
+        .insert_header("content-type", format!("audio/{format}"))
         .set_body_bytes(mock_audio_bytes());
     for (k, v) in headers {
         template = template.insert_header(*k, *v);
@@ -262,8 +262,7 @@ async fn should_handle_different_audio_formats() {
 
         assert!(
             matches!(result.audio, AudioData::Binary(ref b) if b == &mock_audio_bytes()),
-            "format {} should return mock audio bytes",
-            format
+            "format {format} should return mock audio bytes"
         );
     }
 }

--- a/aimux-providers/tests/lmnt_speech_test.rs
+++ b/aimux-providers/tests/lmnt_speech_test.rs
@@ -26,7 +26,7 @@ async fn mock_audio_response(server: &MockServer, format: &str) {
         .and(path("/v1/ai/speech/bytes"))
         .respond_with(
             ResponseTemplate::new(200)
-                .insert_header("content-type", format!("audio/{}", format))
+                .insert_header("content-type", format!("audio/{format}"))
                 .set_body_bytes(mock_audio_bytes()),
         )
         .mount(server)
@@ -39,7 +39,7 @@ async fn mock_audio_response_with_headers(
     headers: &[(&str, &str)],
 ) {
     let mut template = ResponseTemplate::new(200)
-        .insert_header("content-type", format!("audio/{}", format))
+        .insert_header("content-type", format!("audio/{format}"))
         .set_body_bytes(mock_audio_bytes());
     for (k, v) in headers {
         template = template.insert_header(*k, *v);
@@ -254,8 +254,7 @@ async fn should_handle_different_audio_formats() {
 
         assert!(
             matches!(result.audio, AudioData::Binary(ref b) if b == &mock_audio_bytes()),
-            "format {} should return mock audio bytes",
-            format
+            "format {format} should return mock audio bytes"
         );
     }
 }

--- a/aimux-providers/tests/mistral_embedding_test.rs
+++ b/aimux-providers/tests/mistral_embedding_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK Mistral embedding model tests.
+//! Rust translations of the AI SDK Mistral embedding model tests.
 //!
 //! Source: `reference/ai/packages/mistral/src/mistral-embedding-model.test.ts`
 //! (127 lines, 5 cases).
@@ -31,7 +31,10 @@ fn embedding_response_body(embeddings: &[Vec<f32>], usage: Option<Value>) -> Val
 }
 
 fn test_values() -> Vec<String> {
-    TEST_VALUES.iter().map(|s| s.to_string()).collect()
+    TEST_VALUES
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect()
 }
 
 fn default_options(values: Vec<String>) -> EmbeddingCallOptions {
@@ -122,7 +125,7 @@ async fn should_expose_raw_response() {
         .and_then(|r| r.headers.as_ref())
         .expect("headers present");
     assert_eq!(
-        headers.get("test-header").map(|s| s.as_str()),
+        headers.get("test-header").map(std::string::String::as_str),
         Some("test-value")
     );
 }

--- a/aimux-providers/tests/mistral_model_test.rs
+++ b/aimux-providers/tests/mistral_model_test.rs
@@ -88,7 +88,7 @@ fn sse_body(events: &[&str]) -> String {
 fn sse_json_body(chunks: &[&str]) -> String {
     let mut body = String::new();
     for c in chunks {
-        body.push_str(&format!("data: {}\n\n", c));
+        body.push_str(&format!("data: {c}\n\n"));
     }
     body.push_str("data: [DONE]\n\n");
     body
@@ -100,7 +100,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -161,7 +161,7 @@ async fn should_extract_text_response() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
     assert_eq!(result.finish_reason.raw.as_deref(), Some("stop"));
@@ -312,7 +312,7 @@ async fn should_extract_tool_call() {
             assert_eq!(tool_name, "weather");
             assert_eq!(input, &json!({"location": "San Francisco"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }
@@ -567,7 +567,7 @@ async fn should_stream_text() {
             assert_eq!(usage.input_tokens.total, Some(13));
             assert_eq!(usage.output_tokens.total, Some(8));
         }
-        other => panic!("expected Finish, got {:?}", other),
+        other => panic!("expected Finish, got {other:?}"),
     }
 }
 
@@ -991,7 +991,7 @@ async fn should_extract_content_when_message_content_is_object() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello from object"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
 }
 
@@ -1042,7 +1042,7 @@ async fn should_extract_text_from_mixed_thinking_and_text() {
         GenerateContent::Text { text, .. } => {
             assert_eq!(text, "Partial answer.Final answer.");
         }
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
 }
 
@@ -1085,7 +1085,7 @@ async fn should_handle_empty_thinking_content() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Just the answer."),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
 }
 
@@ -1128,7 +1128,7 @@ async fn should_return_raw_text_with_think_tags() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, raw),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
 }
 
@@ -1216,7 +1216,7 @@ async fn should_extract_multiple_tool_calls() {
             assert_eq!(tool_name, "weather");
             assert_eq!(input, &json!({"city": "SF"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     match &result.content[1] {
         GenerateContent::ToolCall {
@@ -1229,7 +1229,7 @@ async fn should_extract_multiple_tool_calls() {
             assert_eq!(tool_name, "time");
             assert_eq!(input, &json!({"zone": "PST"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }

--- a/aimux-providers/tests/moonshotai_test.rs
+++ b/aimux-providers/tests/moonshotai_test.rs
@@ -65,7 +65,7 @@ fn body_with_usage(usage: Value) -> Value {
 }
 
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 fn sse_body(events: &[&str]) -> String {
@@ -83,7 +83,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -410,7 +410,7 @@ async fn do_generate_returns_text() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hi"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
 }

--- a/aimux-providers/tests/open_responses_test.rs
+++ b/aimux-providers/tests/open_responses_test.rs
@@ -82,7 +82,7 @@ async fn mock_sse(server: &MockServer, body: String) {
 
 /// Build a single SSE `data: <json>\n\n` event string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append the `[DONE]` sentinel.
@@ -1004,8 +1004,7 @@ mod do_generate_tests {
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.contains("Responses API returned no output (content_filter)"),
-            "got: {}",
-            msg
+            "got: {msg}"
         );
     }
 
@@ -1034,8 +1033,7 @@ mod do_generate_tests {
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.contains("The upstream provider failed to generate a response."),
-            "got: {}",
-            msg
+            "got: {msg}"
         );
     }
 
@@ -1451,7 +1449,7 @@ mod do_generate_tests {
                 assert_eq!(tool_name, "weather");
                 assert_eq!(input, &json!({"location": "San Francisco"}));
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1864,7 +1862,12 @@ mod do_stream_tests {
     async fn stream_basic_generation() {
         let server = MockServer::start().await;
         let chunks = basic_stream_chunks();
-        let body = sse_body(&chunks.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let body = sse_body(
+            &chunks
+                .iter()
+                .map(std::string::String::as_str)
+                .collect::<Vec<_>>(),
+        );
         mock_sse(&server, body).await;
 
         let model = make_model(&server, "gemma-7b-it");
@@ -1966,7 +1969,12 @@ mod do_stream_tests {
     async fn stream_reasoning_with_tool_call() {
         let server = MockServer::start().await;
         let chunks = reasoning_tool_call_chunks();
-        let body = sse_body(&chunks.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let body = sse_body(
+            &chunks
+                .iter()
+                .map(std::string::String::as_str)
+                .collect::<Vec<_>>(),
+        );
         mock_sse(&server, body).await;
 
         let model = make_model(&server, "gemma-7b-it");
@@ -2061,7 +2069,12 @@ mod do_stream_tests {
     async fn stream_pdf_input() {
         let server = MockServer::start().await;
         let chunks = pdf_stream_chunks();
-        let body = sse_body(&chunks.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let body = sse_body(
+            &chunks
+                .iter()
+                .map(std::string::String::as_str)
+                .collect::<Vec<_>>(),
+        );
         mock_sse(&server, body).await;
 
         let model = make_model(&server, "gpt-4.1-nano");

--- a/aimux-providers/tests/openai_compatible_test.rs
+++ b/aimux-providers/tests/openai_compatible_test.rs
@@ -89,7 +89,7 @@ fn text_completion_body() -> Value {
 
 /// Build a single SSE `data: <json>\n\n` event string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append the `[DONE]` sentinel.
@@ -109,7 +109,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts

--- a/aimux-providers/tests/openai_convert_extended_test.rs
+++ b/aimux-providers/tests/openai_convert_extended_test.rs
@@ -252,7 +252,7 @@ mod convert_extended {
             "application/pdf".to_string(),
             json!({ "anthropic": "file-xyz" }),
         )])];
-        convert_prompt_to_openai_messages(&p);
+        let _ = convert_prompt_to_openai_messages(&p);
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod convert_extended {
     #[test]
     #[should_panic(expected = "file part media type application/something")]
     fn throws_unsupported_mime() {
-        convert_prompt_to_openai_messages(&vec![up(vec![fb64(
+        let _ = convert_prompt_to_openai_messages(&vec![up(vec![fb64(
             "AAECAw==",
             "application/something",
         )])]);
@@ -278,13 +278,13 @@ mod convert_extended {
             "https://example.com/foo.wav".to_string(),
             "audio/wav".to_string(),
         )])];
-        convert_prompt_to_openai_messages(&p);
+        let _ = convert_prompt_to_openai_messages(&p);
     }
 
     #[test]
     #[should_panic(expected = "file part media type text/plain")]
     fn throws_unsupported_file_type() {
-        convert_prompt_to_openai_messages(&vec![up(vec![fb64("AQIDBAU=", "text/plain")])]);
+        let _ = convert_prompt_to_openai_messages(&vec![up(vec![fb64("AQIDBAU=", "text/plain")])]);
     }
 
     #[test]
@@ -294,7 +294,7 @@ mod convert_extended {
             "https://example.com/document.pdf".to_string(),
             "application/pdf".to_string(),
         )])];
-        convert_prompt_to_openai_messages(&p);
+        let _ = convert_prompt_to_openai_messages(&p);
     }
 
     #[test]
@@ -303,7 +303,7 @@ mod convert_extended {
         let r = convert_prompt_to_openai_messages(&vec![up(vec![fb64(b64, "image")])]);
         assert_eq!(
             r[0]["content"][0]["image_url"]["url"],
-            json!(format!("data:image/png;base64,{}", b64))
+            json!(format!("data:image/png;base64,{b64}"))
         );
     }
 
@@ -313,7 +313,7 @@ mod convert_extended {
         let r = convert_prompt_to_openai_messages(&vec![up(vec![fb64(b64, "image/*")])]);
         assert_eq!(
             r[0]["content"][0]["image_url"]["url"],
-            json!(format!("data:image/png;base64,{}", b64))
+            json!(format!("data:image/png;base64,{b64}"))
         );
     }
 
@@ -336,7 +336,7 @@ mod convert_extended {
         let r = convert_prompt_to_openai_messages(&vec![up(vec![fb64(b64, "image/png")])]);
         assert_eq!(
             r[0]["content"][0]["image_url"]["url"],
-            json!(format!("data:image/png;base64,{}", b64))
+            json!(format!("data:image/png;base64,{b64}"))
         );
     }
 

--- a/aimux-providers/tests/openai_embedding_test.rs
+++ b/aimux-providers/tests/openai_embedding_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK OpenAI embedding model tests.
+//! Rust translations of the AI SDK OpenAI embedding model tests.
 //!
 //! Source: `reference/ai/packages/openai/src/embedding/openai-embedding-model.test.ts`
 //! (164 lines, 7 cases).
@@ -45,7 +45,10 @@ fn embedding_response_body() -> Value {
 }
 
 fn test_values() -> Vec<String> {
-    TEST_VALUES.iter().map(|s| s.to_string()).collect()
+    TEST_VALUES
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect()
 }
 
 fn default_options(values: Vec<String>) -> EmbeddingCallOptions {
@@ -132,7 +135,7 @@ async fn should_expose_raw_response_headers() {
         .and_then(|r| r.headers.as_ref())
         .expect("response headers should be present");
     assert_eq!(
-        headers.get("test-header").map(|s| s.as_str()),
+        headers.get("test-header").map(std::string::String::as_str),
         Some("test-value")
     );
 }

--- a/aimux-providers/tests/openai_image_test.rs
+++ b/aimux-providers/tests/openai_image_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translation of the OpenAI image model tests.
+//! Rust translation of the OpenAI image model tests.
 //!
 //! Source: `reference/ai/packages/openai/src/image/openai-image-model.test.ts`
 //!
@@ -371,11 +371,13 @@ async fn should_include_response_data_with_timestamp_model_id_and_headers() {
     assert_eq!(result.response.model_id.as_deref(), Some("dall-e-3"));
     let headers = result.response.headers.as_ref().unwrap();
     assert_eq!(
-        headers.get("x-request-id").map(|s| s.as_str()),
+        headers.get("x-request-id").map(std::string::String::as_str),
         Some("test-request-id")
     );
     assert_eq!(
-        headers.get("x-ratelimit-remaining").map(|s| s.as_str()),
+        headers
+            .get("x-ratelimit-remaining")
+            .map(std::string::String::as_str),
         Some("123")
     );
 }
@@ -1007,7 +1009,7 @@ async fn should_include_response_metadata_for_edited_images() {
     assert_eq!(result.response.model_id.as_deref(), Some("gpt-image-1"));
     let headers = result.response.headers.as_ref().unwrap();
     assert_eq!(
-        headers.get("x-request-id").map(|s| s.as_str()),
+        headers.get("x-request-id").map(std::string::String::as_str),
         Some("edit-request-id")
     );
 }

--- a/aimux-providers/tests/openai_model_extended_test.rs
+++ b/aimux-providers/tests/openai_model_extended_test.rs
@@ -59,7 +59,7 @@ fn po(map: Value) -> Option<std::collections::HashMap<String, Value>> {
     Some(h)
 }
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 fn sse_body(events: &[&str]) -> String {
     let mut s = String::new();
@@ -164,7 +164,7 @@ mod do_generate_extended {
                     "Based on the search results [doc1], I found information."
                 );
             }
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
         match &result.content[1] {
             GenerateContent::Source {
@@ -177,7 +177,7 @@ mod do_generate_extended {
                 assert_eq!(url.as_deref(), Some("https://example.com/doc1.pdf"));
                 assert_eq!(title.as_deref(), Some("Document 1"));
             }
-            other => panic!("expected Source, got {:?}", other),
+            other => panic!("expected Source, got {other:?}"),
         }
     }
 
@@ -720,7 +720,7 @@ mod do_stream_extended {
             Some(StreamPart::Finish { finish_reason, .. }) => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::Stop);
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -766,7 +766,7 @@ mod do_stream_extended {
                 assert_eq!(pm["openai"]["acceptedPredictionTokens"], json!(123));
                 assert_eq!(pm["openai"]["rejectedPredictionTokens"], json!(456));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -809,7 +809,7 @@ mod do_stream_extended {
                 assert_eq!(usage.output_tokens.reasoning, Some(10));
                 assert_eq!(usage.output_tokens.text, Some(10));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 

--- a/aimux-providers/tests/openai_model_test.rs
+++ b/aimux-providers/tests/openai_model_test.rs
@@ -210,7 +210,7 @@ async fn mock_sse_response_with_headers(
 
 /// Build an SSE event string from a JSON value.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append `[DONE]`.
@@ -230,7 +230,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -291,7 +291,7 @@ mod do_generate {
         assert_eq!(result.content.len(), 1);
         match &result.content[0] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
     }
 
@@ -739,7 +739,7 @@ mod do_generate {
                 assert_eq!(tool_name, "test-tool");
                 assert_eq!(input, &json!({"value": "Spark"}));
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 }
@@ -843,13 +843,13 @@ mod do_stream {
                 );
                 assert_eq!(model_id.as_deref(), Some("gpt-3.5-turbo-0613"));
             }
-            other => panic!("expected ResponseMetadata, got {:?}", other),
+            other => panic!("expected ResponseMetadata, got {other:?}"),
         }
 
         // text-start with id "0"
         match &parts[2] {
             StreamPart::TextStart { id, .. } => assert_eq!(id, "0"),
-            other => panic!("expected TextStart, got {:?}", other),
+            other => panic!("expected TextStart, got {other:?}"),
         }
 
         // text-deltas: "", "Hello", ", ", "World!"
@@ -870,7 +870,7 @@ mod do_stream {
             .find(|p| matches!(p, StreamPart::TextEnd { .. }));
         match text_end {
             Some(StreamPart::TextEnd { id, .. }) => assert_eq!(id, "0"),
-            other => panic!("expected TextEnd, got {:?}", other),
+            other => panic!("expected TextEnd, got {other:?}"),
         }
 
         // finish with stop reason and usage
@@ -888,7 +888,7 @@ mod do_stream {
                 assert_eq!(usage.input_tokens.total, Some(17));
                 assert_eq!(usage.output_tokens.total, Some(227));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1007,7 +1007,7 @@ mod do_stream {
                 assert_eq!(usage.input_tokens.total, Some(53));
                 assert_eq!(usage.output_tokens.total, Some(17));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1147,7 +1147,7 @@ mod do_stream {
                 assert_eq!(tool_name, "searchGoogle");
                 assert_eq!(input, &json!({"query": "latest news on ai"}));
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1205,18 +1205,17 @@ mod do_stream {
                     Value::String(s) => {
                         assert!(
                             s.contains("query") && s.contains("limit"),
-                            "input string should contain both 'query' and 'limit': {}",
-                            s
+                            "input string should contain both 'query' and 'limit': {s}"
                         );
                     }
                     Value::Object(_) => {
                         // If it somehow parsed, still check for both keys
                         assert!(input.get("query").is_some(), "should have 'query'");
                     }
-                    other => panic!("expected String or Object, got {:?}", other),
+                    other => panic!("expected String or Object, got {other:?}"),
                 }
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1349,7 +1348,7 @@ mod do_stream {
                 let msg = msg_d.to_string();
                 assert!(msg.contains("The server had an error processing your request."));
             }
-            other => panic!("expected Provider error, got {:?}", other),
+            other => panic!("expected Provider error, got {other:?}"),
         }
     }
 
@@ -1381,7 +1380,7 @@ mod do_stream {
                 assert!(msg.contains("bad request"));
                 assert!(msg.contains("400"));
             }
-            other => panic!("expected Provider error, got {:?}", other),
+            other => panic!("expected Provider error, got {other:?}"),
         }
     }
 
@@ -1431,7 +1430,7 @@ mod do_stream {
             Some(StreamPart::Finish { finish_reason, .. }) => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::Error);
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1467,7 +1466,7 @@ mod do_stream {
             Some(StreamPart::Finish { finish_reason, .. }) => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::Error);
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1548,7 +1547,7 @@ mod do_stream {
                 // TS: outputTokens.total=20
                 assert_eq!(usage.output_tokens.total, Some(20));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1592,7 +1591,7 @@ mod do_stream {
             StreamPart::ResponseMetadata { model_id, .. } => {
                 assert_eq!(model_id.as_deref(), Some("o4-mini"));
             }
-            other => panic!("expected ResponseMetadata, got {:?}", other),
+            other => panic!("expected ResponseMetadata, got {other:?}"),
         }
 
         // Verify text deltas
@@ -1613,7 +1612,7 @@ mod do_stream {
                 assert_eq!(usage.input_tokens.total, Some(17));
                 assert_eq!(usage.output_tokens.total, Some(227));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
 
         // RFC-0016 M10: streaming usage also carries the provider raw usage.

--- a/aimux-providers/tests/openai_output_round_trip_test.rs
+++ b/aimux-providers/tests/openai_output_round_trip_test.rs
@@ -41,7 +41,7 @@ use aimux_providers::openai::{OpenAICompatProfile, OpenAIConfig, OpenAIProvider}
 fn openai_provider(uri: &str) -> aimux_providers::openai::OpenAIModel {
     let provider = OpenAIProvider::new(
         OpenAIConfig::new("test-key")
-            .with_base_url(format!("{}/v1", uri))
+            .with_base_url(format!("{uri}/v1"))
             .with_profile(OpenAICompatProfile::full()),
     );
     provider.model("gpt-4o")
@@ -410,8 +410,7 @@ async fn cross_protocol_anthropic_to_openai_non_streaming() {
         .unwrap_or("stop");
     assert!(
         matches!(fr, "stop" | "length" | "tool_calls" | "content_filter"),
-        "finish_reason should be valid OpenAI value, got {}",
-        fr
+        "finish_reason should be valid OpenAI value, got {fr}"
     );
 }
 
@@ -473,8 +472,7 @@ async fn cross_protocol_anthropic_to_openai_streaming() {
         .unwrap_or("stop");
     assert!(
         matches!(fr, "stop" | "length" | "tool_calls" | "content_filter"),
-        "last chunk finish_reason should be valid, got {}",
-        fr
+        "last chunk finish_reason should be valid, got {fr}"
     );
 
     for chunk in &chunks {

--- a/aimux-providers/tests/openai_responses_test.rs
+++ b/aimux-providers/tests/openai_responses_test.rs
@@ -92,7 +92,7 @@ async fn mock_sse_response(server: &MockServer, sse_body: &str) {
 
 /// Build an SSE event string from a JSON value.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append `[DONE]`.
@@ -112,7 +112,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -486,7 +486,7 @@ mod do_generate_request {
             aimux_core::types::Warning::Unsupported { feature, .. } => {
                 assert_eq!(feature, "conversation");
             }
-            other => panic!("expected Unsupported warning, got {:?}", other),
+            other => panic!("expected Unsupported warning, got {other:?}"),
         }
     }
 
@@ -708,7 +708,7 @@ mod do_generate_response {
         assert_eq!(result.content.len(), 1);
         match &result.content[0] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "answer text"),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
     }
 
@@ -807,13 +807,11 @@ mod do_generate_response {
         let msg = err.to_string();
         assert!(
             msg.contains("no output"),
-            "error should mention 'no output', got: {}",
-            msg
+            "error should mention 'no output', got: {msg}"
         );
         assert!(
             msg.contains("content_filter"),
-            "error should mention 'content_filter', got: {}",
-            msg
+            "error should mention 'content_filter', got: {msg}"
         );
     }
 
@@ -873,7 +871,7 @@ mod do_generate_response {
                 assert_eq!(tool_name, "weather");
                 assert_eq!(input["location"], "San Francisco");
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
         // finish reason should be tool-calls (hasFunctionCall = true, no incomplete_details)
         assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
@@ -933,11 +931,11 @@ mod do_generate_response {
         assert_eq!(result.content.len(), 2);
         match &result.content[0] {
             GenerateContent::Reasoning { text, .. } => assert_eq!(text, "thinking..."),
-            other => panic!("expected Reasoning, got {:?}", other),
+            other => panic!("expected Reasoning, got {other:?}"),
         }
         match &result.content[1] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "answer"),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
         assert_eq!(result.usage.output_tokens.reasoning, Some(15));
         assert_eq!(result.usage.output_tokens.text, Some(5));
@@ -1008,12 +1006,12 @@ mod do_stream {
                 assert_eq!(id.as_deref(), Some("resp_1"));
                 assert_eq!(model_id.as_deref(), Some("gpt-4o-2024-07-18"));
             }
-            other => panic!("expected ResponseMetadata, got {:?}", other),
+            other => panic!("expected ResponseMetadata, got {other:?}"),
         }
 
         match &parts[2] {
             StreamPart::TextStart { id, .. } => assert_eq!(id, "msg_1"),
-            other => panic!("expected TextStart, got {:?}", other),
+            other => panic!("expected TextStart, got {other:?}"),
         }
 
         match &parts[3] {
@@ -1021,7 +1019,7 @@ mod do_stream {
                 assert_eq!(id, "msg_1");
                 assert_eq!(delta, "Hello,");
             }
-            other => panic!("expected TextDelta, got {:?}", other),
+            other => panic!("expected TextDelta, got {other:?}"),
         }
 
         match &parts[4] {
@@ -1029,12 +1027,12 @@ mod do_stream {
                 assert_eq!(id, "msg_1");
                 assert_eq!(delta, " World!");
             }
-            other => panic!("expected TextDelta, got {:?}", other),
+            other => panic!("expected TextDelta, got {other:?}"),
         }
 
         match &parts[5] {
             StreamPart::TextEnd { id, .. } => assert_eq!(id, "msg_1"),
-            other => panic!("expected TextEnd, got {:?}", other),
+            other => panic!("expected TextEnd, got {other:?}"),
         }
 
         match &parts[6] {
@@ -1050,7 +1048,7 @@ mod do_stream {
                 assert_eq!(usage.output_tokens.reasoning, Some(123));
                 assert_eq!(usage.output_tokens.text, Some(355));
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1111,7 +1109,7 @@ mod do_stream {
                 assert_eq!(id, "call_added");
                 assert_eq!(tool_name, "weather");
             }
-            other => panic!("expected ToolInputStart, got {:?}", other),
+            other => panic!("expected ToolInputStart, got {other:?}"),
         }
 
         // ToolInputDelta uses the ongoing tool call's id (from added item).
@@ -1120,20 +1118,20 @@ mod do_stream {
                 assert_eq!(id, "call_added");
                 assert!(delta.contains("location"));
             }
-            other => panic!("expected ToolInputDelta, got {:?}", other),
+            other => panic!("expected ToolInputDelta, got {other:?}"),
         }
         match &parts[4] {
             StreamPart::ToolInputDelta { id, delta, .. } => {
                 assert_eq!(id, "call_added");
                 assert!(delta.contains("Rome"));
             }
-            other => panic!("expected ToolInputDelta, got {:?}", other),
+            other => panic!("expected ToolInputDelta, got {other:?}"),
         }
 
         // ToolInputEnd uses the call_id from the done item.
         match &parts[5] {
             StreamPart::ToolInputEnd { id, .. } => assert_eq!(id, "call_done"),
-            other => panic!("expected ToolInputEnd, got {:?}", other),
+            other => panic!("expected ToolInputEnd, got {other:?}"),
         }
 
         // ToolCall uses the call_id and arguments from the done item.
@@ -1148,7 +1146,7 @@ mod do_stream {
                 assert_eq!(tool_name, "weather");
                 assert_eq!(input["location"], "Rome");
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
 
         // Finish should have tool-calls finish reason.
@@ -1156,7 +1154,7 @@ mod do_stream {
             StreamPart::Finish { finish_reason, .. } => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::ToolCalls);
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -1215,7 +1213,7 @@ mod do_stream {
             StreamPart::ReasoningStart { id, .. } => {
                 assert_eq!(id, "rs_1:0");
             }
-            other => panic!("expected ReasoningStart, got {:?}", other),
+            other => panic!("expected ReasoningStart, got {other:?}"),
         }
 
         match &parts[3] {
@@ -1223,19 +1221,19 @@ mod do_stream {
                 assert_eq!(id, "rs_1:0");
                 assert_eq!(delta, "thinking through the steps");
             }
-            other => panic!("expected ReasoningDelta, got {:?}", other),
+            other => panic!("expected ReasoningDelta, got {other:?}"),
         }
 
         match &parts[4] {
             StreamPart::ReasoningEnd { id, .. } => assert_eq!(id, "rs_1:0"),
-            other => panic!("expected ReasoningEnd, got {:?}", other),
+            other => panic!("expected ReasoningEnd, got {other:?}"),
         }
 
         match &parts[5] {
             StreamPart::Finish { finish_reason, .. } => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::Stop);
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 

--- a/aimux-providers/tests/openai_speech_test.rs
+++ b/aimux-providers/tests/openai_speech_test.rs
@@ -33,7 +33,7 @@ async fn mock_audio_response(server: &MockServer, format: &str) {
         .and(path("/audio/speech"))
         .respond_with(
             ResponseTemplate::new(200)
-                .insert_header("content-type", format!("audio/{}", format))
+                .insert_header("content-type", format!("audio/{format}"))
                 .set_body_bytes(mock_audio_bytes()),
         )
         .mount(server)
@@ -47,7 +47,7 @@ async fn mock_audio_response_with_headers(
     headers: &[(&str, &str)],
 ) {
     let mut template = ResponseTemplate::new(200)
-        .insert_header("content-type", format!("audio/{}", format))
+        .insert_header("content-type", format!("audio/{format}"))
         .set_body_bytes(mock_audio_bytes());
     for (k, v) in headers {
         template = template.insert_header(*k, *v);
@@ -292,8 +292,7 @@ async fn should_handle_different_audio_formats() {
 
         assert!(
             matches!(result.audio, AudioData::Binary(ref b) if b == &mock_audio_bytes()),
-            "format {} should return mock audio bytes",
-            format
+            "format {format} should return mock audio bytes"
         );
     }
 }
@@ -351,6 +350,6 @@ async fn language_option_emits_unsupported_warning() {
         aimux_core::types::Warning::Unsupported { feature, .. } => {
             assert_eq!(feature, "language");
         }
-        other => panic!("expected Unsupported warning, got {:?}", other),
+        other => panic!("expected Unsupported warning, got {other:?}"),
     }
 }

--- a/aimux-providers/tests/openrouter_test.rs
+++ b/aimux-providers/tests/openrouter_test.rs
@@ -94,7 +94,7 @@ fn tool_call_completion_body() -> Value {
 }
 
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 fn sse_body(events: &[&str]) -> String {
@@ -112,7 +112,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -360,7 +360,7 @@ async fn do_generate_returns_text() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
 }
@@ -409,7 +409,7 @@ async fn do_generate_extracts_tool_call() {
             assert_eq!(tool_name, "get-weather");
             assert_eq!(input, &json!({"city": "SF"}));
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }
@@ -683,8 +683,7 @@ mod conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }
@@ -713,8 +712,7 @@ mod conformance {
                 let msg = e.to_string();
                 assert!(
                     !msg.contains("panic") && !msg.contains("unwrap"),
-                    "unexpected error: {}",
-                    msg
+                    "unexpected error: {msg}"
                 );
             }
         }

--- a/aimux-providers/tests/perplexity_test.rs
+++ b/aimux-providers/tests/perplexity_test.rs
@@ -68,7 +68,7 @@ fn text_completion_body() -> Value {
 }
 
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 fn sse_body(events: &[&str]) -> String {
@@ -86,7 +86,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -362,7 +362,7 @@ async fn do_generate_returns_text() {
     assert_eq!(result.content.len(), 1);
     match &result.content[0] {
         GenerateContent::Text { text, .. } => assert_eq!(text, "Hello, World!"),
-        other => panic!("expected Text, got {:?}", other),
+        other => panic!("expected Text, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
 }

--- a/aimux-providers/tests/prodia_image_test.rs
+++ b/aimux-providers/tests/prodia_image_test.rs
@@ -12,17 +12,17 @@ const PROMPT: &str = "A cute baby sea otter";
 
 fn multipart_response(boundary: &str, job_json: &str, image_bytes: &[u8]) -> Vec<u8> {
     let mut body = Vec::new();
-    body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
     body.extend_from_slice(b"Content-Disposition: form-data; name=\"job\"\r\n");
     body.extend_from_slice(b"Content-Type: application/json\r\n\r\n");
     body.extend_from_slice(job_json.as_bytes());
     body.extend_from_slice(b"\r\n");
-    body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
     body.extend_from_slice(b"Content-Disposition: form-data; name=\"output\"\r\n");
     body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
     body.extend_from_slice(image_bytes);
     body.extend_from_slice(b"\r\n");
-    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
     body
 }
 

--- a/aimux-providers/tests/reasoning_map_test.rs
+++ b/aimux-providers/tests/reasoning_map_test.rs
@@ -211,10 +211,7 @@ fn assert_vendor_key(
     assert_eq!(
         result.body[expected_key],
         json!(100),
-        "[{}] {} 分支: 请求体应含 {}",
-        provider,
-        branch,
-        expected_key
+        "[{provider}] {branch} 分支: 请求体应含 {expected_key}"
     );
     let other_key = if expected_key == "max_tokens" {
         "max_completion_tokens"
@@ -239,8 +236,7 @@ fn max_tokens_key_wiring_registry() {
         assert_eq!(
             profile.max_tokens_key,
             Some(expected),
-            "[{}] 注册表接线错误",
-            provider
+            "[{provider}] 注册表接线错误"
         );
     }
 }

--- a/aimux-providers/tests/vertex_anthropic_test.rs
+++ b/aimux-providers/tests/vertex_anthropic_test.rs
@@ -91,7 +91,7 @@ async fn mock_stream_raw_predict_sse(server: &MockServer, sse_body: &str) {
 }
 
 fn sse(data: &Value) -> String {
-    format!("data: {}\n\n", data)
+    format!("data: {data}\n\n")
 }
 
 fn sse_stream(events: &[Value]) -> String {
@@ -101,7 +101,7 @@ fn sse_stream(events: &[Value]) -> String {
 fn as_text(item: &GenerateContent) -> &str {
     match item {
         GenerateContent::Text { text, .. } => text,
-        _ => panic!("expected Text content, got {:?}", item),
+        _ => panic!("expected Text content, got {item:?}"),
     }
 }
 
@@ -111,7 +111,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts

--- a/aimux-providers/tests/vertex_embedding_test.rs
+++ b/aimux-providers/tests/vertex_embedding_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK Google Vertex embedding model tests.
+//! Rust translations of the AI SDK Google Vertex embedding model tests.
 //!
 //! Source: `reference/ai/packages/google-vertex/src/google-vertex-embedding-model.test.ts`
 //! (460 lines, 12 cases).
@@ -58,7 +58,10 @@ fn embed_content_response_body() -> Value {
 }
 
 fn test_values() -> Vec<String> {
-    TEST_VALUES.iter().map(|s| s.to_string()).collect()
+    TEST_VALUES
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect()
 }
 
 fn default_options(values: Vec<String>) -> EmbeddingCallOptions {
@@ -322,7 +325,7 @@ async fn should_expose_response_headers() {
         .and_then(|r| r.headers.as_ref())
         .expect("headers present");
     assert_eq!(
-        headers.get("test-header").map(|s| s.as_str()),
+        headers.get("test-header").map(std::string::String::as_str),
         Some("test-value")
     );
 }

--- a/aimux-providers/tests/vertex_model_test.rs
+++ b/aimux-providers/tests/vertex_model_test.rs
@@ -83,7 +83,7 @@ async fn mock_stream_content(server: &MockServer, sse_body: &str) {
 }
 
 fn sse(data: &Value) -> String {
-    format!("data: {}\n\n", data)
+    format!("data: {data}\n\n")
 }
 
 fn sse_stream(events: &[Value]) -> String {
@@ -93,7 +93,7 @@ fn sse_stream(events: &[Value]) -> String {
 fn as_text(item: &GenerateContent) -> &str {
     match item {
         GenerateContent::Text { text, .. } => text,
-        _ => panic!("expected Text content, got {:?}", item),
+        _ => panic!("expected Text content, got {item:?}"),
     }
 }
 
@@ -105,7 +105,7 @@ fn as_tool_call(item: &GenerateContent) -> (&str, &str, &Value) {
             input,
             ..
         } => (tool_call_id, tool_name, input),
-        _ => panic!("expected ToolCall content, got {:?}", item),
+        _ => panic!("expected ToolCall content, got {item:?}"),
     }
 }
 
@@ -115,7 +115,7 @@ async fn collect_stream(result: StreamResult) -> Vec<StreamPart> {
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -257,7 +257,7 @@ async fn vertex_generate_tool_call_with_thought_signature() {
                 Some("EuIDCt8DARFNMg/aRDRK3THWhBjzltCEy5/VM6ImWLJU8oHmnC75abdcZBMH")
             );
         }
-        other => panic!("expected ToolCall, got {:?}", other),
+        other => panic!("expected ToolCall, got {other:?}"),
     }
     assert_eq!(result.finish_reason.unified, FinishReasonUnified::ToolCalls);
 }
@@ -753,8 +753,7 @@ async fn vertex_stream_code_execution_tool_calls_and_results() {
     });
     assert!(
         has_call,
-        "expected a code_execution tool-call, got {:?}",
-        calls
+        "expected a code_execution tool-call, got {calls:?}"
     );
 
     // The ToolResult must reference the preceding executableCode call id.
@@ -769,8 +768,7 @@ async fn vertex_stream_code_execution_tool_calls_and_results() {
     });
     assert!(
         has_result,
-        "expected a code_execution tool-result, got {:?}",
-        results
+        "expected a code_execution tool-result, got {results:?}"
     );
 
     // Provider-executed tool → Stop, not ToolCalls.
@@ -833,8 +831,7 @@ async fn vertex_stream_code_execution_result_missing_output() {
         .any(|(_, output)| *output == json!({ "outcome": "OUTCOME_OK", "output": "" }));
     assert!(
         has_empty,
-        "expected a tool-result with empty output, got {:?}",
-        results
+        "expected a tool-result with empty output, got {results:?}"
     );
 }
 
@@ -888,16 +885,14 @@ async fn vertex_stream_server_tool_call_and_response() {
         calls
             .iter()
             .any(|(_, name, _)| name == "server:GOOGLE_SEARCH_WEB"),
-        "expected a server-side tool-call in the stream, got {:?}",
-        calls
+        "expected a server-side tool-call in the stream, got {calls:?}"
     );
 
     let results = stream_tool_results(&parts);
     assert!(
         results.iter().any(|(id, output)| *id == "server-call-1"
             && *output == json!({ "results": [{ "title": "Weather in SF" }] })),
-        "expected a server tool-response keyed to server-call-1, got {:?}",
-        results
+        "expected a server tool-response keyed to server-call-1, got {results:?}"
     );
 
     // Provider-executed server tools → stop, not tool-calls.
@@ -963,16 +958,14 @@ async fn vertex_stream_grounding_metadata_sources() {
     assert_eq!(
         example.len(),
         1,
-        "duplicate source should be emitted once, got {:?}",
-        sources
+        "duplicate source should be emitted once, got {sources:?}"
     );
     assert_eq!(example[0].1, "url");
     assert_eq!(example[0].3.as_deref(), Some("Example"));
     assert_eq!(
         sources.len(),
         3,
-        "expected 3 deduplicated sources, got {:?}",
-        sources
+        "expected 3 deduplicated sources, got {sources:?}"
     );
 }
 
@@ -1035,8 +1028,7 @@ async fn vertex_stream_finish_provider_metadata() {
     let vertex = &pm["googleVertex"];
     assert!(
         !vertex.is_null() && vertex.as_object().map(|o| !o.is_empty()).unwrap_or(false),
-        "googleVertex provider metadata should be non-empty, got {}",
-        pm
+        "googleVertex provider metadata should be non-empty, got {pm}"
     );
     assert_eq!(
         vertex["groundingMetadata"],
@@ -1072,8 +1064,7 @@ async fn vertex_stream_finish_provider_metadata() {
     ] {
         assert!(
             vertex.get(key).is_some(),
-            "expected key `{key}` in googleVertex metadata, got {}",
-            pm
+            "expected key `{key}` in googleVertex metadata, got {pm}"
         );
     }
     // …and the three snapshot fields carry their captured values, not just

--- a/aimux-providers/tests/vertex_remaining_test.rs
+++ b/aimux-providers/tests/vertex_remaining_test.rs
@@ -218,7 +218,7 @@ async fn with_api_key_selects_apikey_auth_variant() {
     let config = VertexProviderConfig::with_api_key("express-key");
     match &config.auth {
         VertexAuth::ApiKey(k) => assert_eq!(k, "express-key"),
-        other => panic!("expected ApiKey auth, got {:?}", other),
+        other => panic!("expected ApiKey auth, got {other:?}"),
     }
 }
 
@@ -228,7 +228,7 @@ async fn new_selects_bearer_token_auth_variant() {
     let config = VertexProviderConfig::new("the-token", "proj", "us-central1");
     match &config.auth {
         VertexAuth::BearerToken(t) => assert_eq!(t, "the-token"),
-        other => panic!("expected BearerToken auth, got {:?}", other),
+        other => panic!("expected BearerToken auth, got {other:?}"),
     }
 }
 
@@ -376,7 +376,7 @@ async fn from_env_uses_api_key_when_set() {
     let config = VertexProviderConfig::from_env().expect("from_env");
     match config.auth {
         VertexAuth::ApiKey(k) => assert_eq!(k, "env-api-key"),
-        other => panic!("expected ApiKey auth, got {:?}", other),
+        other => panic!("expected ApiKey auth, got {other:?}"),
     }
     clear_vertex_env();
 }
@@ -400,7 +400,7 @@ async fn from_env_prefers_api_key_over_access_token() {
     );
     match config.auth {
         VertexAuth::ApiKey(k) => assert_eq!(k, "env-api-key"),
-        other => panic!("expected ApiKey auth, got {:?}", other),
+        other => panic!("expected ApiKey auth, got {other:?}"),
     }
     clear_vertex_env();
 }
@@ -418,7 +418,7 @@ async fn from_env_uses_access_token_project_location() {
     let config = VertexProviderConfig::from_env().expect("from_env");
     match config.auth {
         VertexAuth::BearerToken(t) => assert_eq!(t, "env-token"),
-        other => panic!("expected BearerToken auth, got {:?}", other),
+        other => panic!("expected BearerToken auth, got {other:?}"),
     }
     assert!(config.base_url.contains("/projects/env-project/"));
     assert!(config.base_url.contains("/locations/europe-west1/"));
@@ -498,7 +498,7 @@ async fn from_env_empty_api_key_falls_through_to_access_token() {
     let config = VertexProviderConfig::from_env().expect("from_env");
     match config.auth {
         VertexAuth::BearerToken(t) => assert_eq!(t, "env-token"),
-        other => panic!("expected BearerToken auth, got {:?}", other),
+        other => panic!("expected BearerToken auth, got {other:?}"),
     }
     clear_vertex_env();
 }

--- a/aimux-providers/tests/voyage_embedding_test.rs
+++ b/aimux-providers/tests/voyage_embedding_test.rs
@@ -1,4 +1,4 @@
-﻿//! Rust translations of the AI SDK Voyage embedding model tests.
+//! Rust translations of the AI SDK Voyage embedding model tests.
 //!
 //! Source: `reference/ai/packages/voyage/src/voyage-embedding-model.test.ts`
 //! (174 lines, 6 cases).
@@ -28,7 +28,10 @@ fn embedding_response_body() -> Value {
 }
 
 fn test_values() -> Vec<String> {
-    TEST_VALUES.iter().map(|s| s.to_string()).collect()
+    TEST_VALUES
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect()
 }
 
 fn default_options(values: Vec<String>) -> EmbeddingCallOptions {
@@ -110,7 +113,7 @@ async fn should_expose_raw_response() {
         .and_then(|r| r.headers.as_ref())
         .expect("headers present");
     assert_eq!(
-        headers.get("test-header").map(|s| s.as_str()),
+        headers.get("test-header").map(std::string::String::as_str),
         Some("test-value")
     );
 }

--- a/aimux-providers/tests/xai_responses_test.rs
+++ b/aimux-providers/tests/xai_responses_test.rs
@@ -44,7 +44,7 @@ fn default_options(prompt: Vec<LanguageModelPromptMessage>) -> CallOptions {
 }
 
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 fn sse_body(events: &[&str]) -> String {
@@ -62,7 +62,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -129,7 +129,7 @@ mod do_generate {
         assert_eq!(result.content.len(), 1);
         match &result.content[0] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "hello world"),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
     }
 
@@ -366,11 +366,11 @@ mod reasoning {
                     )
                 );
             }
-            other => panic!("expected Reasoning, got {:?}", other),
+            other => panic!("expected Reasoning, got {other:?}"),
         }
         match &result.content[1] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "The answer is 42."),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
     }
 
@@ -423,7 +423,7 @@ mod reasoning {
                     &Some(json!({ "xai": { "itemId": "rs_456" } }))
                 );
             }
-            other => panic!("expected Reasoning, got {:?}", other),
+            other => panic!("expected Reasoning, got {other:?}"),
         }
     }
 
@@ -470,7 +470,7 @@ mod reasoning {
             GenerateContent::Reasoning { text, .. } => {
                 assert_eq!(text, "Let me think step by step.");
             }
-            other => panic!("expected Reasoning, got {:?}", other),
+            other => panic!("expected Reasoning, got {other:?}"),
         }
     }
 
@@ -526,7 +526,7 @@ mod reasoning {
                     )
                 );
             }
-            other => panic!("expected Reasoning, got {:?}", other),
+            other => panic!("expected Reasoning, got {other:?}"),
         }
     }
 }
@@ -1122,7 +1122,7 @@ mod tools {
                 assert_eq!(tool_name, "web_search");
                 assert_eq!(input, "{\"query\":\"test\"}");
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1162,7 +1162,7 @@ mod tools {
 
         match &result.content[0] {
             GenerateContent::ToolCall { tool_name, .. } => assert_eq!(tool_name, "web_search"),
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1202,7 +1202,7 @@ mod tools {
 
         match &result.content[0] {
             GenerateContent::ToolCall { tool_name, .. } => assert_eq!(tool_name, "x_search"),
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1242,7 +1242,7 @@ mod tools {
 
         match &result.content[0] {
             GenerateContent::ToolCall { tool_name, .. } => assert_eq!(tool_name, "code_execution"),
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1282,7 +1282,7 @@ mod tools {
 
         match &result.content[0] {
             GenerateContent::ToolCall { tool_name, .. } => assert_eq!(tool_name, "code_execution"),
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1324,7 +1324,7 @@ mod tools {
             GenerateContent::ToolCall { tool_name, .. } => {
                 assert_eq!(tool_name, "my_custom_search")
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1386,7 +1386,7 @@ mod tools {
                 assert_eq!(tool_name, "file_search");
                 assert_eq!(input, "");
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
         // Tool result
         match &result.content[1] {
@@ -1402,12 +1402,12 @@ mod tools {
                 assert_eq!(result["results"].as_array().unwrap().len(), 2);
                 assert_eq!(result["results"][0]["fileId"], "file_abc123");
             }
-            other => panic!("expected ToolResult, got {:?}", other),
+            other => panic!("expected ToolResult, got {other:?}"),
         }
         // Text
         match &result.content[2] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "Based on the documents..."),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
     }
 
@@ -1458,7 +1458,7 @@ mod tools {
                 assert_eq!(result["queries"], json!(["nonexistent topic"]));
                 assert_eq!(result["results"], Value::Null);
             }
-            other => panic!("expected ToolResult, got {:?}", other),
+            other => panic!("expected ToolResult, got {other:?}"),
         }
     }
 
@@ -1511,7 +1511,7 @@ mod tools {
                 assert_eq!(tool_name, "weather");
                 assert_eq!(input, &json!({ "location": "sf" }));
             }
-            other => panic!("expected ToolCall, got {:?}", other),
+            other => panic!("expected ToolCall, got {other:?}"),
         }
     }
 
@@ -1616,7 +1616,7 @@ mod citations {
         // Text
         match &result.content[0] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "based on research"),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
         // Source 1
         match &result.content[1] {
@@ -1624,7 +1624,7 @@ mod citations {
                 assert_eq!(url.as_deref(), Some("https://example.com"));
                 assert_eq!(title.as_deref(), Some("example title"));
             }
-            other => panic!("expected Source, got {:?}", other),
+            other => panic!("expected Source, got {other:?}"),
         }
         // Source 2 (title falls back to url)
         match &result.content[2] {
@@ -1632,7 +1632,7 @@ mod citations {
                 assert_eq!(url.as_deref(), Some("https://test.com"));
                 assert_eq!(title.as_deref(), Some("https://test.com"));
             }
-            other => panic!("expected Source, got {:?}", other),
+            other => panic!("expected Source, got {other:?}"),
         }
     }
 }

--- a/aimux-providers/tests/xai_test.rs
+++ b/aimux-providers/tests/xai_test.rs
@@ -106,7 +106,7 @@ fn xai_text_fixture() -> Value {
 
 /// Build a single SSE `data: <json>\n\n` event string.
 fn sse_event(json_str: &str) -> String {
-    format!("data: {}\n\n", json_str)
+    format!("data: {json_str}\n\n")
 }
 
 /// Concatenate SSE events and append the `[DONE]` sentinel.
@@ -126,7 +126,7 @@ async fn collect_stream(result: aimux_core::result::StreamResult) -> Vec<StreamP
     while let Some(part) = stream.next().await {
         match part {
             Ok(p) => parts.push(p),
-            Err(e) => panic!("stream error: {:?}", e),
+            Err(e) => panic!("stream error: {e:?}"),
         }
     }
     parts
@@ -617,7 +617,7 @@ mod prepare_tools {
                 || tools
                     .unwrap()
                     .as_array()
-                    .map(|a| a.is_empty())
+                    .map(std::vec::Vec::is_empty)
                     .unwrap_or(true)
         );
 
@@ -1356,7 +1356,7 @@ mod do_generate {
         assert_eq!(result.content.len(), 1);
         match &result.content[0] {
             GenerateContent::Text { text, .. } => assert_eq!(text, "Hello from object"),
-            other => panic!("expected Text, got {:?}", other),
+            other => panic!("expected Text, got {other:?}"),
         }
         assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
     }
@@ -1962,7 +1962,7 @@ mod do_stream {
             Some(StreamPart::Finish { finish_reason, .. }) => {
                 assert_eq!(finish_reason.unified, FinishReasonUnified::Stop);
             }
-            other => panic!("expected Finish, got {:?}", other),
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -2429,7 +2429,7 @@ mod reasoning {
                 .map(|c| sse_event(c))
                 .collect::<Vec<_>>()
                 .iter()
-                .map(|s| s.as_str())
+                .map(std::string::String::as_str)
                 .collect::<Vec<_>>(),
         );
         Mock::given(method("POST"))
@@ -2478,7 +2478,7 @@ mod reasoning {
                 .map(|c| sse_event(c))
                 .collect::<Vec<_>>()
                 .iter()
-                .map(|s| s.as_str())
+                .map(std::string::String::as_str)
                 .collect::<Vec<_>>(),
         );
         Mock::given(method("POST"))
@@ -2552,8 +2552,7 @@ mod error_handling {
         let msg = err.to_string();
         assert!(
             msg.contains("Invalid value: temperature must be between 0 and 2"),
-            "got: {}",
-            msg
+            "got: {msg}"
         );
     }
 
@@ -2579,10 +2578,9 @@ mod error_handling {
         let msg = err.to_string();
         assert!(
             msg.contains("Client specified an invalid argument"),
-            "got: {}",
-            msg
+            "got: {msg}"
         );
-        assert!(msg.contains("Invalid request content"), "got: {}", msg);
+        assert!(msg.contains("Invalid request content"), "got: {msg}");
     }
 
     /// TS: should throw APICallError when xai returns error with 200 status (doGenerate)
@@ -2607,8 +2605,7 @@ mod error_handling {
         let msg = err.to_string();
         assert!(
             msg.contains("Timed out waiting for first token"),
-            "got: {}",
-            msg
+            "got: {msg}"
         );
     }
 
@@ -2634,8 +2631,7 @@ mod error_handling {
         let msg = err.to_string();
         assert!(
             msg.contains("Timed out waiting for first token"),
-            "got: {}",
-            msg
+            "got: {msg}"
         );
     }
 

--- a/aimux-stream/src/lines.rs
+++ b/aimux-stream/src/lines.rs
@@ -12,6 +12,7 @@
 /// - `end_line` past EOF clamps to the last line.
 /// - Mixed line endings are not supported: detection picks one and uses it for
 ///   both the split and the rejoin.
+#[must_use]
 pub fn extract_lines(text: &str, start_line: Option<usize>, end_line: Option<usize>) -> String {
     if start_line.is_none() && end_line.is_none() {
         return text.to_string();

--- a/aimux-stream/src/streaming_tool_call_tracker.rs
+++ b/aimux-stream/src/streaming_tool_call_tracker.rs
@@ -46,26 +46,31 @@ pub struct StreamingToolCallDelta {
 }
 
 impl StreamingToolCallDelta {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    #[must_use]
     pub fn index(mut self, index: usize) -> Self {
         self.index = Some(index);
         self
     }
 
+    #[must_use]
     pub fn id(mut self, id: impl Into<String>) -> Self {
         self.id = Some(id.into());
         self
     }
 
     /// Set the `type` field (named `tool_type` because `type` is reserved).
+    #[must_use]
     pub fn tool_type(mut self, t: impl Into<String>) -> Self {
         self.r#type = Some(t.into());
         self
     }
 
+    #[must_use]
     pub fn function_name(mut self, name: impl Into<String>) -> Self {
         self.function.get_or_insert_with(Default::default).name = Some(name.into());
         self
@@ -73,11 +78,13 @@ impl StreamingToolCallDelta {
 
     /// Set the `function.arguments` fragment. Pass `""` for an explicit empty
     /// fragment; omit the call entirely for `None` (TS `arguments: null`).
+    #[must_use]
     pub fn arguments(mut self, args: impl Into<String>) -> Self {
         self.function.get_or_insert_with(Default::default).arguments = Some(args.into());
         self
     }
 
+    #[must_use]
     pub fn extra(mut self, extra: Value) -> Self {
         self.extra = extra;
         self
@@ -181,6 +188,7 @@ impl Default for StreamingToolCallTracker<()> {
 
 impl<M> StreamingToolCallTracker<M> {
     /// Create a new tracker with no metadata handling and default settings.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             tool_calls: Vec::new(),
@@ -194,12 +202,14 @@ impl<M> StreamingToolCallTracker<M> {
     }
 
     /// Set a custom id generator (the TS `generateId` option).
+    #[must_use]
     pub fn with_generate_id<F: Fn() -> String + 'static>(mut self, f: F) -> Self {
         self.generate_id = Box::new(f);
         self
     }
 
     /// Set the `type` validation mode (the TS `typeValidation` option).
+    #[must_use]
     pub fn with_type_validation(mut self, v: TypeValidation) -> Self {
         self.type_validation = v;
         self
@@ -209,6 +219,7 @@ impl<M> StreamingToolCallTracker<M> {
     /// whose resolved `index` exceeds `max_index` returns
     /// [`TrackerError::IndexOutOfRange`] instead of resizing `tool_calls` to
     /// `index + 1` slots.
+    #[must_use]
     pub fn with_max_index(mut self, max_index: usize) -> Self {
         self.max_index = max_index;
         self
@@ -217,6 +228,7 @@ impl<M> StreamingToolCallTracker<M> {
     /// Set the metadata extractor (the TS `extractMetadata` option). Called
     /// once when a new tool call is detected; the returned metadata is stored
     /// on the tool call and passed to the builder at finalization.
+    #[must_use]
     pub fn with_extract_metadata<F: Fn(&StreamingToolCallDelta) -> Option<M> + 'static>(
         mut self,
         f: F,
@@ -228,6 +240,7 @@ impl<M> StreamingToolCallTracker<M> {
     /// Set the provider-metadata builder (the TS `buildToolCallProviderMetadata`
     /// option). Receives the metadata previously extracted; if `None` is
     /// returned, no `provider_metadata` is included in the `tool-call` event.
+    #[must_use]
     pub fn with_build_provider_metadata<F: Fn(Option<&M>) -> Option<M> + 'static>(
         mut self,
         f: F,
@@ -238,6 +251,11 @@ impl<M> StreamingToolCallTracker<M> {
 
     /// Process a tool call delta from a streaming response chunk. Emits events
     /// into the internal buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `TrackerError::IndexOutOfRange` when the delta's tool index
+    /// exceeds the configured maximum.
     pub fn process_delta(&mut self, delta: &StreamingToolCallDelta) -> Result<(), TrackerError> {
         let index = delta.index.unwrap_or(self.tool_calls.len());
         // Guard against a remote `index` resizing `tool_calls` to a huge vector.
@@ -247,7 +265,7 @@ impl<M> StreamingToolCallTracker<M> {
         let is_new = self
             .tool_calls
             .get(index)
-            .map(|o| o.is_none())
+            .map(std::option::Option::is_none)
             .unwrap_or(true);
         if is_new {
             self.process_new_tool_call(index, delta)?;
@@ -274,6 +292,7 @@ impl<M> StreamingToolCallTracker<M> {
     }
 
     /// The events emitted so far (accumulated across `process_delta`/`flush`).
+    #[must_use]
     pub fn parts(&self) -> &[ToolCallStreamPart<M>] {
         &self.parts
     }

--- a/aimux-stream/tests/ndjson_test.rs
+++ b/aimux-stream/tests/ndjson_test.rs
@@ -41,11 +41,10 @@ async fn emoji_ndjson_line_split_at_every_byte_boundary() {
         );
         let line = lines[0]
             .as_ref()
-            .unwrap_or_else(|e| panic!("split at byte {} errored: {:?}", split, e));
+            .unwrap_or_else(|e| panic!("split at byte {split} errored: {e:?}"));
         assert_eq!(
             line.text, "😀👋",
-            "split at byte {} corrupted the text",
-            split
+            "split at byte {split} corrupted the text"
         );
     }
 }
@@ -63,7 +62,7 @@ async fn invalid_utf8_line_returns_utf8_error() {
     assert_eq!(lines.len(), 1, "expected exactly one result");
     match &lines[0] {
         Err(NdjsonError::Utf8(_)) => {}
-        other => panic!("expected NdjsonError::Utf8, got {:?}", other),
+        other => panic!("expected NdjsonError::Utf8, got {other:?}"),
     }
 }
 

--- a/aimux-stream/tests/sse_test.rs
+++ b/aimux-stream/tests/sse_test.rs
@@ -299,11 +299,10 @@ async fn chinese_sse_event_split_at_every_byte_boundary() {
         );
         let event = events[0]
             .as_ref()
-            .unwrap_or_else(|e| panic!("split at byte {} errored: {:?}", split, e));
+            .unwrap_or_else(|e| panic!("split at byte {split} errored: {e:?}"));
         assert_eq!(
             event.data, "你好世界",
-            "split at byte {} corrupted the data",
-            split
+            "split at byte {split} corrupted the data"
         );
     }
 }
@@ -319,7 +318,7 @@ async fn invalid_utf8_frame_returns_utf8_error() {
     assert_eq!(events.len(), 1, "expected exactly one result");
     match &events[0] {
         Err(SseError::Utf8(_)) => {}
-        other => panic!("expected SseError::Utf8, got {:?}", other),
+        other => panic!("expected SseError::Utf8, got {other:?}"),
     }
 }
 

--- a/scripts/gen_provider_names.py
+++ b/scripts/gen_provider_names.py
@@ -58,6 +58,7 @@ impl ProviderName {{
     ];
 
     /// The registry name (snake_case), e.g. `ProviderName::Groq -> "groq"`.
+    #[must_use]
     pub fn as_str(self) -> &'static str {{
         match self {{
 {arms_str}
@@ -65,6 +66,7 @@ impl ProviderName {{
     }}
 
     /// All registry names (for error messages / docs).
+    #[must_use]
     pub const fn all_names() -> &'static str {{
         "{','.join(names)}"
     }}


### PR DESCRIPTION
Fixes #120（Round 4 审计 p7 §1.1，校验后数字）

## 启用的 5 个 lint 与修复量

| lint | 修复 | 方式 |
|---|---|---|
| uninlined_format_args | ~558 | cargo clippy --fix（两轮收敛） |
| redundant_closure_for_method_calls | ~355 | 自动 |
| must_use_candidate | ~330 自动 + 5 测试 `let _ =` 连带 | 混合 |
| return_self_not_must_use | 109 | 手工 `#[must_use]` |
| missing_errors_doc | 146 | 手工——逐函数从错误路径归纳写实，34 个无文档 fn 顺带补摘要 |

不启用：doc_markdown / missing_const_for_fn / cast_possible_truncation（理由见 #120）。

## 验证

- `clippy --workspace --all-targets -- -D warnings` **0 告警**（CI 现有 -D warnings 门从此强制该子集）
- workspace 测试 **3,604 过 / 0 败** / 59 忽略；fmt 干净
- 238 文件 +2,484/−1,123

## 评审

独立评审全量核对 1,120 条删除行：**零行为变更**（仅 must_use/doc/格式串内联/闭包→方法引用/恒等换行重排）；20 个新 # Errors 段对照函数体属实；两处顺手修正（api_key.rs LoadAPIKeyError、bedrock_mantle.rs Auth→InvalidArgument）复核正确；测试无断言弱化；0 处新增 #[allow]。
唯一记录项：19 个文件的 UTF-8 BOM 被 --fix 顺带移除（零影响）。