### PR TITLE
fix: aimux-web lint subset compliance; regen ts-rs types

### DIFF
--- a/bindings/node/src/types/HttpRecord.ts
+++ b/bindings/node/src/types/HttpRecord.ts
@@ -2,7 +2,7 @@
 
 export type HttpRecord = { method: string, url: string, 
 /**
- * 敏感头(authorization/cookie/含 api-key/key/x-amz-security-token 等)已脱敏为 "[REDACTED]"。
+ * 敏感头(authorization/cookie/含 api-key/key/x-amz-security-token 等)已脱敏为 "\[REDACTED\]"。
  */
 headers: Array<[string, string]>, 
 /**

--- a/tools/aimux-web/src/api/providers.rs
+++ b/tools/aimux-web/src/api/providers.rs
@@ -10,7 +10,10 @@ use aimux_providers::provider_name::ProviderName;
 /// registry-backed OpenAI-compatible provider (generated enum).
 pub fn provider_names() -> Vec<String> {
     const NATIVE: [&str; 6] = ["openai", "anthropic", "google", "mistral", "xai", "cohere"];
-    let mut names: Vec<String> = NATIVE.iter().map(|s| s.to_string()).collect();
+    let mut names: Vec<String> = NATIVE
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
     names.extend(ProviderName::ALL.iter().map(|p| p.as_str().to_string()));
     names
 }


### PR DESCRIPTION
master 上新合入的 aimux-web（#132）与 HttpRecord 类型未过 #148 引入的 lint 门与 ts-rs 同步门，阻塞所有合入当前 master 的 PR。修一处闭包 + 重新生成类型。