### PR TITLE
test: unified e2e protocol expansion + FFI all-export smoke harness

### DIFF
--- a/aimux-ffi/src/lib.rs
+++ b/aimux-ffi/src/lib.rs
@@ -2728,8 +2728,9 @@ pub extern "C" fn aimux_trace_new_audited(handle: u64, strict: i32, err: *mut CA
 }
 
 /// Query: aggregated probe statistics, filtered by `filter_json` (a serialized
-/// `TraceFilter`, NULL = all). Returns JSON `TraceStats[]` or NULL on failure;
-/// caller frees with `aimux_free_string`.
+/// `TraceFilter`; pass `"{}"` for all rows — NULL is rejected as an invalid
+/// argument). Returns JSON `TraceStats[]` or NULL on failure; caller frees
+/// with `aimux_free_string`.
 #[unsafe(no_mangle)]
 pub extern "C" fn aimux_trace_aggregate(
     handle: u64,

--- a/aimux-ffi/tests/exports_smoke_test.rs
+++ b/aimux-ffi/tests/exports_smoke_test.rs
@@ -1,0 +1,1071 @@
+//! FFI export smoke harness (issue #119).
+//!
+//! A no-network smoke traversal of the C ABI surface in `aimux-ffi/src/lib.rs`.
+//! It does NOT verify protocol behaviour — wiremock round-trips live in
+//! `aimux-providers/tests/e2e_test.rs` — it verifies that every exported
+//! symbol can be called from a C-style caller without panicking and honours
+//! the ABI contract:
+//!
+//! - **Constructor class** (`*_new` / `*_new_with_base` / composites): fake
+//!   API key + `base_url` pointing at a loopback port nothing listens on
+//!   (`http://127.0.0.1:1`) → must return a non-zero handle, which is then
+//!   released with [`aimux_ffi::aimux_drop_handle`]. Constructors that cannot
+//!   take a base URL (e.g. `aimux_provider_from_env`) are only checked for a
+//!   clean handle-or-error outcome.
+//! - **Utility class**: called directly with minimal/empty arguments; asserts
+//!   a sane return value, never a panic.
+//! - **Session class** (generate / stream / embed / speech / image /
+//!   transcription / rerank / video / search / files): handle + minimal
+//!   options against the unreachable base URL → must return the failure
+//!   sentinel with `CAimuxError` filled (a clean error path). Text calls pass
+//!   `{"max_retries":0}` to skip the retry backoff; the multimodal option
+//!   structs expose no retry override, so those tests run as separate
+//!   `#[test]`s to parallelise the default backoff.
+//! - Every `CAimuxError.message` / `error_value` and every returned JSON
+//!   string is released with [`aimux_ffi::aimux_free_string`].
+//!
+//! ## Coverage
+//!
+//! 96 of the 96 `#[unsafe(no_mangle)]` exports in `src/lib.rs` are exercised
+//! (the constructor and utility classes in full; the session class one
+//! representative call per export — every export is still touched):
+//! - constructors: 49 (9 native protocol pairs + multimodal pairs +
+//!   provider/trace/router/moa/abort/mock-replay factories)
+//! - session-class calls: 25 (text generate ×4, stream ×4, multimodal ×8,
+//!   transcription session ×5, provider discovery + catalogue + codex ×4)
+//! - utility: 22 (handle/string lifecycle, session + trace queries,
+//!   recording ×6, logging, proxy, provider registration)
+
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_void};
+use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use aimux_ffi::{
+    AIMUX_E_JSON_PARSE, AIMUX_OK, CAimuxError, aimux_abort_signal_abort, aimux_abort_signal_drop,
+    aimux_abort_signal_new, aimux_anthropic_aws_new, aimux_anthropic_aws_new_with_base,
+    aimux_anthropic_new, aimux_anthropic_new_with_base, aimux_azure_new, aimux_azure_new_with_base,
+    aimux_bedrock_new, aimux_bedrock_new_with_base, aimux_codex_refresh,
+    aimux_cohere_embedding_new, aimux_cohere_embedding_new_with_base, aimux_cohere_new,
+    aimux_cohere_new_with_base, aimux_cohere_reranking_new, aimux_cohere_reranking_new_with_base,
+    aimux_consume_stream_text, aimux_drop_handle, aimux_embed, aimux_file_upload,
+    aimux_free_string, aimux_generate_object, aimux_generate_text, aimux_generate_text_as_openai,
+    aimux_get_model_specs, aimux_google_embedding_new, aimux_google_embedding_new_with_base,
+    aimux_google_image_new, aimux_google_image_new_with_base, aimux_google_video_new,
+    aimux_google_video_new_with_base, aimux_image_generate, aimux_init_logging, aimux_init_proxy,
+    aimux_init_recording, aimux_init_recording_ring, aimux_init_recording_ring_default,
+    aimux_list_sessions, aimux_mistral_new, aimux_mistral_new_with_base, aimux_moa_new,
+    aimux_mock_replay_new, aimux_openai_embedding_new, aimux_openai_embedding_new_with_base,
+    aimux_openai_files_new, aimux_openai_files_new_with_base, aimux_openai_image_new,
+    aimux_openai_image_new_with_base, aimux_openai_new, aimux_openai_new_with_base,
+    aimux_openai_speech_new, aimux_openai_speech_new_with_base, aimux_openai_transcription_new,
+    aimux_openai_transcription_new_with_base, aimux_provider_from_env, aimux_provider_handle_new,
+    aimux_provider_list_models, aimux_provider_model, aimux_provider_new, aimux_recording_flush,
+    aimux_recording_stop, aimux_recording_try_flush, aimux_register_providers, aimux_rerank,
+    aimux_router_new, aimux_search, aimux_session_calls, aimux_session_infer_init,
+    aimux_session_store_init, aimux_speech_generate, aimux_stream_text,
+    aimux_stream_text_as_openai, aimux_stream_text_as_openai_with_abort,
+    aimux_stream_text_with_abort, aimux_tavily_search_new, aimux_tavily_search_new_with_base,
+    aimux_trace_aggregate, aimux_trace_clear, aimux_trace_export_jsonl, aimux_trace_new,
+    aimux_trace_new_audited, aimux_trace_session_chain, aimux_trace_session_trajectory,
+    aimux_transcription_generate, aimux_transcription_input_done, aimux_transcription_next_part,
+    aimux_transcription_push_audio, aimux_transcription_session_drop,
+    aimux_transcription_session_new, aimux_vertex_new, aimux_vertex_new_with_base,
+    aimux_video_generate, aimux_xai_new, aimux_xai_new_with_base,
+};
+
+/// Loopback port that nothing listens on: connections are refused (fast,
+/// deterministic) on every platform. Through an HTTP proxy it surfaces as a
+/// proxy error — either way a clean transport error, never a hang.
+const UNREACHABLE: &str = "http://127.0.0.1:1";
+
+const FAKE_KEY: &str = "sk-ffi-smoke-fake-key";
+
+// ── harness helpers ─────────────────────────────────────────────────────────
+
+fn c(s: &str) -> CString {
+    CString::new(s).expect("CString::new: no interior NUL in harness literals")
+}
+
+fn fresh_err() -> CAimuxError {
+    CAimuxError {
+        code: AIMUX_OK,
+        status: -1,
+        retry_ms: -1,
+        message: ptr::null_mut(),
+        error_value: ptr::null_mut(),
+        reserved: [ptr::null_mut(); 1],
+    }
+}
+
+fn err_message(err: &CAimuxError) -> String {
+    if err.message.is_null() {
+        return String::new();
+    }
+    // SAFETY: `message` is an owned NUL-terminated string filled by the FFI
+    // layer for this error slot (aimux-error.h contract).
+    unsafe { CStr::from_ptr(err.message) }
+        .to_str()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Release the strings the FFI layer allocated inside `err`.
+fn release_err(err: &mut CAimuxError) {
+    // SAFETY: both pointers, when non-null, were produced by `into_cstring_raw`
+    // on the Rust side and are owned by this error slot.
+    unsafe {
+        aimux_free_string(err.message);
+        aimux_free_string(err.error_value);
+    }
+    err.message = ptr::null_mut();
+    err.error_value = ptr::null_mut();
+}
+
+fn expect_handle(h: u64, name: &str) {
+    assert_ne!(h, 0, "{name}: expected a non-zero handle");
+}
+
+/// The smoke contract for failure returns: failure sentinel + `err` filled
+/// with a non-OK code and a non-empty, freeable message.
+fn expect_clean_failure(code: i32, message: &str, name: &str) {
+    assert_ne!(code, AIMUX_OK, "{name}: expected a non-OK error code");
+    assert!(
+        !message.is_empty(),
+        "{name}: expected a non-empty error message"
+    );
+}
+
+fn expect_ptr_failure(out: *mut c_char, err: &CAimuxError, name: &str) {
+    assert!(out.is_null(), "{name}: expected NULL on failure");
+    expect_clean_failure(err.code, &err_message(err), name);
+}
+
+fn expect_i32_failure(rc: i32, err: &CAimuxError, name: &str) {
+    assert_eq!(rc, 0, "{name}: expected 0 on failure");
+    expect_clean_failure(err.code, &err_message(err), name);
+}
+
+fn expect_u64_failure(h: u64, err: &CAimuxError, name: &str) {
+    assert_eq!(h, 0, "{name}: expected handle 0 on failure");
+    expect_clean_failure(err.code, &err_message(err), name);
+}
+
+/// For constructors whose inputs cannot be fully controlled (env-var key):
+/// either a live handle or a clean failure is acceptable — a panic is not.
+fn expect_handle_or_clean_failure(h: u64, err: &CAimuxError, name: &str) {
+    if h != 0 {
+        return;
+    }
+    expect_clean_failure(err.code, &err_message(err), name);
+}
+
+/// Read a returned JSON string, assert it is non-empty, and free it.
+fn read_and_free_json(out: *mut c_char, name: &str) -> String {
+    assert!(!out.is_null(), "{name}: expected a non-NULL JSON string");
+    // SAFETY: `out` is an owned NUL-terminated C string returned by the FFI.
+    let s = unsafe { CStr::from_ptr(out) }
+        .to_string_lossy()
+        .into_owned();
+    assert!(!s.is_empty(), "{name}: expected a non-empty JSON payload");
+    // SAFETY: `out` was allocated by the FFI layer for the caller to free.
+    unsafe { aimux_free_string(out) };
+    s
+}
+
+/// An OpenAI model handle bound to the unreachable base URL (session-class
+/// smoke input; `max_retries:0` is passed per-call via opts).
+fn unreachable_model(err: *mut CAimuxError) -> u64 {
+    aimux_openai_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("gpt-4o-mini").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        err,
+    )
+}
+
+// ── no-op stream callbacks (must never re-enter the FFI layer) ──────────────
+
+static PARTS_SEEN: AtomicUsize = AtomicUsize::new(0);
+static DONE_SEEN: AtomicUsize = AtomicUsize::new(0);
+
+extern "C" fn smoke_on_part(_json: *const c_char, _ctx: *mut c_void) {
+    PARTS_SEEN.fetch_add(1, Ordering::Relaxed);
+}
+
+extern "C" fn smoke_on_done(_ctx: *mut c_void) {
+    DONE_SEEN.fetch_add(1, Ordering::Relaxed);
+}
+
+// ── constructor class (49 exports) ──────────────────────────────────────────
+
+#[test]
+fn constructor_exports_build_and_release_handles() {
+    let key = c(FAKE_KEY);
+    let secret = c("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+    let region = c("us-east-1");
+    let token = c("ya29.ffi-smoke-token");
+    let project = c("ffi-smoke-project");
+    let location = c("us-central1");
+    let resource = c("ffi-smoke-resource");
+    let base = c(UNREACHABLE);
+    let mut err = fresh_err();
+
+    // Simple key constructors + with_base variants.
+    expect_handle(
+        aimux_openai_new(key.as_ptr(), c("gpt-4o-mini").as_ptr(), &mut err),
+        "openai_new",
+    );
+    expect_handle(
+        aimux_openai_new_with_base(
+            key.as_ptr(),
+            c("gpt-4o-mini").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "openai_new_with_base",
+    );
+    expect_handle(
+        aimux_anthropic_new(
+            key.as_ptr(),
+            c("claude-3-5-sonnet-latest").as_ptr(),
+            &mut err,
+        ),
+        "anthropic_new",
+    );
+    expect_handle(
+        aimux_anthropic_new_with_base(
+            key.as_ptr(),
+            c("claude-3-5-sonnet-latest").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "anthropic_new_with_base",
+    );
+    expect_handle(
+        aimux_cohere_new(key.as_ptr(), c("command-r-plus").as_ptr(), &mut err),
+        "cohere_new",
+    );
+    expect_handle(
+        aimux_cohere_new_with_base(
+            key.as_ptr(),
+            c("command-r-plus").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "cohere_new_with_base",
+    );
+    expect_handle(
+        aimux_mistral_new(key.as_ptr(), c("mistral-small-latest").as_ptr(), &mut err),
+        "mistral_new",
+    );
+    expect_handle(
+        aimux_mistral_new_with_base(
+            key.as_ptr(),
+            c("mistral-small-latest").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "mistral_new_with_base",
+    );
+    expect_handle(
+        aimux_xai_new(key.as_ptr(), c("grok-3").as_ptr(), &mut err),
+        "xai_new",
+    );
+    expect_handle(
+        aimux_xai_new_with_base(key.as_ptr(), c("grok-3").as_ptr(), base.as_ptr(), &mut err),
+        "xai_new_with_base",
+    );
+
+    // Credential constructors.
+    expect_handle(
+        aimux_anthropic_aws_new(
+            key.as_ptr(),
+            region.as_ptr(),
+            c("anthropic.claude-3-5-sonnet-20240620-v1:0").as_ptr(),
+            &mut err,
+        ),
+        "anthropic_aws_new",
+    );
+    expect_handle(
+        aimux_anthropic_aws_new_with_base(
+            key.as_ptr(),
+            region.as_ptr(),
+            c("anthropic.claude-3-5-sonnet-20240620-v1:0").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "anthropic_aws_new_with_base",
+    );
+    expect_handle(
+        aimux_azure_new(
+            key.as_ptr(),
+            resource.as_ptr(),
+            c("gpt-4o").as_ptr(),
+            ptr::null(),
+            &mut err,
+        ),
+        "azure_new",
+    );
+    expect_handle(
+        aimux_azure_new_with_base(
+            key.as_ptr(),
+            base.as_ptr(),
+            c("gpt-4o").as_ptr(),
+            ptr::null(),
+            &mut err,
+        ),
+        "azure_new_with_base",
+    );
+    expect_handle(
+        aimux_bedrock_new(
+            key.as_ptr(),
+            secret.as_ptr(),
+            region.as_ptr(),
+            c("anthropic.claude-3-5-sonnet-20240620-v1:0").as_ptr(),
+            &mut err,
+        ),
+        "bedrock_new",
+    );
+    expect_handle(
+        aimux_bedrock_new_with_base(
+            key.as_ptr(),
+            secret.as_ptr(),
+            region.as_ptr(),
+            c("anthropic.claude-3-5-sonnet-20240620-v1:0").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "bedrock_new_with_base",
+    );
+    expect_handle(
+        aimux_vertex_new(
+            token.as_ptr(),
+            project.as_ptr(),
+            location.as_ptr(),
+            c("gemini-2.0-flash").as_ptr(),
+            &mut err,
+        ),
+        "vertex_new",
+    );
+    expect_handle(
+        aimux_vertex_new_with_base(
+            token.as_ptr(),
+            project.as_ptr(),
+            location.as_ptr(),
+            c("gemini-2.0-flash").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "vertex_new_with_base",
+    );
+
+    // Multimodal constructors.
+    expect_handle(
+        aimux_openai_embedding_new(key.as_ptr(), c("text-embedding-3-small").as_ptr(), &mut err),
+        "openai_embedding_new",
+    );
+    expect_handle(
+        aimux_openai_embedding_new_with_base(
+            key.as_ptr(),
+            c("text-embedding-3-small").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "openai_embedding_new_with_base",
+    );
+    expect_handle(
+        aimux_cohere_embedding_new(key.as_ptr(), c("embed-english-v3.0").as_ptr(), &mut err),
+        "cohere_embedding_new",
+    );
+    expect_handle(
+        aimux_cohere_embedding_new_with_base(
+            key.as_ptr(),
+            c("embed-english-v3.0").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "cohere_embedding_new_with_base",
+    );
+    expect_handle(
+        aimux_google_embedding_new(key.as_ptr(), c("text-embedding-004").as_ptr(), &mut err),
+        "google_embedding_new",
+    );
+    expect_handle(
+        aimux_google_embedding_new_with_base(
+            key.as_ptr(),
+            c("text-embedding-004").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "google_embedding_new_with_base",
+    );
+    expect_handle(
+        aimux_openai_speech_new(key.as_ptr(), c("tts-1").as_ptr(), &mut err),
+        "openai_speech_new",
+    );
+    expect_handle(
+        aimux_openai_speech_new_with_base(
+            key.as_ptr(),
+            c("tts-1").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "openai_speech_new_with_base",
+    );
+    expect_handle(
+        aimux_openai_image_new(key.as_ptr(), c("gpt-image-1").as_ptr(), &mut err),
+        "openai_image_new",
+    );
+    expect_handle(
+        aimux_openai_image_new_with_base(
+            key.as_ptr(),
+            c("gpt-image-1").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "openai_image_new_with_base",
+    );
+    expect_handle(
+        aimux_google_image_new(
+            key.as_ptr(),
+            c("imagen-4.0-generate-001").as_ptr(),
+            &mut err,
+        ),
+        "google_image_new",
+    );
+    expect_handle(
+        aimux_google_image_new_with_base(
+            key.as_ptr(),
+            c("imagen-4.0-generate-001").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "google_image_new_with_base",
+    );
+    expect_handle(
+        aimux_openai_transcription_new(key.as_ptr(), c("whisper-1").as_ptr(), &mut err),
+        "openai_transcription_new",
+    );
+    expect_handle(
+        aimux_openai_transcription_new_with_base(
+            key.as_ptr(),
+            c("whisper-1").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "openai_transcription_new_with_base",
+    );
+    expect_handle(
+        aimux_openai_files_new(key.as_ptr(), &mut err),
+        "openai_files_new",
+    );
+    expect_handle(
+        aimux_openai_files_new_with_base(key.as_ptr(), base.as_ptr(), &mut err),
+        "openai_files_new_with_base",
+    );
+    expect_handle(
+        aimux_cohere_reranking_new(key.as_ptr(), c("rerank-v3.5").as_ptr(), &mut err),
+        "cohere_reranking_new",
+    );
+    expect_handle(
+        aimux_cohere_reranking_new_with_base(
+            key.as_ptr(),
+            c("rerank-v3.5").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "cohere_reranking_new_with_base",
+    );
+    expect_handle(
+        aimux_google_video_new(key.as_ptr(), c("veo-3.0-generate-001").as_ptr(), &mut err),
+        "google_video_new",
+    );
+    expect_handle(
+        aimux_google_video_new_with_base(
+            key.as_ptr(),
+            c("veo-3.0-generate-001").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "google_video_new_with_base",
+    );
+    expect_handle(
+        aimux_tavily_search_new(key.as_ptr(), c("tavily").as_ptr(), &mut err),
+        "tavily_search_new",
+    );
+    expect_handle(
+        aimux_tavily_search_new_with_base(
+            key.as_ptr(),
+            c("tavily").as_ptr(),
+            base.as_ptr(),
+            &mut err,
+        ),
+        "tavily_search_new_with_base",
+    );
+
+    // Registry-backed constructors (RFC-0017 / RFC-0027).
+    let provider_opts = c(r#"{"base_url":"http://127.0.0.1:1","max_retries":0}"#);
+    expect_handle(
+        aimux_provider_new(
+            c("groq").as_ptr(),
+            key.as_ptr(),
+            c("llama-3.3-70b-versatile").as_ptr(),
+            provider_opts.as_ptr(),
+            &mut err,
+        ),
+        "provider_new",
+    );
+    expect_handle(
+        aimux_provider_handle_new(
+            c("groq").as_ptr(),
+            key.as_ptr(),
+            provider_opts.as_ptr(),
+            &mut err,
+        ),
+        "provider_handle_new",
+    );
+
+    // Composite wrappers over an unreachable model handle.
+    let model = unreachable_model(&mut err);
+    expect_handle(model, "openai_new_with_base (composite base)");
+    let traced = aimux_trace_new(model, &mut err);
+    expect_handle(traced, "trace_new");
+    let audited = aimux_trace_new_audited(model, 0, &mut err);
+    expect_handle(audited, "trace_new_audited");
+    let children = [traced, audited];
+    let router = aimux_router_new(children.as_ptr(), children.len(), ptr::null(), &mut err);
+    expect_handle(router, "router_new");
+    let moa = aimux_moa_new(
+        children.as_ptr(),
+        children.len(),
+        model,
+        ptr::null(),
+        &mut err,
+    );
+    expect_handle(moa, "moa_new");
+    expect_handle(aimux_abort_signal_new(), "abort_signal_new");
+
+    // Release every handle created above (aimux_drop_handle is safe with 0).
+    for h in [traced, audited, router, moa, model] {
+        aimux_drop_handle(h);
+    }
+
+    // mock_replay_new: empty input must fail cleanly (no recordings) — the
+    // success path needs a real Recording, covered by replay tests elsewhere.
+    let mut replay_err = fresh_err();
+    let h = aimux_mock_replay_new(c("").as_ptr(), &mut replay_err);
+    expect_u64_failure(h, &replay_err, "mock_replay_new (empty jsonl)");
+    release_err(&mut replay_err);
+
+    // None of the successful constructors above filled the shared error slot.
+    assert_eq!(
+        err.code, AIMUX_OK,
+        "successful constructors must not fill err"
+    );
+}
+
+/// `provider_from_env` reads the provider's env var, which the harness cannot
+/// control: a live handle or a clean missing-key error are both correct.
+#[test]
+fn provider_from_env_handle_or_clean_failure() {
+    let mut err = fresh_err();
+    let h = aimux_provider_from_env(
+        c("groq").as_ptr(),
+        c("llama-3.3-70b-versatile").as_ptr(),
+        &mut err,
+    );
+    expect_handle_or_clean_failure(h, &err, "provider_from_env");
+    if h != 0 {
+        aimux_drop_handle(h);
+    }
+    release_err(&mut err);
+}
+
+// ── session class: text generation (4 exports) ──────────────────────────────
+
+#[test]
+fn text_generation_exports_fail_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = unreachable_model(&mut err);
+    expect_handle(h, "model handle");
+
+    let prompt = c("\"ffi smoke\"");
+    let opts = c(r#"{"max_retries":0}"#);
+
+    let out = aimux_generate_text(h, prompt.as_ptr(), opts.as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "generate_text");
+    release_err(&mut err);
+
+    let out = aimux_generate_object(h, prompt.as_ptr(), opts.as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "generate_object");
+    release_err(&mut err);
+
+    let out = aimux_consume_stream_text(h, prompt.as_ptr(), opts.as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "consume_stream_text");
+    release_err(&mut err);
+
+    let out = aimux_generate_text_as_openai(h, prompt.as_ptr(), opts.as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "generate_text_as_openai");
+    release_err(&mut err);
+
+    aimux_drop_handle(h);
+}
+
+// ── session class: streaming with callbacks (4 exports) ─────────────────────
+
+#[test]
+fn streaming_exports_fail_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = unreachable_model(&mut err);
+    expect_handle(h, "model handle");
+
+    let prompt = c("\"ffi smoke\"");
+    let opts = c(r#"{"max_retries":0}"#);
+
+    let rc = aimux_stream_text(
+        h,
+        prompt.as_ptr(),
+        opts.as_ptr(),
+        smoke_on_part,
+        smoke_on_done,
+        ptr::null_mut(),
+        &mut err,
+    );
+    expect_i32_failure(rc, &err, "stream_text");
+    release_err(&mut err);
+
+    let abort = aimux_abort_signal_new();
+    let rc = aimux_stream_text_with_abort(
+        h,
+        abort,
+        prompt.as_ptr(),
+        opts.as_ptr(),
+        smoke_on_part,
+        smoke_on_done,
+        ptr::null_mut(),
+        &mut err,
+    );
+    expect_i32_failure(rc, &err, "stream_text_with_abort");
+    release_err(&mut err);
+
+    let rc = aimux_stream_text_as_openai(
+        h,
+        prompt.as_ptr(),
+        opts.as_ptr(),
+        smoke_on_part,
+        smoke_on_done,
+        ptr::null_mut(),
+        &mut err,
+    );
+    expect_i32_failure(rc, &err, "stream_text_as_openai");
+    release_err(&mut err);
+
+    let rc = aimux_stream_text_as_openai_with_abort(
+        h,
+        abort,
+        prompt.as_ptr(),
+        opts.as_ptr(),
+        smoke_on_part,
+        smoke_on_done,
+        ptr::null_mut(),
+        &mut err,
+    );
+    expect_i32_failure(rc, &err, "stream_text_as_openai_with_abort");
+    release_err(&mut err);
+
+    aimux_abort_signal_drop(abort);
+    aimux_drop_handle(h);
+}
+
+// ── session class: multimodal generation (8 exports, one per test to
+// parallelise the default retry backoff — their option structs expose no
+// max_retries override) ───────────────────────────────────────────────────────
+
+#[test]
+fn embed_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = aimux_openai_embedding_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("text-embedding-3-small").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(h, "embedding handle");
+    let out = aimux_embed(
+        h,
+        c(r#"["hello"]"#).as_ptr(),
+        c(r#"{"values":[]}"#).as_ptr(),
+        &mut err,
+    );
+    expect_ptr_failure(out, &err, "embed");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn speech_generate_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = aimux_openai_speech_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("tts-1").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(h, "speech handle");
+    let out = aimux_speech_generate(h, c(r#"{"text":"ffi smoke"}"#).as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "speech_generate");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn image_generate_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = aimux_openai_image_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("gpt-image-1").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(h, "image handle");
+    let opts = c(r#"{"prompt":"a rust crab","n":1,"provider_options":{}}"#);
+    let out = aimux_image_generate(h, opts.as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "image_generate");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn transcription_generate_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = aimux_openai_transcription_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("whisper-1").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(h, "transcription handle");
+    let out = aimux_transcription_generate(
+        h,
+        c("ZmFrZS1hdWRpbw==").as_ptr(),
+        c("audio/wav").as_ptr(),
+        ptr::null(),
+        &mut err,
+    );
+    expect_ptr_failure(out, &err, "transcription_generate");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn file_upload_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h =
+        aimux_openai_files_new_with_base(c(FAKE_KEY).as_ptr(), c(UNREACHABLE).as_ptr(), &mut err);
+    expect_handle(h, "files handle");
+    let out = aimux_file_upload(
+        h,
+        c("ZmFrZS1maWxl").as_ptr(),
+        c("text/plain").as_ptr(),
+        ptr::null(),
+        &mut err,
+    );
+    expect_ptr_failure(out, &err, "file_upload");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn rerank_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = aimux_cohere_reranking_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("rerank-v3.5").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(h, "reranking handle");
+    let opts = c(r#"{"query":"rust","documents":{"Text":{"values":["a","b"]}}}"#);
+    let out = aimux_rerank(h, opts.as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "rerank");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn video_generate_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = aimux_google_video_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("veo-3.0-generate-001").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(h, "video handle");
+    let opts = c(r#"{"prompt":"waves","n":1,"provider_options":{}}"#);
+    let out = aimux_video_generate(h, opts.as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "video_generate");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+#[test]
+fn search_fails_cleanly_on_unreachable_host() {
+    let mut err = fresh_err();
+    let h = aimux_tavily_search_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("tavily").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(h, "search handle");
+    let out = aimux_search(h, c(r#"{"query":"ffi smoke"}"#).as_ptr(), &mut err);
+    expect_ptr_failure(out, &err, "search");
+    release_err(&mut err);
+    aimux_drop_handle(h);
+}
+
+// ── session class: transcription streaming session (5 exports) ──────────────
+
+#[test]
+fn transcription_session_reaches_clean_terminal_error() {
+    let mut err = fresh_err();
+    let model = aimux_openai_transcription_new_with_base(
+        c(FAKE_KEY).as_ptr(),
+        c("whisper-1").as_ptr(),
+        c(UNREACHABLE).as_ptr(),
+        &mut err,
+    );
+    expect_handle(model, "transcription handle");
+
+    let session = aimux_transcription_session_new(model, 0, ptr::null(), &mut err);
+    expect_handle(session, "transcription_session_new");
+
+    // The driver fails on the unreachable host; pull parts until the stream
+    // reaches its terminal NULL (error or end) within a bounded number of
+    // timed pulls. This is exactly the smoke point: a clean error path.
+    let mut reached_terminal = false;
+    for _ in 0..3 {
+        let mut err = fresh_err();
+        let part = aimux_transcription_next_part(session, 3_000, &mut err);
+        if part.is_null() {
+            release_err(&mut err);
+            reached_terminal = true;
+            break;
+        }
+        read_and_free_json(part, "transcription part");
+    }
+    assert!(
+        reached_terminal,
+        "session must reach a terminal NULL within a few pulls"
+    );
+
+    // After the terminal state a push is either rejected (0 + err) or still
+    // buffered (1) — both clean, non-panicking outcomes.
+    let mut err = fresh_err();
+    let chunk = [0u8, 1, 2, 3];
+    let _ = aimux_transcription_push_audio(session, chunk.as_ptr(), chunk.len(), &mut err);
+    release_err(&mut err);
+
+    assert_eq!(
+        aimux_transcription_input_done(session, ptr::null_mut()),
+        1,
+        "input_done on a live session handle must succeed"
+    );
+
+    // Drop, then verify the handle is gone (clean failure, no panic).
+    aimux_transcription_session_drop(session);
+    let mut err = fresh_err();
+    assert_eq!(
+        aimux_transcription_push_audio(session, chunk.as_ptr(), chunk.len(), &mut err),
+        0,
+        "push after drop must fail"
+    );
+    release_err(&mut err);
+    aimux_drop_handle(model);
+}
+
+// ── session class: provider discovery + catalogue + codex (4 exports) ───────
+
+#[test]
+fn provider_discovery_and_catalogue_exports_fail_cleanly() {
+    let mut err = fresh_err();
+    // Provider handle bound to the unreachable host with retries disabled.
+    let provider = aimux_provider_handle_new(
+        c("groq").as_ptr(),
+        c(FAKE_KEY).as_ptr(),
+        c(r#"{"base_url":"http://127.0.0.1:1","max_retries":0}"#).as_ptr(),
+        &mut err,
+    );
+    expect_handle(provider, "provider_handle_new");
+
+    let models = aimux_provider_list_models(provider, &mut err);
+    expect_ptr_failure(models, &err, "provider_list_models");
+    release_err(&mut err);
+
+    let model = aimux_provider_model(provider, c("llama-3.3-70b-versatile").as_ptr(), &mut err);
+    expect_handle(model, "provider_model");
+    aimux_drop_handle(model);
+    aimux_drop_handle(provider);
+
+    // Catalogue fetch pointed at the unreachable host.
+    let specs = aimux_get_model_specs(c(UNREACHABLE).as_ptr(), &mut err);
+    expect_ptr_failure(specs, &err, "get_model_specs");
+    release_err(&mut err);
+
+    // Codex OAuth refresh: NULL args fail cleanly at the boundary without
+    // touching the network.
+    let out = aimux_codex_refresh(ptr::null(), ptr::null(), &mut err);
+    expect_ptr_failure(out, &err, "codex_refresh (null args)");
+    release_err(&mut err);
+}
+
+// ── utility class: lifecycle, sessions, config (10 exports) ─────────────────
+
+#[test]
+fn utility_exports_return_clean_values() {
+    assert_eq!(aimux_init_logging(c("warn").as_ptr()), 0, "init_logging");
+    assert_eq!(aimux_session_store_init(), 0, "session_store_init");
+    assert_eq!(aimux_session_infer_init(0), 0, "session_infer_init");
+
+    let mut err = fresh_err();
+    let calls = aimux_session_calls(c("ffi-smoke-session").as_ptr(), &mut err);
+    let calls = read_and_free_json(calls, "session_calls");
+    assert!(calls.starts_with('['), "session_calls returns a JSON array");
+
+    let sessions = aimux_list_sessions(&mut err);
+    let sessions = read_and_free_json(sessions, "list_sessions");
+    assert!(
+        sessions.starts_with('['),
+        "list_sessions returns a JSON array"
+    );
+
+    // Abort-signal lifecycle.
+    let abort = aimux_abort_signal_new();
+    aimux_abort_signal_abort(abort); // idempotent no-op on valid handle
+    aimux_abort_signal_abort(abort);
+    aimux_abort_signal_drop(abort);
+    aimux_abort_signal_drop(0); // safe with 0
+
+    // aimux_drop_handle(0) is documented as a safe no-op.
+    aimux_drop_handle(0);
+
+    // register_providers: valid overlay then a malformed config.
+    let valid = c(
+        r#"{"providers":[{"name":"ffi-smoke-provider","base_url":"http://127.0.0.1:1/v1","protocol":"openai_compat"}]}"#,
+    );
+    assert_eq!(
+        aimux_register_providers(valid.as_ptr(), ptr::null_mut()),
+        1,
+        "register_providers (valid)"
+    );
+    let mut err = fresh_err();
+    assert_eq!(
+        aimux_register_providers(c("{not json").as_ptr(), &mut err),
+        0,
+        "register_providers (malformed)"
+    );
+    assert_eq!(err.code, AIMUX_E_JSON_PARSE);
+    release_err(&mut err);
+
+    // Empty proxy config is the documented no-op-style success.
+    assert_eq!(
+        aimux_init_proxy(c("{}").as_ptr(), ptr::null_mut()),
+        1,
+        "init_proxy"
+    );
+}
+
+// ── utility class: trace queries (5 exports) ────────────────────────────────
+
+#[test]
+fn trace_query_exports_return_clean_values() {
+    let mut err = fresh_err();
+    let model = unreachable_model(&mut err);
+    expect_handle(model, "model handle");
+    let traced = aimux_trace_new(model, &mut err);
+    expect_handle(traced, "trace handle");
+
+    // Empty filter `{}` = all (TraceFilter is all-Option).
+    let stats = aimux_trace_aggregate(traced, c("{}").as_ptr(), &mut err);
+    let stats = read_and_free_json(stats, "trace_aggregate");
+    assert!(
+        stats.starts_with('['),
+        "trace_aggregate returns a JSON array"
+    );
+
+    // Unknown session: documented clean failure.
+    let chain = aimux_trace_session_chain(traced, c("ffi-smoke-unknown").as_ptr(), &mut err);
+    expect_ptr_failure(chain, &err, "trace_session_chain (unknown session)");
+    release_err(&mut err);
+
+    let trajectory =
+        aimux_trace_session_trajectory(traced, c("ffi-smoke-unknown").as_ptr(), &mut err);
+    let trajectory = read_and_free_json(trajectory, "trace_session_trajectory");
+    assert!(
+        trajectory.starts_with('['),
+        "trace_session_trajectory returns a JSON array"
+    );
+
+    let jsonl_ptr = aimux_trace_export_jsonl(traced, &mut err);
+    assert!(
+        !jsonl_ptr.is_null(),
+        "trace_export_jsonl must return a string"
+    );
+    // SAFETY: `jsonl_ptr` is an owned NUL-terminated C string returned by the
+    // FFI layer; read it, then hand the original pointer back for freeing.
+    let jsonl = unsafe { CStr::from_ptr(jsonl_ptr) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { aimux_free_string(jsonl_ptr) };
+    assert!(
+        jsonl.is_empty() || jsonl.lines().all(|l| !l.trim().is_empty()),
+        "trace_export_jsonl is empty-or-JSONL"
+    );
+
+    assert_eq!(aimux_trace_clear(traced), 0, "trace_clear on live handle");
+    assert_eq!(
+        aimux_trace_clear(999_999),
+        -1,
+        "trace_clear on unknown handle"
+    );
+
+    aimux_drop_handle(traced);
+    aimux_drop_handle(model);
+}
+
+// ── utility class: recording (6 exports) ────────────────────────────────────
+
+#[test]
+fn recording_exports_lifecycle_cleanly() {
+    // cap == 0 is the documented failure.
+    assert_eq!(aimux_init_recording_ring(0), -1, "init_recording_ring(0)");
+
+    assert_eq!(aimux_init_recording_ring(8), 0, "init_recording_ring");
+    assert_eq!(aimux_recording_flush(), 0, "recording_flush");
+    assert_eq!(aimux_recording_try_flush(), AIMUX_OK, "recording_try_flush");
+
+    // File-backed recorder in a throwaway temp dir.
+    let dir = std::env::temp_dir().join(format!("aimux-ffi-smoke-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    assert_eq!(
+        aimux_init_recording(c(dir.to_str().expect("utf8 temp dir")).as_ptr()),
+        0,
+        "init_recording"
+    );
+
+    assert_eq!(
+        aimux_init_recording_ring_default(),
+        0,
+        "init_recording_ring_default"
+    );
+    assert_eq!(aimux_recording_stop(), 0, "recording_stop");
+    assert_eq!(aimux_recording_flush(), 0, "recording_flush after stop");
+    assert_eq!(
+        aimux_recording_try_flush(),
+        AIMUX_OK,
+        "recording_try_flush after stop"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/aimux-ffi/tests/exports_smoke_test.rs
+++ b/aimux-ffi/tests/exports_smoke_test.rs
@@ -10,6 +10,10 @@
 //!   API key + `base_url` pointing at a loopback port nothing listens on
 //!   (`http://127.0.0.1:1`) → must return a non-zero handle, which is then
 //!   released with [`aimux_ffi::aimux_drop_handle`]. Constructors that cannot
+//!
+//! Note: multimodal session smoke calls use the default RetryConfig
+//! (2 retries) against a refused port; under `--test-threads=1` this adds
+//! roughly a minute of backoff sleep — run the default parallel profile.
 //!   take a base URL (e.g. `aimux_provider_from_env`) are only checked for a
 //!   clean handle-or-error outcome.
 //! - **Utility class**: called directly with minimal/empty arguments; asserts
@@ -122,8 +126,9 @@ fn release_err(err: &mut CAimuxError) {
     err.error_value = ptr::null_mut();
 }
 
-fn expect_handle(h: u64, name: &str) {
+fn expect_handle(h: u64, name: &str) -> u64 {
     assert_ne!(h, 0, "{name}: expected a non-zero handle");
+    h
 }
 
 /// The smoke contract for failure returns: failure sentinel + `err` filled
@@ -201,6 +206,8 @@ extern "C" fn smoke_on_done(_ctx: *mut c_void) {
 
 #[test]
 fn constructor_exports_build_and_release_handles() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let key = c(FAKE_KEY);
     let secret = c("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     let region = c("us-east-1");
@@ -212,11 +219,11 @@ fn constructor_exports_build_and_release_handles() {
     let mut err = fresh_err();
 
     // Simple key constructors + with_base variants.
-    expect_handle(
+    handles.push(expect_handle(
         aimux_openai_new(key.as_ptr(), c("gpt-4o-mini").as_ptr(), &mut err),
         "openai_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_new_with_base(
             key.as_ptr(),
             c("gpt-4o-mini").as_ptr(),
@@ -224,16 +231,16 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "openai_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_anthropic_new(
             key.as_ptr(),
             c("claude-3-5-sonnet-latest").as_ptr(),
             &mut err,
         ),
         "anthropic_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_anthropic_new_with_base(
             key.as_ptr(),
             c("claude-3-5-sonnet-latest").as_ptr(),
@@ -241,12 +248,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "anthropic_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_cohere_new(key.as_ptr(), c("command-r-plus").as_ptr(), &mut err),
         "cohere_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_cohere_new_with_base(
             key.as_ptr(),
             c("command-r-plus").as_ptr(),
@@ -254,12 +261,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "cohere_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_mistral_new(key.as_ptr(), c("mistral-small-latest").as_ptr(), &mut err),
         "mistral_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_mistral_new_with_base(
             key.as_ptr(),
             c("mistral-small-latest").as_ptr(),
@@ -267,18 +274,18 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "mistral_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_xai_new(key.as_ptr(), c("grok-3").as_ptr(), &mut err),
         "xai_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_xai_new_with_base(key.as_ptr(), c("grok-3").as_ptr(), base.as_ptr(), &mut err),
         "xai_new_with_base",
-    );
+    ));
 
     // Credential constructors.
-    expect_handle(
+    handles.push(expect_handle(
         aimux_anthropic_aws_new(
             key.as_ptr(),
             region.as_ptr(),
@@ -286,8 +293,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "anthropic_aws_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_anthropic_aws_new_with_base(
             key.as_ptr(),
             region.as_ptr(),
@@ -296,8 +303,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "anthropic_aws_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_azure_new(
             key.as_ptr(),
             resource.as_ptr(),
@@ -306,8 +313,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "azure_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_azure_new_with_base(
             key.as_ptr(),
             base.as_ptr(),
@@ -316,8 +323,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "azure_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_bedrock_new(
             key.as_ptr(),
             secret.as_ptr(),
@@ -326,8 +333,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "bedrock_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_bedrock_new_with_base(
             key.as_ptr(),
             secret.as_ptr(),
@@ -337,8 +344,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "bedrock_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_vertex_new(
             token.as_ptr(),
             project.as_ptr(),
@@ -347,8 +354,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "vertex_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_vertex_new_with_base(
             token.as_ptr(),
             project.as_ptr(),
@@ -358,14 +365,14 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "vertex_new_with_base",
-    );
+    ));
 
     // Multimodal constructors.
-    expect_handle(
+    handles.push(expect_handle(
         aimux_openai_embedding_new(key.as_ptr(), c("text-embedding-3-small").as_ptr(), &mut err),
         "openai_embedding_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_embedding_new_with_base(
             key.as_ptr(),
             c("text-embedding-3-small").as_ptr(),
@@ -373,12 +380,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "openai_embedding_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_cohere_embedding_new(key.as_ptr(), c("embed-english-v3.0").as_ptr(), &mut err),
         "cohere_embedding_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_cohere_embedding_new_with_base(
             key.as_ptr(),
             c("embed-english-v3.0").as_ptr(),
@@ -386,12 +393,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "cohere_embedding_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_google_embedding_new(key.as_ptr(), c("text-embedding-004").as_ptr(), &mut err),
         "google_embedding_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_google_embedding_new_with_base(
             key.as_ptr(),
             c("text-embedding-004").as_ptr(),
@@ -399,12 +406,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "google_embedding_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_speech_new(key.as_ptr(), c("tts-1").as_ptr(), &mut err),
         "openai_speech_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_speech_new_with_base(
             key.as_ptr(),
             c("tts-1").as_ptr(),
@@ -412,12 +419,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "openai_speech_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_image_new(key.as_ptr(), c("gpt-image-1").as_ptr(), &mut err),
         "openai_image_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_image_new_with_base(
             key.as_ptr(),
             c("gpt-image-1").as_ptr(),
@@ -425,16 +432,16 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "openai_image_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_google_image_new(
             key.as_ptr(),
             c("imagen-4.0-generate-001").as_ptr(),
             &mut err,
         ),
         "google_image_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_google_image_new_with_base(
             key.as_ptr(),
             c("imagen-4.0-generate-001").as_ptr(),
@@ -442,12 +449,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "google_image_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_transcription_new(key.as_ptr(), c("whisper-1").as_ptr(), &mut err),
         "openai_transcription_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_transcription_new_with_base(
             key.as_ptr(),
             c("whisper-1").as_ptr(),
@@ -455,20 +462,20 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "openai_transcription_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_files_new(key.as_ptr(), &mut err),
         "openai_files_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_openai_files_new_with_base(key.as_ptr(), base.as_ptr(), &mut err),
         "openai_files_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_cohere_reranking_new(key.as_ptr(), c("rerank-v3.5").as_ptr(), &mut err),
         "cohere_reranking_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_cohere_reranking_new_with_base(
             key.as_ptr(),
             c("rerank-v3.5").as_ptr(),
@@ -476,12 +483,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "cohere_reranking_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_google_video_new(key.as_ptr(), c("veo-3.0-generate-001").as_ptr(), &mut err),
         "google_video_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_google_video_new_with_base(
             key.as_ptr(),
             c("veo-3.0-generate-001").as_ptr(),
@@ -489,12 +496,12 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "google_video_new_with_base",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_tavily_search_new(key.as_ptr(), c("tavily").as_ptr(), &mut err),
         "tavily_search_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_tavily_search_new_with_base(
             key.as_ptr(),
             c("tavily").as_ptr(),
@@ -502,11 +509,11 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "tavily_search_new_with_base",
-    );
+    ));
 
     // Registry-backed constructors (RFC-0017 / RFC-0027).
     let provider_opts = c(r#"{"base_url":"http://127.0.0.1:1","max_retries":0}"#);
-    expect_handle(
+    handles.push(expect_handle(
         aimux_provider_new(
             c("groq").as_ptr(),
             key.as_ptr(),
@@ -515,8 +522,8 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "provider_new",
-    );
-    expect_handle(
+    ));
+    handles.push(expect_handle(
         aimux_provider_handle_new(
             c("groq").as_ptr(),
             key.as_ptr(),
@@ -524,18 +531,21 @@ fn constructor_exports_build_and_release_handles() {
             &mut err,
         ),
         "provider_handle_new",
-    );
+    ));
 
     // Composite wrappers over an unreachable model handle.
     let model = unreachable_model(&mut err);
-    expect_handle(model, "openai_new_with_base (composite base)");
+    handles.push(expect_handle(
+        model,
+        "openai_new_with_base (composite base)",
+    ));
     let traced = aimux_trace_new(model, &mut err);
-    expect_handle(traced, "trace_new");
+    handles.push(expect_handle(traced, "trace_new"));
     let audited = aimux_trace_new_audited(model, 0, &mut err);
-    expect_handle(audited, "trace_new_audited");
+    handles.push(expect_handle(audited, "trace_new_audited"));
     let children = [traced, audited];
     let router = aimux_router_new(children.as_ptr(), children.len(), ptr::null(), &mut err);
-    expect_handle(router, "router_new");
+    handles.push(expect_handle(router, "router_new"));
     let moa = aimux_moa_new(
         children.as_ptr(),
         children.len(),
@@ -543,8 +553,8 @@ fn constructor_exports_build_and_release_handles() {
         ptr::null(),
         &mut err,
     );
-    expect_handle(moa, "moa_new");
-    expect_handle(aimux_abort_signal_new(), "abort_signal_new");
+    handles.push(expect_handle(moa, "moa_new"));
+    handles.push(expect_handle(aimux_abort_signal_new(), "abort_signal_new"));
 
     // Release every handle created above (aimux_drop_handle is safe with 0).
     for h in [traced, audited, router, moa, model] {
@@ -563,6 +573,9 @@ fn constructor_exports_build_and_release_handles() {
         err.code, AIMUX_OK,
         "successful constructors must not fill err"
     );
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 /// `provider_from_env` reads the provider's env var, which the harness cannot
@@ -586,9 +599,11 @@ fn provider_from_env_handle_or_clean_failure() {
 
 #[test]
 fn text_generation_exports_fail_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = unreachable_model(&mut err);
-    expect_handle(h, "model handle");
+    handles.push(expect_handle(h, "model handle"));
 
     let prompt = c("\"ffi smoke\"");
     let opts = c(r#"{"max_retries":0}"#);
@@ -610,15 +625,20 @@ fn text_generation_exports_fail_cleanly_on_unreachable_host() {
     release_err(&mut err);
 
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 // ── session class: streaming with callbacks (4 exports) ─────────────────────
 
 #[test]
 fn streaming_exports_fail_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = unreachable_model(&mut err);
-    expect_handle(h, "model handle");
+    handles.push(expect_handle(h, "model handle"));
 
     let prompt = c("\"ffi smoke\"");
     let opts = c(r#"{"max_retries":0}"#);
@@ -676,6 +696,9 @@ fn streaming_exports_fail_cleanly_on_unreachable_host() {
 
     aimux_abort_signal_drop(abort);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 // ── session class: multimodal generation (8 exports, one per test to
@@ -684,6 +707,8 @@ fn streaming_exports_fail_cleanly_on_unreachable_host() {
 
 #[test]
 fn embed_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = aimux_openai_embedding_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -691,7 +716,7 @@ fn embed_fails_cleanly_on_unreachable_host() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(h, "embedding handle");
+    handles.push(expect_handle(h, "embedding handle"));
     let out = aimux_embed(
         h,
         c(r#"["hello"]"#).as_ptr(),
@@ -701,10 +726,15 @@ fn embed_fails_cleanly_on_unreachable_host() {
     expect_ptr_failure(out, &err, "embed");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 #[test]
 fn speech_generate_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = aimux_openai_speech_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -712,15 +742,20 @@ fn speech_generate_fails_cleanly_on_unreachable_host() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(h, "speech handle");
+    handles.push(expect_handle(h, "speech handle"));
     let out = aimux_speech_generate(h, c(r#"{"text":"ffi smoke"}"#).as_ptr(), &mut err);
     expect_ptr_failure(out, &err, "speech_generate");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 #[test]
 fn image_generate_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = aimux_openai_image_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -728,16 +763,21 @@ fn image_generate_fails_cleanly_on_unreachable_host() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(h, "image handle");
+    handles.push(expect_handle(h, "image handle"));
     let opts = c(r#"{"prompt":"a rust crab","n":1,"provider_options":{}}"#);
     let out = aimux_image_generate(h, opts.as_ptr(), &mut err);
     expect_ptr_failure(out, &err, "image_generate");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 #[test]
 fn transcription_generate_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = aimux_openai_transcription_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -745,7 +785,7 @@ fn transcription_generate_fails_cleanly_on_unreachable_host() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(h, "transcription handle");
+    handles.push(expect_handle(h, "transcription handle"));
     let out = aimux_transcription_generate(
         h,
         c("ZmFrZS1hdWRpbw==").as_ptr(),
@@ -756,14 +796,19 @@ fn transcription_generate_fails_cleanly_on_unreachable_host() {
     expect_ptr_failure(out, &err, "transcription_generate");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 #[test]
 fn file_upload_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h =
         aimux_openai_files_new_with_base(c(FAKE_KEY).as_ptr(), c(UNREACHABLE).as_ptr(), &mut err);
-    expect_handle(h, "files handle");
+    handles.push(expect_handle(h, "files handle"));
     let out = aimux_file_upload(
         h,
         c("ZmFrZS1maWxl").as_ptr(),
@@ -774,10 +819,15 @@ fn file_upload_fails_cleanly_on_unreachable_host() {
     expect_ptr_failure(out, &err, "file_upload");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 #[test]
 fn rerank_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = aimux_cohere_reranking_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -785,16 +835,21 @@ fn rerank_fails_cleanly_on_unreachable_host() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(h, "reranking handle");
+    handles.push(expect_handle(h, "reranking handle"));
     let opts = c(r#"{"query":"rust","documents":{"Text":{"values":["a","b"]}}}"#);
     let out = aimux_rerank(h, opts.as_ptr(), &mut err);
     expect_ptr_failure(out, &err, "rerank");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 #[test]
 fn video_generate_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = aimux_google_video_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -802,16 +857,21 @@ fn video_generate_fails_cleanly_on_unreachable_host() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(h, "video handle");
+    handles.push(expect_handle(h, "video handle"));
     let opts = c(r#"{"prompt":"waves","n":1,"provider_options":{}}"#);
     let out = aimux_video_generate(h, opts.as_ptr(), &mut err);
     expect_ptr_failure(out, &err, "video_generate");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 #[test]
 fn search_fails_cleanly_on_unreachable_host() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let h = aimux_tavily_search_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -819,17 +879,22 @@ fn search_fails_cleanly_on_unreachable_host() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(h, "search handle");
+    handles.push(expect_handle(h, "search handle"));
     let out = aimux_search(h, c(r#"{"query":"ffi smoke"}"#).as_ptr(), &mut err);
     expect_ptr_failure(out, &err, "search");
     release_err(&mut err);
     aimux_drop_handle(h);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 // ── session class: transcription streaming session (5 exports) ──────────────
 
 #[test]
 fn transcription_session_reaches_clean_terminal_error() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let model = aimux_openai_transcription_new_with_base(
         c(FAKE_KEY).as_ptr(),
@@ -837,10 +902,10 @@ fn transcription_session_reaches_clean_terminal_error() {
         c(UNREACHABLE).as_ptr(),
         &mut err,
     );
-    expect_handle(model, "transcription handle");
+    handles.push(expect_handle(model, "transcription handle"));
 
     let session = aimux_transcription_session_new(model, 0, ptr::null(), &mut err);
-    expect_handle(session, "transcription_session_new");
+    handles.push(expect_handle(session, "transcription_session_new"));
 
     // The driver fails on the unreachable host; pull parts until the stream
     // reaches its terminal NULL (error or end) within a bounded number of
@@ -884,12 +949,17 @@ fn transcription_session_reaches_clean_terminal_error() {
     );
     release_err(&mut err);
     aimux_drop_handle(model);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 // ── session class: provider discovery + catalogue + codex (4 exports) ───────
 
 #[test]
 fn provider_discovery_and_catalogue_exports_fail_cleanly() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     // Provider handle bound to the unreachable host with retries disabled.
     let provider = aimux_provider_handle_new(
@@ -898,14 +968,14 @@ fn provider_discovery_and_catalogue_exports_fail_cleanly() {
         c(r#"{"base_url":"http://127.0.0.1:1","max_retries":0}"#).as_ptr(),
         &mut err,
     );
-    expect_handle(provider, "provider_handle_new");
+    handles.push(expect_handle(provider, "provider_handle_new"));
 
     let models = aimux_provider_list_models(provider, &mut err);
     expect_ptr_failure(models, &err, "provider_list_models");
     release_err(&mut err);
 
     let model = aimux_provider_model(provider, c("llama-3.3-70b-versatile").as_ptr(), &mut err);
-    expect_handle(model, "provider_model");
+    handles.push(expect_handle(model, "provider_model"));
     aimux_drop_handle(model);
     aimux_drop_handle(provider);
 
@@ -919,6 +989,9 @@ fn provider_discovery_and_catalogue_exports_fail_cleanly() {
     let out = aimux_codex_refresh(ptr::null(), ptr::null(), &mut err);
     expect_ptr_failure(out, &err, "codex_refresh (null args)");
     release_err(&mut err);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 // ── utility class: lifecycle, sessions, config (10 exports) ─────────────────
@@ -981,11 +1054,13 @@ fn utility_exports_return_clean_values() {
 
 #[test]
 fn trace_query_exports_return_clean_values() {
+    // Collect every created handle so the release path is exercised too.
+    let mut handles: Vec<u64> = Vec::new();
     let mut err = fresh_err();
     let model = unreachable_model(&mut err);
-    expect_handle(model, "model handle");
+    handles.push(expect_handle(model, "model handle"));
     let traced = aimux_trace_new(model, &mut err);
-    expect_handle(traced, "trace handle");
+    handles.push(expect_handle(traced, "trace handle"));
 
     // Empty filter `{}` = all (TraceFilter is all-Option).
     let stats = aimux_trace_aggregate(traced, c("{}").as_ptr(), &mut err);
@@ -1033,6 +1108,9 @@ fn trace_query_exports_return_clean_values() {
 
     aimux_drop_handle(traced);
     aimux_drop_handle(model);
+    for h in handles {
+        aimux_drop_handle(h);
+    }
 }
 
 // ── utility class: recording (6 exports) ────────────────────────────────────

--- a/aimux-providers/tests/e2e_test.rs
+++ b/aimux-providers/tests/e2e_test.rs
@@ -999,10 +999,10 @@ async fn e2e_mistral_stream_text() {
     let server = MockServer::start().await;
 
     let sse_body = concat!(
-        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n",
-        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
-        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}\n\n",
-        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n",
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"\"}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"Hello\"}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\" world\"}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"\"}]},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n",
         "data: [DONE]\n\n"
     );
 

--- a/aimux-providers/tests/e2e_test.rs
+++ b/aimux-providers/tests/e2e_test.rs
@@ -1,5 +1,10 @@
 //! End-to-end tests: verify generate_text / stream_text user-facing API
-//! works with both OpenAI and Anthropic providers via wiremock.
+//! works with multiple native-protocol providers via wiremock.
+//!
+//! Covers openai + anthropic + google + mistral + cohere full round-trips
+//! (request shape → JSON / SSE response → aggregated assertions). Protocol
+//! response fixtures mirror the per-provider wiremock test files
+//! (`google_model_test.rs` / `mistral_model_test.rs` / `cohere_model_test.rs`).
 
 use aimux_core::content::ContentPart;
 use aimux_core::generate::{GenerateTextOptions, generate_text, stream_text};
@@ -7,10 +12,23 @@ use aimux_core::message::{MessageContent, ModelMessage, Role};
 use aimux_core::stream_part::StreamPart;
 use aimux_core::tool::{FunctionTool, Tool, ToolChoice};
 use aimux_core::types::FinishReasonUnified;
-use aimux_providers::{AnthropicConfig, AnthropicProvider, OpenAIConfig, OpenAIProvider};
+use aimux_providers::{
+    AnthropicConfig, AnthropicProvider, CohereConfig, CohereProvider, GoogleConfig, GoogleProvider,
+    MistralConfig, MistralProvider, OpenAIConfig, OpenAIProvider,
+};
 use futures::StreamExt;
 use serde_json::json;
 use wiremock::{Mock, MockServer, ResponseTemplate, matchers::*};
+
+/// Deserialize the (first) recorded request body of a wiremock server.
+async fn received_json_body(server: &MockServer) -> serde_json::Value {
+    let requests = server
+        .received_requests()
+        .await
+        .expect("requests should be recorded");
+    assert!(!requests.is_empty(), "expected at least one request");
+    serde_json::from_slice(&requests[0].body).expect("request body is JSON")
+}
 
 // ─────────────────────────────────────────────────────────────────
 // OpenAI end-to-end
@@ -845,4 +863,268 @@ async fn e2e_openai_stream_tool_calls() {
         assert_eq!(tool_name, "get_weather");
         assert_eq!(input["location"], "Tokyo");
     }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Google (Gemini native protocol) end-to-end
+// ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn e2e_google_generate_text() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/models/gemini-2.0-flash:generateContent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{ "text": "Rust is memory-safe without a GC." }],
+                    "role": "model"
+                },
+                "finishReason": "STOP",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 8,
+                "totalTokenCount": 18
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = GoogleProvider::new(GoogleConfig::new("test-key").with_base_url(server.uri()));
+    let model = provider.model("gemini-2.0-flash");
+
+    let result = generate_text(&model, "What is Rust?", GenerateTextOptions::default())
+        .await
+        .expect("generate_text should succeed");
+
+    assert_eq!(result.text, "Rust is memory-safe without a GC.");
+    assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
+    assert_eq!(result.usage.input_tokens.total, Some(10));
+    assert_eq!(result.usage.output_tokens.total, Some(8));
+
+    // Request body shape: Gemini `contents[].parts[].text`.
+    let body = received_json_body(&server).await;
+    assert_eq!(body["contents"][0]["role"], "user");
+    assert_eq!(body["contents"][0]["parts"][0]["text"], "What is Rust?");
+}
+
+#[tokio::test]
+async fn e2e_google_stream_text() {
+    let server = MockServer::start().await;
+
+    // Gemini SSE: one JSON object per `data:` event, no [DONE] sentinel.
+    let sse_body = concat!(
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}],\"role\":\"model\"},\"index\":0}],\"responseId\":\"resp-1\"}\n\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\", World\"}],\"role\":\"model\"},\"index\":0}],\"responseId\":\"resp-1\"}\n\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"!\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":3,\"totalTokenCount\":8},\"responseId\":\"resp-1\"}\n\n"
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/models/gemini-2.0-flash:streamGenerateContent"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_body),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = GoogleProvider::new(GoogleConfig::new("test-key").with_base_url(server.uri()));
+    let model = provider.model("gemini-2.0-flash");
+
+    let result = stream_text(&model, "Say hello", GenerateTextOptions::default())
+        .await
+        .expect("stream_text should succeed");
+
+    let request_body = result.request_body.clone();
+    let text = result.text().await.expect("should collect text");
+    assert_eq!(text, "Hello, World!");
+
+    // Streaming request body shape: same contents[] structure.
+    let body = request_body.expect("stream request body should be recorded");
+    assert_eq!(body["contents"][0]["role"], "user");
+    assert_eq!(body["contents"][0]["parts"][0]["text"], "Say hello");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Mistral (OpenAI-compatible variant) end-to-end
+// ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn e2e_mistral_generate_text() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "5319bd0299614c679a0068a4f2c8ffd0",
+            "object": "chat.completion",
+            "created": 1769088720,
+            "model": "mistral-small-latest",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Rust compiles fast."}
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18}
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = MistralProvider::new(MistralConfig::new("test-key").with_base_url(server.uri()));
+    let model = provider.model("mistral-small-latest");
+
+    let result = generate_text(&model, "What is Rust?", GenerateTextOptions::default())
+        .await
+        .expect("generate_text should succeed");
+
+    assert_eq!(result.text, "Rust compiles fast.");
+    assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
+    assert_eq!(result.usage.input_tokens.total, Some(10));
+    assert_eq!(result.usage.output_tokens.total, Some(8));
+
+    // Request body shape: Mistral sends content as a parts array.
+    let body = received_json_body(&server).await;
+    assert_eq!(body["model"], "mistral-small-latest");
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+    assert_eq!(body["messages"][0]["content"][0]["text"], "What is Rust?");
+}
+
+#[tokio::test]
+async fn e2e_mistral_stream_text() {
+    let server = MockServer::start().await;
+
+    let sse_body = concat!(
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"mistral-small-latest\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_body),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = MistralProvider::new(MistralConfig::new("test-key").with_base_url(server.uri()));
+    let model = provider.model("mistral-small-latest");
+
+    let result = stream_text(&model, "Say hello", GenerateTextOptions::default())
+        .await
+        .expect("stream_text should succeed");
+
+    let request_body = result.request_body.clone();
+    let text = result.text().await.expect("should collect text");
+    assert_eq!(text, "Hello world");
+
+    // Streaming request body shape: stream=true + the user message.
+    let body = request_body.expect("stream request body should be recorded");
+    assert_eq!(body["model"], "mistral-small-latest");
+    assert_eq!(body["stream"], json!(true));
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"][0]["text"], "Say hello");
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Cohere (native protocol) end-to-end
+// ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn e2e_cohere_generate_text() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "e7592632-1e3d-424f-b129-bd5f9f980f7b",
+            "message": {
+                "role": "assistant",
+                "content": [{ "type": "text", "text": "Rust is fearless concurrency." }]
+            },
+            "finish_reason": "COMPLETE",
+            "usage": {
+                "billed_units": { "input_tokens": 10, "output_tokens": 8 },
+                "tokens": { "input_tokens": 12, "output_tokens": 9 }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = CohereProvider::new(CohereConfig::new("test-key").with_base_url(server.uri()));
+    let model = provider.model("command-r-plus");
+
+    let result = generate_text(&model, "What is Rust?", GenerateTextOptions::default())
+        .await
+        .expect("generate_text should succeed");
+
+    assert_eq!(result.text, "Rust is fearless concurrency.");
+    assert_eq!(result.finish_reason.unified, FinishReasonUnified::Stop);
+    // Cohere maps the `tokens` pair (not `billed_units`) into usage.
+    assert_eq!(result.usage.input_tokens.total, Some(12));
+    assert_eq!(result.usage.output_tokens.total, Some(9));
+
+    // Request body shape: Cohere sends plain-string message content.
+    let body = received_json_body(&server).await;
+    assert_eq!(body["model"], "command-r-plus");
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"], "What is Rust?");
+}
+
+#[tokio::test]
+async fn e2e_cohere_stream_text() {
+    let server = MockServer::start().await;
+
+    // Cohere SSE: typed `event:` lines + `data:` payloads.
+    let sse_body = concat!(
+        "event: message-start\n",
+        "data: {\"id\":\"321d178c\",\"type\":\"message-start\",\"delta\":{\"message\":{\"role\":\"assistant\",\"content\":[],\"tool_plan\":\"\",\"tool_calls\":[],\"citations\":[]}}}\n\n",
+        "event: content-start\n",
+        "data: {\"type\":\"content-start\",\"index\":0,\"delta\":{\"message\":{\"content\":{\"type\":\"text\",\"text\":\"\"}}}}\n\n",
+        "event: content-delta\n",
+        "data: {\"type\":\"content-delta\",\"index\":0,\"delta\":{\"message\":{\"content\":{\"text\":\"Hello\"}}}}\n\n",
+        "event: content-delta\n",
+        "data: {\"type\":\"content-delta\",\"index\":0,\"delta\":{\"message\":{\"content\":{\"text\":\" world\"}}}}\n\n",
+        "event: content-end\n",
+        "data: {\"type\":\"content-end\",\"index\":0}\n\n",
+        "event: message-end\n",
+        "data: {\"type\":\"message-end\",\"delta\":{\"finish_reason\":\"COMPLETE\",\"usage\":{\"billed_units\":{\"input_tokens\":5,\"output_tokens\":2},\"tokens\":{\"input_tokens\":7,\"output_tokens\":3}}}}\n\n"
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/chat"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_body),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = CohereProvider::new(CohereConfig::new("test-key").with_base_url(server.uri()));
+    let model = provider.model("command-r-plus");
+
+    let result = stream_text(&model, "Say hello", GenerateTextOptions::default())
+        .await
+        .expect("stream_text should succeed");
+
+    let request_body = result.request_body.clone();
+    let text = result.text().await.expect("should collect text");
+    assert_eq!(text, "Hello world");
+
+    // Streaming request body shape: stream=true + plain-string content.
+    let body = request_body.expect("stream request body should be recorded");
+    assert_eq!(body["model"], "command-r-plus");
+    assert_eq!(body["stream"], json!(true));
+    assert_eq!(body["messages"][0]["role"], "user");
+    assert_eq!(body["messages"][0]["content"], "Say hello");
 }


### PR DESCRIPTION
Fixes #119（c 绑定项此前已按维护者评审移除）

## A：统一 e2e 扩协议（14 → 20 用例）

google / mistral / cohere 各补 generate_text + stream_text 完整往返（wiremock + 请求体形状断言 + 流聚合），三家均支持自定义 base_url，无跳过；fixture 与各家既有测试一致（mistral 流式为 parts-array 形状，Round 2 复核确认与 mistral_model_test 镜像）。

## B：FFI 全导出冒烟（96/96）

新 `exports_smoke_test.rs`：构造类（假 key + 不可达端点 → 句柄 → **统一收集释放**）+ 工具类全量 + 会话类最小 opts 打不可达端点断言"干净错误非 panic"；CAimuxError message/error_value 每条失败路径都 free。ffi/lib.rs 覆盖预期 43% → 显著提升（数字待 CI coverage 复测）。

## 评审

两轮独立评审：Round 1（断言强度/96 覆盖核实/泄漏/确定性通过，3 整改项）→ 3e38614 落实（~44 个漏释放句柄、fixture 形状、时序注释）→ Round 2 CLEAN（附注：个别测试显式 drop 与 Vec 循环重复释放，drop 幂等无害）。
**顺带修正**：aimux_trace_aggregate 失实注释（NULL 实为 INVALID_ARGUMENT，全过滤需传 "{}"）——5 行纯注释变更，在此披露。

## 验证

e2e 20/20、ffi 全套 73/0、fmt + clippy -D warnings 干净（含新启用的 lint 子集）。