### PR TITLE
feat(web): in-page API key settings (RFC-0029 revision, loopback-gated)

### DIFF
--- a/rfc/0029-web-console.md
+++ b/rfc/0029-web-console.md
@@ -37,7 +37,7 @@ aimux 是 access layer(README 明确不做 agent loop / RAG / 编排)。**agent 
 2. **浏览器跑简单 agent loop**:循环逻辑在前端 JS 驱动(决策 D1),用户发消息,页面实时展示每步的模型调用/tool 调用/结果;agent 定义用 JSON,无需写 Rust。
 3. **trace 可视化**:录制列表 + 单条三层详情(输入/provider 配置/HTTP exchanges)+ 会话瀑布图 + 双 Recording diff。
 4. **最大化复用**:录制、trace、session、回放、mock、model catalogue 全部复用 core 现有实现,不重写。
-5. **本地优先、凭据不落地前端**:默认绑 `127.0.0.1`;API key 只在服务端(env 引用),录制脱敏复用 RFC-0023 现成规则。
+5. **本地优先、凭据服务端托管**:默认绑 `127.0.0.1`;API key 支持网页内 Settings 保存(内存默认 + 显式 remember 落盘 `0600`,GET 仅掩码)或 `env:` 引用,明文永不回传前端,录制脱敏复用 RFC-0023 现成规则(见 §5.5)。
 
 ---
 
@@ -48,6 +48,7 @@ aimux 是 access layer(README 明确不做 agent loop / RAG / 编排)。**agent 
 | **D1** agent loop 放哪 | **前端 JS**。循环状态在浏览器,Vue 组件驱动;每次 model call 走后端 `POST /api/calls`(带 `session_id`+`step`),后端负责调用 + 录制,不感知循环 |
 | **D2** 前端技术栈 | **Vite + Vue 3 + TS + shadcn-vue + Tailwind CSS**(组件库 2026-08-14 定稿);类型由 ts-rs 从 Rust 生成,不手写;界面设计见 §8 |
 | **D3** V1 范围 | **P1–P5 一次做完**(Playground / Agent / Traces / Sessions / Replay / Cache probe) |
+| **D4** 凭据管理(**2026-08-14 修订**,替代原"凭据不落地前端") | **网页内 Settings + 服务端托管**:provider 下拉 + key 输入;内存为默认,显式勾选 remember 才落盘(配置目录 `keys.json`,`0600`);`GET /api/settings/keys` 只返回掩码(末 4 位),明文永不回传;非回环绑定时 PUT/DELETE 返回 403、请求内明文维持拒绝,回退 `env:` 引用。调用优先级:请求内显式 spec > Settings 已存 key > provider 注册 env var(§5.5) |
 
 ---
 
@@ -113,7 +114,8 @@ tools/aimux-web/web/
 │       ├── Traces.vue
 │       ├── Sessions.vue
 │       ├── Replay.vue
-│       └── CacheProbe.vue
+│       ├── CacheProbe.vue
+│       └── Settings.vue      # API key 管理(§5.5,决策 D4)
 └── index.html
 ```
 
@@ -138,6 +140,9 @@ tools/aimux-web/web/
 | `/api/recordings/export` | GET | 导出全部录制为 jsonl(与 `aimux-replay` 格式互通) |
 | `/api/recordings/import` | POST | 导入 jsonl(RFC-0023 `from_jsonl` 兼容) |
 | `/api/providers` | GET | provider 列表 + 可用模型(复用 RFC-0027 catalogue) |
+| `/api/settings/keys` | GET | 已存 key 掩码列表(末 4 位)+ `plaintext_entry` 标志(**2026-08-14 修订新增**,§5.5) |
+| `/api/settings/keys` | PUT | `{provider, key, remember?}` 保存 key(内存 + 可选落盘;非回环 403) |
+| `/api/settings/keys/:provider` | DELETE | 移除该 provider 的 key(内存 + 磁盘;非回环 403) |
 | `/api/cache-probe` | POST | 在线缓存探测(平移 `aimux-cli probe::provider`,含 `--dry-run` 等价语义) |
 
 ### 5.2 SSE 协议(`POST /api/calls?stream=1`)
@@ -171,7 +176,7 @@ POST /api/calls
 {
   "provider": "openai",            // 注册表名或原生 provider 名
   "model": "gpt-4o",
-  "api_key": "env:OPENAI_API_KEY", // 仅允许 env:VAR 引用或空(服务端已配置);不接受明文 key
+  "api_key": "env:OPENAI_API_KEY", // env:VAR 引用 / 留空(Settings 已存 key 或 provider env var)/ 明文仅限回环绑定(§5.5)
   "base_url": null,
   "stream": true,
   "options": {
@@ -200,7 +205,7 @@ POST /api/calls
 映射规则:
 - `system/user/assistant/tool` → `ModelMessage`,`content` 数组映射 `ContentPart`(text / image / tool_result…);
 - `tool_calls` 按 provider 能力转 `ToolChoice`/消息内嵌 tool call(OpenAI 兼容族);
-- `api_key` 只接受 `env:VAR`,后端经 `provider_utils` 的 key 加载逻辑解析;**浏览器永远见不到 key 明文**。
+- `api_key` 解析见 §5.5:显式 `env:VAR` 引用、Settings key store 回退、回环绑定下的明文直传;**浏览器永远见不到 key 明文**(Settings 页只显示掩码)。
 
 ### 5.4 多步关联(前端 loop 与 trace 的桥梁)
 
@@ -208,6 +213,20 @@ POST /api/calls
 - 后端 `CallOptions.session_id` 透传(RFC-0024),`SessionStore.append` 归组,`RingRecorder` 落 `Recording`(`session_id`/`step` 字段由 RFC-0023 P1 已实现);
 - Traces 页按 `session_id` 过滤即得**整个 agent 运行的调用链**,按 `step` 排序渲染瀑布图;
 - 单条失败/异常调用不影响会话归组(录制在入口发生,失败也在会话内)。
+
+### 5.5 Settings 与凭据(决策 D4,2026-08-14 修订)
+
+原设计只接受 `env:VAR` 引用,用户必须先在 shell `export`——对"下载即用"的预编译二进制不友好。修订为**网页内设置**(Settings 页):
+
+- **存储**(`settings.rs` `KeyStore`):每 provider 一把明文 key,内存 `HashMap` 为默认;勾选 "remember" 才落盘到配置目录(Linux/macOS `~/.config/aimux-web/keys.json`,Windows `%APPDATA%/aimux-web/keys.json`),文件权限 `0600`(unix `PermissionsExt`,Windows 尽力而为),启动时若文件存在则加载进内存。同 provider 重新保存但不勾 remember 时,磁盘旧条目同步移除(避免重启复活旧 key)。
+- **API 面**(见 §5.1):`GET` 只返回 `{provider, status, hint}`(hint = 末 4 位,不足 4 位给长度),**明文永不回传**;`PUT`/`DELETE` 非回环绑定时返回 403。
+- **回环门控**:后端启动时已知 bind host;非 `127.0.0.1`/`localhost`/`::1` 时 Settings 写接口 403(错误信息引导 `env:` 引用),`GET` 附 `plaintext_entry: false` 供前端隐藏输入框,请求内明文 spec 亦维持拒绝。
+- **调用优先级**(`wire.rs` `resolve_api_key`,三个调用方 calls/cache-probe/replay 均带上 provider 名):
+  1. **请求内显式 spec** —— `env:VAR` 引用(任意绑定可用);明文仅限回环绑定(Playground 快速用一次、不保存的场景);
+  2. **Settings 已存该 provider 的 key**(KeyStore,含启动时从磁盘加载的);
+  3. `None` —— provider 读自己注册的默认 env var。
+
+**威胁模型**:信任边界 = 本机回环客户端。回环下浏览器 ↔ 后端信道视为可信,故允许网页内明文录入与请求内明文直传;非回环(如 `--host 0.0.0.0` LAN 共享)下任何局域网客户端都能 POST,故全部明文入口关闭。明文 key 永不进日志、永不回传前端、永不进 Recording(录制层脱敏复用 RFC-0023 规则)。
 
 ---
 
@@ -478,7 +497,7 @@ Replay 页对同一 `Recording` 重发真实 API 后,新旧两条 `Recording` **
 | 维度 | 设计 |
 |---|---|
 | 绑定 | 默认 `127.0.0.1`;`--host 0.0.0.0` 需显式开启(LAN 共享用,文档警示) |
-| API key | 只接受 `env:VAR` 引用或服务端已配置;**浏览器侧永不出现 key 明文** |
+| API key | 网页内 Settings 保存(内存默认 + 显式 remember 落盘 `0600`)或 `env:VAR` 引用;`GET` 仅掩码,**明文永不回传浏览器**;非回环绑定关闭一切明文入口(403 / 拒绝),回退 `env:` 引用(§5.5,决策 D4) |
 | 录制脱敏 | 复用 RFC-0023 现成规则:api_key/Authorization/含 api-key 头恒 `[REDACTED]` |
 | `http_get` 工具 | 白名单域名 + 仅 http/https,防 SSRF;默认关闭 |
 | 请求回放 | 重发真实 API 消耗费用,UI 明确警示 + 需用户确认(等价 CLI `--dry-run` 的精神) |
@@ -523,7 +542,7 @@ Replay 页对同一 `Recording` 重发真实 API 后,新旧两条 `Recording` **
 | 前端 loop 与 provider tool 语义差异(OpenAI-compat vs 原生) | 中 | `wire.rs` 收敛 tool call 映射;V1 以 OpenAI 兼容族为主(与 mock 回放范围一致),原生 provider 逐步补 |
 | 前端消息 schema 与 `ModelPrompt` 往返丢字段 | 中 | wire 往返单测(round-trip)覆盖;未知字段显式报错而非静默丢弃 |
 | SSE 中断 / 浏览器 fetch reader 兼容 | 低 | fetch streaming + TextDecoder 解析;断流重试 + 失败态展示 |
-| key 误入前端(用户手填明文) | 低 | 输入框只接受 `env:VAR`;检测到明文 key 时拒绝并提示 |
+| key 误入前端(用户手填明文) | 低 | Settings 页与请求内明文仅回环可用;`GET` 只回掩码;非回环一律拒绝并提示 `env:VAR` |
 | `http_get` SSRF | 中 | 白名单 + 协议限制,默认关闭 |
 | 请求回放消耗真实费用 | 中 | UI 确认弹窗 + 每请求显示预估 token;与 CLI `--dry-run` 精神一致 |
 | 前端体量膨胀 | 中 | shadcn-vue 组件按需拷贝进仓库(不用即删);业务组件(JSON 查看器/瀑布/Schema form)复用;shiki 按需加载语言 |

--- a/tools/aimux-web/README.md
+++ b/tools/aimux-web/README.md
@@ -57,6 +57,19 @@ cargo run -p aimux-web
 cargo run -p aimux-web -- --port 8787 --no-open
 ```
 
+### 配置 API key(二选一)
+
+1. **网页内设置(推荐,无需 shell)**:打开控制台后进入 **Settings** 页,选
+   provider、粘贴 key 保存即可;默认只保存在内存(重启失效),勾选
+   "记住(写入磁盘)" 会持久化到配置目录的 `keys.json`(权限 `0600`)并在下次
+   启动自动加载。列表只显示掩码(末 4 位),明文永不回传前端。
+2. **shell 环境变量(可选)**:`export OPENAI_API_KEY=sk-…`(或对应 provider
+   的注册 env var);Playground 等页的 key 字段也可填 `env:VAR` 引用。
+
+调用优先级:请求内显式 `env:` 引用 > Settings 已存 key > provider 注册的默认
+env var。非回环绑定(`--host 0.0.0.0` 等)时网页内 key 管理自动禁用,只能走
+`env:` 引用。
+
 打开后使用 Playground / Agent 页跑一次调用,Traces 页即可看到完整录制。
 
 ## 开发模式(前端热更新)
@@ -81,6 +94,7 @@ npm run dev
 | Sessions | 会话归组与调用链 |
 | Replay | 请求回放(重发真实 API)+ 新旧输出 diff + mock 模式加载 |
 | Cache | 在线 prefix 缓存探测(dry-run 免费) |
+| Settings | 网页内 API key 管理:provider 下拉 + key 输入 + "记住(存盘)"开关;列表仅掩码 |
 
 ## 关键设计
 
@@ -88,8 +102,10 @@ npm run dev
   (SSE),循环逻辑、tool 执行桥(`POST /api/tools/:name`)在浏览器驱动。
 - **多步关联**:同一 `session_id` + 后端 `SessionStore` 自动分配 step,
   Traces 页按会话聚合瀑布图。
-- **凭据安全**:API key 只接受 `env:VAR` 引用或由 provider 注册表 env var 自动读取;
-  明文 key 一律拒绝;录制脱敏复用 core 规则。
+- **凭据安全**:API key 可在 Settings 页网页内保存(内存默认,显式勾选才落盘
+  `~/.config/aimux-web/keys.json`,权限 `0600`),或用 `env:VAR` 引用 / provider
+  注册表 env var 自动读取;`GET /api/settings/keys` 只返回掩码,明文永不回传前端;
+  非回环绑定时网页内明文入口全部关闭(403);录制脱敏复用 core 规则。
 - **Mock 模式**:`POST /api/mock/load` 加载录制 jsonl(与 `aimux-replay` 格式互通),
   之后 `mock: true` 的调用走 `MockReplayModel`,零成本离线验证。
 

--- a/tools/aimux-web/src/api/cache_probe.rs
+++ b/tools/aimux-web/src/api/cache_probe.rs
@@ -24,7 +24,8 @@ use crate::wire;
 pub struct ProbeRequest {
     pub provider: String,
     pub model: String,
-    /// `None` / `env:VAR` only (plaintext rejected).
+    /// `None` (Settings key store / provider env var) / `env:VAR`, or a
+    /// plaintext literal on loopback binds (RFC-0029 §5.5).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -48,14 +49,14 @@ const PROBE_SESSION: &str = "cache-probe";
 
 /// `POST /api/cache-probe` — run a cache probe and return per-round results,
 /// aggregated stats and the raw trace records.
-pub async fn run(State(_state): State<AppState>, Json(req): Json<ProbeRequest>) -> Response {
-    match run_inner(req).await {
+pub async fn run(State(state): State<AppState>, Json(req): Json<ProbeRequest>) -> Response {
+    match run_inner(state, req).await {
         Ok(resp) => resp,
         Err(e) => err_response(e),
     }
 }
 
-async fn run_inner(req: ProbeRequest) -> Result<Response, AiMuxError> {
+async fn run_inner(state: AppState, req: ProbeRequest) -> Result<Response, AiMuxError> {
     if req.max_requests == 0 {
         return Err(AiMuxError::InvalidArgument(
             "max_requests must be >= 1".into(),
@@ -75,7 +76,12 @@ async fn run_inner(req: ProbeRequest) -> Result<Response, AiMuxError> {
         .into_response());
     }
 
-    let key = wire::resolve_api_key(req.api_key.as_deref())?;
+    let key = wire::resolve_api_key(
+        req.api_key.as_deref(),
+        &req.provider,
+        &state.keys,
+        state.loopback,
+    )?;
     let model =
         model_builder::build_model(&req.provider, key, &req.model, req.base_url.as_deref())?;
 

--- a/tools/aimux-web/src/api/calls.rs
+++ b/tools/aimux-web/src/api/calls.rs
@@ -30,8 +30,14 @@ pub async fn call(State(state): State<AppState>, Json(req): Json<WireCallRequest
 }
 
 async fn run(state: AppState, req: WireCallRequest) -> Result<Response, AiMuxError> {
-    // api_key: only env references (plaintext rejected).
-    let key = wire::resolve_api_key(req.api_key.as_deref())?;
+    // api_key: explicit spec (env: ref, or plaintext on loopback) > Settings
+    // key store > provider's registered env var (RFC-0029 §5.5).
+    let key = wire::resolve_api_key(
+        req.api_key.as_deref(),
+        &req.provider,
+        &state.keys,
+        state.loopback,
+    )?;
 
     let model: Arc<dyn LanguageModel> = if req.mock {
         let key = format!("{}/{}", req.provider, req.model);

--- a/tools/aimux-web/src/api/mod.rs
+++ b/tools/aimux-web/src/api/mod.rs
@@ -5,6 +5,7 @@ pub mod calls;
 pub mod providers;
 pub mod replay;
 pub mod sessions;
+pub mod settings;
 pub mod tools;
 pub mod traces;
 
@@ -38,6 +39,14 @@ pub fn router(state: AppState) -> Router {
         .route("/api/mock/load", axum::routing::post(replay::mock_load))
         .route("/api/cache-probe", axum::routing::post(cache_probe::run))
         .route("/api/providers", get(providers::list))
+        .route(
+            "/api/settings/keys",
+            get(settings::list_keys).put(settings::put_key),
+        )
+        .route(
+            "/api/settings/keys/{provider}",
+            axum::routing::delete(settings::delete_key),
+        )
         .with_state(state)
 }
 

--- a/tools/aimux-web/src/api/replay.rs
+++ b/tools/aimux-web/src/api/replay.rs
@@ -22,8 +22,9 @@ use crate::wire::{self, WireMessage};
 #[derive(Deserialize)]
 pub struct ReplayRequest {
     pub call_id: String,
-    /// Required for recordings whose key source is `explicit`/`unknown`
-    /// (only `env:VAR` references accepted).
+    /// Fallback for recordings whose key source is `explicit`/`unknown`:
+    /// `env:VAR` reference, or a plaintext literal on loopback binds
+    /// (RFC-0029 §5.5). Keys saved in Settings apply as well.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -59,13 +60,26 @@ async fn run_inner(state: AppState, req: ReplayRequest) -> Result<Response, AiMu
         AiMuxError::InvalidArgument(format!("recording '{}' not found", req.call_id))
     })?;
 
-    // Resolve the key for provider rebuild (privacy: never plaintext).
+    // Resolve the key for provider rebuild: the recording's own env: source
+    // first, then the request spec, with the Settings key store as the
+    // fallback (RFC-0029 §5.5).
+    let provider_name = recording.provider.provider.clone();
     let key = match recording.provider.api_key_source.as_str() {
-        s if s.starts_with("env:") => wire::resolve_api_key(Some(s))?,
-        "none" => None,
-        _ => wire::resolve_api_key(req.api_key.as_deref()).map_err(|_| {
+        s if s.starts_with("env:") => {
+            wire::resolve_api_key(Some(s), &provider_name, &state.keys, state.loopback)?
+        }
+        "none" => wire::resolve_api_key(None, &provider_name, &state.keys, state.loopback)?,
+        _ => wire::resolve_api_key(
+            req.api_key.as_deref(),
+            &provider_name,
+            &state.keys,
+            state.loopback,
+        )
+        .map_err(|_| {
             AiMuxError::InvalidArgument(
-                "this recording has no env key source — pass api_key=\"env:VAR\" to replay".into(),
+                "this recording has no env key source — pass api_key=\"env:VAR\" or save the \
+                 provider key in Settings to replay"
+                    .into(),
             )
         })?,
     };

--- a/tools/aimux-web/src/api/settings.rs
+++ b/tools/aimux-web/src/api/settings.rs
@@ -1,0 +1,251 @@
+//! `GET/PUT/DELETE /api/settings/keys` — console credential settings
+//! (RFC-0029 §5.5). Plaintext keys are stored server-side only and never
+//! appear in responses: `GET` returns a masked listing (last 4 chars).
+//!
+//! Loopback gating: `PUT`/`DELETE` return 403 when the server is bound to a
+//! non-loopback host (any LAN client could otherwise plant or exfiltrate
+//! keys); `GET` still lists hints but reports `plaintext_entry: false` so
+//! the frontend hides the input and points users at `env:` references.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::state::AppState;
+
+#[derive(Deserialize)]
+pub struct PutKeyRequest {
+    pub provider: String,
+    pub key: String,
+    /// Persist to the config-dir `keys.json` (0600) in addition to memory.
+    #[serde(default)]
+    pub remember: bool,
+}
+
+/// `GET /api/settings/keys` — masked listing + whether plaintext entry is
+/// allowed (loopback binding only).
+pub async fn list_keys(State(state): State<AppState>) -> Response {
+    let keys: Vec<_> = state
+        .keys
+        .hints()
+        .into_iter()
+        .map(|h| {
+            json!({
+                "provider": h.provider,
+                "status": "stored",
+                "hint": h.hint,
+                "remembered": h.remembered,
+            })
+        })
+        .collect();
+    Json(json!({
+        "keys": keys,
+        "plaintext_entry": state.loopback,
+    }))
+    .into_response()
+}
+
+/// `PUT /api/settings/keys` — save one provider key (memory + optional disk).
+pub async fn put_key(State(state): State<AppState>, Json(req): Json<PutKeyRequest>) -> Response {
+    if !state.loopback {
+        return non_loopback_forbidden();
+    }
+    let provider = req.provider.trim().to_string();
+    if provider.is_empty() || req.key.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "provider and key must be non-empty" })),
+        )
+            .into_response();
+    }
+    match state.keys.set(&provider, &req.key, req.remember) {
+        Ok(remembered) => Json(json!({
+            "provider": provider,
+            "stored": true,
+            "remembered": remembered,
+        }))
+        .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("key stored in memory, but disk persistence failed: {e}") })),
+        )
+            .into_response(),
+    }
+}
+
+/// `DELETE /api/settings/keys/{provider}` — drop the key (memory + disk).
+pub async fn delete_key(State(state): State<AppState>, Path(provider): Path<String>) -> Response {
+    if !state.loopback {
+        return non_loopback_forbidden();
+    }
+    match state.keys.remove(&provider) {
+        Ok(removed) => Json(json!({ "provider": provider, "removed": removed })).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("failed to remove persisted key: {e}") })),
+        )
+            .into_response(),
+    }
+}
+
+/// 403 with guidance back to `env:` references.
+fn non_loopback_forbidden() -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({
+            "error": "key management is disabled: the console is bound to a non-loopback address — \
+                      keep using api_key=\"env:VAR\" references or the provider's registered env var"
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::api::router;
+    use crate::settings::KeyStore;
+
+    fn app(host: &str, keys: KeyStore) -> axum::Router {
+        router(AppState::with_bind_host_and_store(host, keys))
+    }
+
+    async fn body(resp: Response) -> String {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn put_get_delete_round_trip_on_loopback() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys = KeyStore::from_path(Some(dir.path().join("keys.json")));
+        let app = app("127.0.0.1", keys);
+
+        // PUT (remember) → stored + remembered.
+        let resp = app
+            .clone()
+            .oneshot(
+                axum::http::Request::put("/api/settings/keys")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        r#"{"provider":"openai","key":"sk-secret-abcd","remember":true}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let b = body(resp).await;
+        assert!(b.contains("\"remembered\":true"), "body: {b}");
+
+        // GET → masked hint, plaintext never leaks.
+        let resp = app
+            .clone()
+            .oneshot(
+                axum::http::Request::get("/api/settings/keys")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let b = body(resp).await;
+        assert!(b.contains("\"plaintext_entry\":true"), "body: {b}");
+        assert!(b.contains("…abcd"), "masked hint missing: {b}");
+        assert!(!b.contains("sk-secret-abcd"), "plaintext leaked: {b}");
+
+        // DELETE → removed, listing empty.
+        let resp = app
+            .clone()
+            .oneshot(
+                axum::http::Request::delete("/api/settings/keys/openai")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp = app
+            .oneshot(
+                axum::http::Request::get("/api/settings/keys")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let b = body(resp).await;
+        assert!(!b.contains("openai"), "provider still listed: {b}");
+    }
+
+    #[tokio::test]
+    async fn non_loopback_rejects_put_and_delete_but_lists_masked() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys = KeyStore::from_path(Some(dir.path().join("keys.json")));
+        keys.set("anthropic", "sk-lan-secret-777", false).unwrap();
+        let app = app("0.0.0.0", keys);
+
+        let resp = app
+            .clone()
+            .oneshot(
+                axum::http::Request::put("/api/settings/keys")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        r#"{"provider":"openai","key":"sk-x","remember":false}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let b = body(resp).await;
+        assert!(b.contains("env:"), "403 must guide to env: refs: {b}");
+
+        let resp = app
+            .clone()
+            .oneshot(
+                axum::http::Request::delete("/api/settings/keys/anthropic")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // GET still works: masked + plaintext_entry:false.
+        let resp = app
+            .oneshot(
+                axum::http::Request::get("/api/settings/keys")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let b = body(resp).await;
+        assert!(b.contains("\"plaintext_entry\":false"), "body: {b}");
+        assert!(b.contains("…-777"), "masked hint missing: {b}");
+        assert!(!b.contains("sk-lan-secret-777"), "plaintext leaked: {b}");
+    }
+
+    #[tokio::test]
+    async fn put_validates_empty_fields() {
+        let app = app("localhost", KeyStore::from_path(None));
+        let resp = app
+            .oneshot(
+                axum::http::Request::put("/api/settings/keys")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(r#"{"provider":"  ","key":"sk-x"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/tools/aimux-web/src/api/settings.rs
+++ b/tools/aimux-web/src/api/settings.rs
@@ -81,6 +81,7 @@ pub async fn delete_key(State(state): State<AppState>, Path(provider): Path<Stri
     if !state.loopback {
         return non_loopback_forbidden();
     }
+    let provider = provider.trim().to_string();
     match state.keys.remove(&provider) {
         Ok(removed) => Json(json!({ "provider": provider, "removed": removed })).into_response(),
         Err(e) => (

--- a/tools/aimux-web/src/main.rs
+++ b/tools/aimux-web/src/main.rs
@@ -20,6 +20,7 @@ use clap::Parser;
 mod agents;
 mod api;
 mod model_builder;
+mod settings;
 mod state;
 mod wire;
 
@@ -51,7 +52,9 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let state = state::AppState::new();
+    let state = state::AppState::with_bind_host(&cli.host);
+    let loopback = state.loopback;
+    let key_store = state.keys.clone();
 
     let app = Router::new().merge(api::router(state));
 
@@ -95,6 +98,15 @@ async fn main() -> Result<()> {
             .display()
     );
     println!("  wiring: RingRecorder(2048) + RingTraceStore + SessionStore");
+    if !key_store.is_empty() {
+        println!(
+            "  key store: {} provider key(s) loaded from Settings",
+            key_store.len()
+        );
+    }
+    if !loopback {
+        println!("  note: non-loopback bind — web key entry is disabled, use env:VAR references");
+    }
 
     if !cli.no_open {
         // Best-effort browser open (ignore failures on headless machines).

--- a/tools/aimux-web/src/settings.rs
+++ b/tools/aimux-web/src/settings.rs
@@ -1,0 +1,421 @@
+//! Console credential store (RFC-0029 §5.5 "Settings 与凭据").
+//!
+//! `KeyStore` holds one plaintext API key per provider for the lifetime of
+//! the process (memory-first, so a key saved without "remember" never touches
+//! the disk). When the user opts in with `remember`, the remembered subset is
+//! written to a JSON file under the config dir with `0600` permissions on
+//! unix (best effort on Windows) and reloaded on the next start.
+//!
+//! Threat model / invariants:
+//! - plaintext keys never appear in API responses (`hints()` only leaks the
+//!   last 4 characters), never in logs, and never in recordings (the
+//!   recording layer already redacts key material);
+//! - mutating the store (`set` / `remove`) is gated to loopback-bound servers
+//!   by the API layer (`api::settings`), not here — the store itself is
+//!   transport-agnostic.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Stored-key listing entry: provider + masked hint (never the key itself).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyHint {
+    pub provider: String,
+    /// Masked hint: last 4 characters, or the length when shorter.
+    pub hint: String,
+    /// Whether the key is persisted on disk (vs memory-only for this run).
+    pub remembered: bool,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Every key known this run: memory-only entries plus remembered ones.
+    keys: HashMap<String, String>,
+    /// Providers whose keys are persisted to disk.
+    remembered: HashSet<String>,
+}
+
+/// Per-provider API key store with optional disk persistence.
+pub struct KeyStore {
+    inner: Mutex<Inner>,
+    /// Persistence target; `None` = memory-only (tests, no usable config dir).
+    path: Option<PathBuf>,
+}
+
+impl KeyStore {
+    /// Store backed by the default config path (loaded when the file exists).
+    pub fn load_default() -> Self {
+        Self::from_path(default_keys_path())
+    }
+
+    /// Store backed by `path` (loaded when the file exists; best effort —
+    /// an unreadable/corrupt file logs a warning and starts empty).
+    pub fn from_path(path: Option<PathBuf>) -> Self {
+        let store = Self {
+            inner: Mutex::new(Inner::default()),
+            path,
+        };
+        if let Some(err) = store.load() {
+            let shown = store
+                .path
+                .as_deref()
+                .map_or_else(|| "<memory>".to_string(), |p| p.display().to_string());
+            eprintln!(
+                "aimux-web: warning: failed to load saved keys from {shown} ({err}) — starting empty"
+            );
+        }
+        store
+    }
+
+    /// The plaintext key for `provider`, if saved this run or loaded at start.
+    pub fn get(&self, provider: &str) -> Option<String> {
+        self.inner.lock().unwrap().keys.get(provider).cloned()
+    }
+
+    /// Number of providers with a key in memory.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().keys.len()
+    }
+
+    /// Whether no key is stored (companion of [`len`](Self::len)).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Save `key` for `provider`.
+    ///
+    /// Always updates memory; additionally persists to disk when `remember`
+    /// is set (a previously remembered key for the same provider is dropped
+    /// from disk when `remember` is false, so restarts cannot resurrect it).
+    ///
+    /// # Errors
+    ///
+    /// Returns the disk write error when persistence was requested and
+    /// failed — the memory entry is still updated.
+    pub fn set(&self, provider: &str, key: &str, remember: bool) -> std::io::Result<bool> {
+        let disk_dirty;
+        {
+            let mut inner = self.inner.lock().unwrap();
+            inner.keys.insert(provider.to_string(), key.to_string());
+            let was_remembered = inner.remembered.contains(provider);
+            if remember {
+                inner.remembered.insert(provider.to_string());
+            } else {
+                inner.remembered.remove(provider);
+            }
+            disk_dirty = was_remembered || remember;
+        }
+        if disk_dirty {
+            self.persist()?;
+        }
+        Ok(remember)
+    }
+
+    /// Remove the key for `provider` from memory and disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns the disk write error when a remembered key was removed and
+    /// the rewrite failed — the memory entry is still removed.
+    pub fn remove(&self, provider: &str) -> std::io::Result<bool> {
+        let disk_dirty;
+        {
+            let mut inner = self.inner.lock().unwrap();
+            let existed = inner.keys.remove(provider).is_some();
+            disk_dirty = inner.remembered.remove(provider);
+            if !existed {
+                return Ok(false);
+            }
+        }
+        if disk_dirty {
+            self.persist()?;
+        }
+        Ok(true)
+    }
+
+    /// Masked listing of every stored key (sorted by provider; never
+    /// contains plaintext).
+    pub fn hints(&self) -> Vec<KeyHint> {
+        let inner = self.inner.lock().unwrap();
+        let mut hints: Vec<KeyHint> = inner
+            .keys
+            .iter()
+            .map(|(provider, key)| KeyHint {
+                provider: provider.clone(),
+                hint: mask_key(key),
+                remembered: inner.remembered.contains(provider),
+            })
+            .collect();
+        hints.sort_by(|a, b| a.provider.cmp(&b.provider));
+        hints
+    }
+
+    /// Load the persisted file into memory. `Some(err)` on a read/parse
+    /// failure worth warning about.
+    fn load(&self) -> Option<std::io::Error> {
+        let path = self.path.as_ref()?;
+        let raw = match fs::read(path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => return Some(e),
+        };
+        let file: KeysFile = match serde_json::from_slice(&raw) {
+            Ok(f) => f,
+            Err(e) => return Some(std::io::Error::other(e)),
+        };
+        let mut inner = self.inner.lock().unwrap();
+        inner.remembered = file.keys.keys().cloned().collect();
+        inner.keys = file.keys.into_iter().collect();
+        None
+    }
+
+    /// Rewrite the disk file with the current remembered subset.
+    fn persist(&self) -> std::io::Result<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        let snapshot: BTreeMap<String, String> = {
+            let inner = self.inner.lock().unwrap();
+            inner
+                .remembered
+                .iter()
+                .filter_map(|p| inner.keys.get(p).map(|k| (p.clone(), k.clone())))
+                .collect()
+        };
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        // Create (or truncate) first, then tighten permissions before the
+        // plaintext lands in the file.
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        set_private(path)?;
+        let json = serde_json::to_string_pretty(&KeysFile { keys: snapshot })
+            .map_err(std::io::Error::other)?;
+        std::io::Write::write_all(&mut file, json.as_bytes())?;
+        file.sync_all()
+    }
+}
+
+/// Masked hint for a stored key: `…abcd` (last 4 chars) when long enough,
+/// otherwise just the length — never the full key.
+fn mask_key(key: &str) -> String {
+    let chars: Vec<char> = key.chars().collect();
+    if chars.len() >= 4 {
+        let tail: String = chars[chars.len() - 4..].iter().collect();
+        format!("…{tail}")
+    } else {
+        format!("({} chars)", chars.len())
+    }
+}
+
+/// On-disk format: `{"keys": {provider: plaintext}}`.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct KeysFile {
+    keys: BTreeMap<String, String>,
+}
+
+/// `0600` on unix; best effort (no-op) elsewhere.
+fn set_private(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(path, perms)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+/// Whether the console is bound to a loopback host (trusted local client).
+///
+/// Accepts the textual forms axum may see: `127.0.0.1`, `localhost`, `::1`
+/// and the bracketed `[::1]`. Anything else (`0.0.0.0`, LAN IPs, hostnames)
+/// is treated as non-loopback.
+pub fn is_loopback_host(host: &str) -> bool {
+    let normalized = host.trim().trim_start_matches('[').trim_end_matches(']');
+    matches!(
+        normalized.to_ascii_lowercase().as_str(),
+        "127.0.0.1" | "localhost" | "::1"
+    )
+}
+
+/// User home directory (`$HOME` on unix, `%USERPROFILE%` fallback on
+/// Windows) — tiny helper instead of pulling in the `dirs`/`home` crates.
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    let dir = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"));
+    #[cfg(not(windows))]
+    let dir = std::env::var_os("HOME");
+    dir.filter(|s| !s.is_empty()).map(PathBuf::from)
+}
+
+/// Config directory: `~/.config/aimux-web` (Linux/macOS) or
+/// `%APPDATA%/aimux-web` (Windows). `None` when no home is resolvable.
+fn config_dir() -> Option<PathBuf> {
+    if cfg!(windows) {
+        std::env::var_os("APPDATA")
+            .filter(|s| !s.is_empty())
+            .map(|d| PathBuf::from(d).join("aimux-web"))
+    } else {
+        home_dir().map(|h| h.join(".config").join("aimux-web"))
+    }
+}
+
+/// Default persistence target: `keys.json` inside the config dir.
+fn default_keys_path() -> Option<PathBuf> {
+    config_dir().map(|d| d.join("keys.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (KeyStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = KeyStore::from_path(Some(dir.path().join("keys.json")));
+        (store, dir)
+    }
+
+    #[test]
+    fn mask_key_last_four_or_length() {
+        assert_eq!(mask_key("sk-abcd1234"), "…1234");
+        assert_eq!(mask_key("abcd"), "…abcd");
+        assert_eq!(mask_key("abc"), "(3 chars)");
+        assert_eq!(mask_key(""), "(0 chars)");
+    }
+
+    #[test]
+    fn loopback_detection() {
+        for host in [
+            "127.0.0.1",
+            "localhost",
+            "LOCALHOST",
+            "::1",
+            "[::1]",
+            " 127.0.0.1 ",
+        ] {
+            assert!(is_loopback_host(host), "expected loopback: {host}");
+        }
+        for host in ["0.0.0.0", "192.168.1.5", "::", "example.com", "127.0.0.2"] {
+            assert!(!is_loopback_host(host), "expected non-loopback: {host}");
+        }
+    }
+
+    #[test]
+    fn remember_round_trip_via_disk() {
+        let (store, dir) = temp_store();
+        store.set("openai", "sk-plain-1234", true).unwrap();
+
+        let path = dir.path().join("keys.json");
+        assert!(path.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = path.metadata().unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "keys.json must be 0600");
+        }
+
+        // A fresh store on the same path picks the key up at "startup".
+        let reloaded = KeyStore::from_path(Some(path));
+        assert_eq!(reloaded.get("openai").as_deref(), Some("sk-plain-1234"));
+        assert_eq!(
+            reloaded.hints(),
+            vec![KeyHint {
+                provider: "openai".into(),
+                hint: "…1234".into(),
+                remembered: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn remember_false_stays_in_memory_and_drops_disk_entry() {
+        let (store, dir) = temp_store();
+        let path = dir.path().join("keys.json");
+        store.set("openai", "sk-first", true).unwrap();
+        assert!(path.exists());
+
+        // Re-save without remember: memory updated, disk entry dropped.
+        store.set("openai", "sk-second", false).unwrap();
+        assert_eq!(store.get("openai").as_deref(), Some("sk-second"));
+        let reloaded = KeyStore::from_path(Some(path));
+        assert_eq!(reloaded.get("openai"), None, "old key must not resurrect");
+
+        // A never-remembered provider never creates the file.
+        let (fresh, dir2) = temp_store();
+        fresh.set("deepseek", "sk-mem", false).unwrap();
+        assert!(!dir2.path().join("keys.json").exists());
+        assert_eq!(fresh.get("deepseek").as_deref(), Some("sk-mem"));
+        assert_eq!(fresh.hints().len(), 1);
+        assert!(!fresh.hints()[0].remembered);
+    }
+
+    #[test]
+    fn remove_clears_memory_and_disk() {
+        let (store, dir) = temp_store();
+        let path = dir.path().join("keys.json");
+        store.set("openai", "sk-a", true).unwrap();
+        store.set("anthropic", "sk-b", false).unwrap();
+
+        assert!(store.remove("openai").unwrap());
+        assert_eq!(store.get("openai"), None);
+        assert_eq!(
+            KeyStore::from_path(Some(path)).get("openai"),
+            None,
+            "disk copy must be gone"
+        );
+
+        // Memory-only removal + removing an absent provider.
+        assert!(store.remove("anthropic").unwrap());
+        assert!(!store.remove("anthropic").unwrap());
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn startup_loads_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keys.json");
+        std::fs::write(
+            &path,
+            r#"{"keys": {"openai": "sk-old-9999", "zhipu": "z-new"}}"#,
+        )
+        .unwrap();
+
+        let store = KeyStore::from_path(Some(path));
+        assert_eq!(store.get("openai").as_deref(), Some("sk-old-9999"));
+        assert_eq!(store.get("zhipu").as_deref(), Some("z-new"));
+        // Sorted by provider; hints never contain the plaintext.
+        let hints = store.hints();
+        assert_eq!(hints.len(), 2);
+        assert_eq!(hints[0].provider, "openai");
+        assert_eq!(hints[0].hint, "…9999");
+        assert_eq!(hints[1].provider, "zhipu");
+        assert_eq!(hints[1].hint, "…-new");
+    }
+
+    #[test]
+    fn corrupt_file_starts_empty_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keys.json");
+        std::fs::write(&path, "not json at all").unwrap();
+        let store = KeyStore::from_path(Some(path));
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn missing_file_starts_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = KeyStore::from_path(Some(dir.path().join("keys.json")));
+        assert!(store.is_empty());
+    }
+}

--- a/tools/aimux-web/src/settings.rs
+++ b/tools/aimux-web/src/settings.rs
@@ -191,7 +191,9 @@ impl KeyStore {
         // Atomic write via temp + rename: two concurrent PUT(remember) calls
         // snapshot-then-write outside the lock, so an in-place truncate could
         // interleave into torn JSON (silently wiping all keys on next load).
-        let tmp = path.with_extension("json.tmp");
+        static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = path.with_extension(format!("json.{seq}.tmp"));
         {
             let mut file = fs::OpenOptions::new()
                 .write(true)
@@ -208,8 +210,8 @@ impl KeyStore {
     }
 }
 
-/// Masked hint for a stored key: `…abcd` (last 4 chars) when long enough,
-/// otherwise just the length — never the full key.
+/// Masked hint for a stored key: `…abcd` (last 4 chars) when longer than
+/// 8 chars; shorter keys reveal only their length — never the full key.
 fn mask_key(key: &str) -> String {
     let chars: Vec<char> = key.chars().collect();
     // Only reveal a tail when it cannot reconstruct a meaningful fraction of

--- a/tools/aimux-web/src/settings.rs
+++ b/tools/aimux-web/src/settings.rs
@@ -188,18 +188,23 @@ impl KeyStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        // Create (or truncate) first, then tighten permissions before the
-        // plaintext lands in the file.
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)?;
-        set_private(path)?;
-        let json = serde_json::to_string_pretty(&KeysFile { keys: snapshot })
-            .map_err(std::io::Error::other)?;
-        std::io::Write::write_all(&mut file, json.as_bytes())?;
-        file.sync_all()
+        // Atomic write via temp + rename: two concurrent PUT(remember) calls
+        // snapshot-then-write outside the lock, so an in-place truncate could
+        // interleave into torn JSON (silently wiping all keys on next load).
+        let tmp = path.with_extension("json.tmp");
+        {
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp)?;
+            set_private(&tmp)?;
+            let json = serde_json::to_string_pretty(&KeysFile { keys: snapshot })
+                .map_err(std::io::Error::other)?;
+            std::io::Write::write_all(&mut file, json.as_bytes())?;
+            file.sync_all()?;
+        }
+        fs::rename(&tmp, path)
     }
 }
 
@@ -207,7 +212,10 @@ impl KeyStore {
 /// otherwise just the length — never the full key.
 fn mask_key(key: &str) -> String {
     let chars: Vec<char> = key.chars().collect();
-    if chars.len() >= 4 {
+    // Only reveal a tail when it cannot reconstruct a meaningful fraction of
+    // the key — short keys (≤8 chars) get length only, so a 4-char key never
+    // leaks in full via "…abcd".
+    if chars.len() > 8 {
         let tail: String = chars[chars.len() - 4..].iter().collect();
         format!("…{tail}")
     } else {
@@ -289,7 +297,10 @@ mod tests {
     #[test]
     fn mask_key_last_four_or_length() {
         assert_eq!(mask_key("sk-abcd1234"), "…1234");
-        assert_eq!(mask_key("abcd"), "…abcd");
+        // Short keys reveal length only — a 4-char key must not leak in full
+        // via its own tail (threshold: > 8 chars).
+        assert_eq!(mask_key("abcdefgh"), "(8 chars)");
+        assert_eq!(mask_key("abcd"), "(4 chars)");
         assert_eq!(mask_key("abc"), "(3 chars)");
         assert_eq!(mask_key(""), "(0 chars)");
     }
@@ -400,7 +411,7 @@ mod tests {
         assert_eq!(hints[0].provider, "openai");
         assert_eq!(hints[0].hint, "…9999");
         assert_eq!(hints[1].provider, "zhipu");
-        assert_eq!(hints[1].hint, "…-new");
+        assert_eq!(hints[1].hint, "(5 chars)");
     }
 
     #[test]

--- a/tools/aimux-web/src/state.rs
+++ b/tools/aimux-web/src/state.rs
@@ -81,10 +81,33 @@ pub struct AppState {
     pub mock_models: Arc<Mutex<HashMap<String, Arc<dyn LanguageModel>>>>,
     /// Recordings imported from jsonl (RFC-0023), merged into listings.
     pub imported: Arc<Mutex<Vec<Recording>>>,
+    /// Console credential store (RFC-0029 §5.5): per-provider keys saved
+    /// from the Settings page, optionally persisted under the config dir.
+    pub keys: Arc<crate::settings::KeyStore>,
+    /// Whether the server is bound to a loopback host — gates plaintext key
+    /// entry (Settings PUT/DELETE and per-request key literals).
+    pub loopback: bool,
 }
 
 impl AppState {
     pub fn new() -> Self {
+        Self::with_bind_host("127.0.0.1")
+    }
+
+    /// State for a given bind host: loopback detection + key store loaded
+    /// from the default config path (when a remembered-keys file exists).
+    pub fn with_bind_host(host: &str) -> Self {
+        let keys = crate::settings::KeyStore::load_default();
+        Self::build(crate::settings::is_loopback_host(host), keys)
+    }
+
+    /// Test constructor: explicit bind host + injected key store (tempdir).
+    #[cfg(test)]
+    pub fn with_bind_host_and_store(host: &str, keys: crate::settings::KeyStore) -> Self {
+        Self::build(crate::settings::is_loopback_host(host), keys)
+    }
+
+    fn build(loopback: bool, keys: crate::settings::KeyStore) -> Self {
         let recorder = Arc::new(RingRecorder::new());
         let trace_sink = Arc::new(WebTraceSink::new());
         let session_store = Arc::new(SessionStore::new());
@@ -99,6 +122,8 @@ impl AppState {
             session_store,
             mock_models: Arc::new(Mutex::new(HashMap::new())),
             imported: Arc::new(Mutex::new(Vec::new())),
+            keys: Arc::new(keys),
+            loopback,
         }
     }
 

--- a/tools/aimux-web/src/wire.rs
+++ b/tools/aimux-web/src/wire.rs
@@ -286,6 +286,9 @@ pub fn resolve_api_key(
 ) -> Result<Option<String>, AiMuxError> {
     match spec {
         None => Ok(store.get(provider)),
+        // An empty/whitespace-only field is "unset", not an empty key — fall
+        // through to the stored key / provider's registered env var.
+        Some(s) if s.trim().is_empty() => Ok(store.get(provider)),
         Some(s) if s.starts_with("env:") => {
             let var = &s[4..];
             if var.is_empty() {

--- a/tools/aimux-web/src/wire.rs
+++ b/tools/aimux-web/src/wire.rs
@@ -319,6 +319,22 @@ mod tests {
     use crate::settings::KeyStore;
 
     #[test]
+    fn empty_spec_resolves_as_unset() {
+        // Empty/whitespace spec behaves exactly like None: fall through to
+        // the stored key, then the provider's registered env var.
+        let store = KeyStore::from_path(None);
+        store.set("openai", "sk-from-store", false).unwrap();
+        assert_eq!(
+            resolve_api_key(Some(""), "openai", &store, true).unwrap(),
+            Some("sk-from-store".to_string())
+        );
+        assert_eq!(
+            resolve_api_key(Some("   "), "unknown-provider", &store, true).unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn resolve_key_priority_explicit_env_over_store() {
         let store = KeyStore::from_path(None);
         store.set("openai", "sk-from-store", false).unwrap();

--- a/tools/aimux-web/src/wire.rs
+++ b/tools/aimux-web/src/wire.rs
@@ -30,8 +30,9 @@ pub struct WireCallRequest {
     pub provider: String,
     /// Model id (free text, e.g. "gpt-4o").
     pub model: String,
-    /// API key: `None` (provider reads its registered env var), or
-    /// `Some("env:VAR")`. Plaintext keys are rejected (RFC-0029 §9).
+    /// API key: `None` (Settings-saved key or the provider's registered env
+    /// var), `Some("env:VAR")`, or a plaintext literal — the latter only
+    /// while the console is loopback-bound (RFC-0029 §5.5).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     /// Base URL override (proxies / local endpoints).
@@ -265,14 +266,26 @@ pub fn to_generate_options(
     })
 }
 
-/// Validate and resolve the wire `api_key` field.
+/// Validate and resolve the wire `api_key` field for one call (RFC-0029 §5.5).
 ///
-/// - `None` → `None` (the provider reads its registered env var).
-/// - `Some("env:VAR")` → read the environment variable.
-/// - any other literal → rejected (plaintext keys must not reach the backend).
-pub fn resolve_api_key(spec: Option<&str>) -> Result<Option<String>, AiMuxError> {
+/// Priority:
+/// 1. **explicit request spec** — `Some("env:VAR")` reads the environment
+///    variable; a plaintext literal is accepted only when the console is
+///    loopback-bound (`allow_plaintext`, one-shot Playground use);
+/// 2. **Settings key store** — a key saved for this provider in the console
+///    Settings page (`store.get(provider)`);
+/// 3. `None` — the provider reads its registered env var.
+///
+/// Plaintext literals stay rejected on non-loopback bindings (any LAN client
+/// could otherwise ship keys through the request body).
+pub fn resolve_api_key(
+    spec: Option<&str>,
+    provider: &str,
+    store: &crate::settings::KeyStore,
+    allow_plaintext: bool,
+) -> Result<Option<String>, AiMuxError> {
     match spec {
-        None => Ok(None),
+        None => Ok(store.get(provider)),
         Some(s) if s.starts_with("env:") => {
             let var = &s[4..];
             if var.is_empty() {
@@ -287,9 +300,11 @@ pub fn resolve_api_key(spec: Option<&str>) -> Result<Option<String>, AiMuxError>
                 ))),
             }
         }
+        Some(s) if allow_plaintext => Ok(Some(s.to_string())),
         Some(_) => Err(AiMuxError::InvalidArgument(
-            "plaintext API keys are not accepted — use env:VAR_NAME or leave empty \
-             (the provider's registered env var is read automatically)"
+            "plaintext API keys are only accepted while the console is bound to a loopback \
+             address — use env:VAR_NAME, save the key in Settings, or leave empty (the \
+             provider's registered env var is read automatically)"
                 .into(),
         )),
     }
@@ -298,25 +313,75 @@ pub fn resolve_api_key(spec: Option<&str>) -> Result<Option<String>, AiMuxError>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::settings::KeyStore;
 
     #[test]
-    fn resolve_key_env_and_none() {
+    fn resolve_key_priority_explicit_env_over_store() {
+        let store = KeyStore::from_path(None);
+        store.set("openai", "sk-from-store", false).unwrap();
         // SAFETY: test-only, single-threaded env mutation.
         unsafe { std::env::set_var("AIMUX_WEB_TEST_KEY", "k-123") };
         assert_eq!(
-            resolve_api_key(Some("env:AIMUX_WEB_TEST_KEY")).unwrap(),
+            resolve_api_key(Some("env:AIMUX_WEB_TEST_KEY"), "openai", &store, true).unwrap(),
             Some("k-123".to_string())
         );
-        assert_eq!(resolve_api_key(None).unwrap(), None);
+        // SAFETY: test-only cleanup.
+        unsafe { std::env::remove_var("AIMUX_WEB_TEST_KEY") };
+    }
+
+    #[test]
+    fn resolve_key_falls_back_to_store_then_none() {
+        let store = KeyStore::from_path(None);
+        // Tier 3: empty store → provider's registered env var.
+        assert_eq!(
+            resolve_api_key(None, "openai", &store, false).unwrap(),
+            None
+        );
+        // Tier 2: stored key used when no explicit spec.
+        store.set("openai", "sk-from-store", false).unwrap();
+        assert_eq!(
+            resolve_api_key(None, "openai", &store, false).unwrap(),
+            Some("sk-from-store".to_string())
+        );
+        // Store lookup is per-provider.
+        assert_eq!(
+            resolve_api_key(None, "anthropic", &store, false).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_key_plaintext_only_on_loopback() {
+        let store = KeyStore::from_path(None);
+        store.set("openai", "sk-from-store", false).unwrap();
+
+        // Loopback: explicit plaintext wins (one-shot use, not saved).
+        assert_eq!(
+            resolve_api_key(Some("sk-literal"), "openai", &store, true).unwrap(),
+            Some("sk-literal".to_string())
+        );
+        // Non-loopback: plaintext rejected, even over a stored key.
+        let err = resolve_api_key(Some("sk-literal"), "openai", &store, false).unwrap_err();
+        assert!(err.to_string().contains("loopback"), "err: {err}");
+        // env: references still work on non-loopback.
+        // SAFETY: test-only, single-threaded env mutation.
+        unsafe { std::env::set_var("AIMUX_WEB_TEST_KEY", "k-lan") };
+        assert_eq!(
+            resolve_api_key(Some("env:AIMUX_WEB_TEST_KEY"), "openai", &store, false).unwrap(),
+            Some("k-lan".to_string())
+        );
         // SAFETY: test-only cleanup.
         unsafe { std::env::remove_var("AIMUX_WEB_TEST_KEY") };
     }
 
     #[test]
     fn resolve_key_rejects_plaintext_and_missing_env() {
-        assert!(resolve_api_key(Some("sk-literal")).is_err());
-        assert!(resolve_api_key(Some("env:AIMUX_WEB_MISSING_VAR")).is_err());
-        assert!(resolve_api_key(Some("env:")).is_err());
+        let store = KeyStore::from_path(None);
+        assert!(resolve_api_key(Some("sk-literal"), "openai", &store, false).is_err());
+        assert!(
+            resolve_api_key(Some("env:AIMUX_WEB_MISSING_VAR"), "openai", &store, true).is_err()
+        );
+        assert!(resolve_api_key(Some("env:"), "openai", &store, true).is_err());
     }
 
     #[test]

--- a/tools/aimux-web/web/src/App.vue
+++ b/tools/aimux-web/web/src/App.vue
@@ -13,6 +13,7 @@ const nav = [
   { path: '/sessions', label: 'Sessions', icon: '≡' },
   { path: '/replay', label: 'Replay', icon: '↻' },
   { path: '/cache-probe', label: 'Cache', icon: '◉' },
+  { path: '/settings', label: 'Settings', icon: '⚙' },
 ]
 </script>
 

--- a/tools/aimux-web/web/src/api/client.ts
+++ b/tools/aimux-web/web/src/api/client.ts
@@ -82,8 +82,44 @@ function parseSSE(raw: string): SSEEvent | null {
 
 // ── typed endpoints ─────────────────────────────────────────────────────────
 
+/** One entry of `GET /api/settings/keys` — masked, never the plaintext key. */
+export interface StoredKey {
+  provider: string
+  status: 'stored' | 'unset'
+  hint: string | null
+  remembered?: boolean
+}
+
+export interface SettingsKeys {
+  keys: StoredKey[]
+  /** false when the server is bound non-loopback → hide the key input. */
+  plaintext_entry: boolean
+}
+
 export const api = {
   health: () => fetch(`${API}/health`).then((r) => r.text()),
+
+  settingsKeys(): Promise<SettingsKeys> {
+    return fetch(`${API}/settings/keys`).then((r) => j<SettingsKeys>(r))
+  },
+
+  putSettingsKey(body: { provider: string; key: string; remember?: boolean }): Promise<{
+    provider: string
+    stored: boolean
+    remembered: boolean
+  }> {
+    return fetch(`${API}/settings/keys`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => j(r))
+  },
+
+  deleteSettingsKey(provider: string): Promise<{ provider: string; removed: boolean }> {
+    return fetch(`${API}/settings/keys/${encodeURIComponent(provider)}`, {
+      method: 'DELETE',
+    }).then((r) => j(r))
+  },
 
   call(body: WireCallRequest): Promise<WireCallResponse> {
     return fetch(`${API}/calls`, {

--- a/tools/aimux-web/web/src/router.ts
+++ b/tools/aimux-web/web/src/router.ts
@@ -5,6 +5,7 @@ import Traces from './views/Traces.vue'
 import Sessions from './views/Sessions.vue'
 import Replay from './views/Replay.vue'
 import CacheProbe from './views/CacheProbe.vue'
+import Settings from './views/Settings.vue'
 
 export const router = createRouter({
   history: createWebHashHistory(),
@@ -15,5 +16,6 @@ export const router = createRouter({
     { path: '/sessions', name: 'sessions', component: Sessions },
     { path: '/replay', name: 'replay', component: Replay },
     { path: '/cache-probe', name: 'cache-probe', component: CacheProbe },
+    { path: '/settings', name: 'settings', component: Settings },
   ],
 })

--- a/tools/aimux-web/web/src/views/CacheProbe.vue
+++ b/tools/aimux-web/web/src/views/CacheProbe.vue
@@ -84,7 +84,7 @@ function hitRate(): number | null {
       </div>
       <div class="w-44">
         <Label>API key（env）</Label>
-        <Input v-model="apiKey" class="mt-1 font-mono" placeholder="env:VAR 或留空" />
+        <Input v-model="apiKey" class="mt-1 font-mono" placeholder="env:VAR / 留空用 Settings" />
       </div>
       <div class="w-40">
         <Label>Base URL</Label>

--- a/tools/aimux-web/web/src/views/Playground.vue
+++ b/tools/aimux-web/web/src/views/Playground.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import { useAppStore } from '../stores/app'
 import { api, callStream, parseStreamPart } from '../api/client'
 import type { WireMessage } from '../types/WireMessage'
@@ -274,8 +274,11 @@ function openTrace(item: ChatItem) {
           </button>
         </div>
         <div>
-          <Label>API key（只接受 env 引用）</Label>
+          <Label>API key（env 引用；留空用 Settings）</Label>
           <Input v-model="apiKey" class="mt-1 font-mono" :placeholder="apiKeyHint" />
+          <div class="mt-1 text-[11px] text-muted-foreground">
+            也可在 <RouterLink to="/settings" class="underline decoration-dotted">Settings</RouterLink> 保存该 provider 的 key，此处留空即可。
+          </div>
         </div>
         <div>
           <Label>Base URL（可选）</Label>

--- a/tools/aimux-web/web/src/views/Replay.vue
+++ b/tools/aimux-web/web/src/views/Replay.vue
@@ -93,7 +93,7 @@ async function replay() {
       </div>
       <div class="w-44">
         <Label>API key（env，explicit 源需要）</Label>
-        <Input v-model="apiKey" class="mt-1 font-mono" placeholder="env:VAR" />
+        <Input v-model="apiKey" class="mt-1 font-mono" placeholder="env:VAR（或 Settings 保存）" />
       </div>
       <div class="w-32">
         <Label>Temperature</Label>

--- a/tools/aimux-web/web/src/views/Settings.vue
+++ b/tools/aimux-web/web/src/views/Settings.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useAppStore } from '../stores/app'
+import { api } from '../api/client'
+import type { StoredKey } from '../api/client'
+import Button from '../components/ui/Button.vue'
+import Input from '../components/ui/Input.vue'
+import Combobox from '../components/ui/Combobox.vue'
+import Label from '../components/ui/Label.vue'
+import Card from '../components/ui/Card.vue'
+import Badge from '../components/ui/Badge.vue'
+import Switch from '../components/ui/Switch.vue'
+import Alert from '../components/ui/Alert.vue'
+import Separator from '../components/ui/Separator.vue'
+
+const store = useAppStore()
+
+const provider = ref('openai')
+const key = ref('')
+const remember = ref(false)
+const saved = ref<StoredKey[]>([])
+const plaintextEntry = ref(true)
+const loaded = ref(false)
+const saving = ref(false)
+const message = ref<string | null>(null)
+const error = ref<string | null>(null)
+
+async function load() {
+  error.value = null
+  try {
+    const res = await api.settingsKeys()
+    saved.value = res.keys
+    plaintextEntry.value = res.plaintext_entry
+    loaded.value = true
+  } catch (e) {
+    error.value = String(e)
+  }
+}
+onMounted(() => {
+  store.load()
+  load()
+})
+
+async function save() {
+  if (!provider.value.trim() || !key.value || saving.value) return
+  error.value = null
+  message.value = null
+  saving.value = true
+  try {
+    const res = await api.putSettingsKey({
+      provider: provider.value.trim(),
+      key: key.value,
+      remember: remember.value,
+    })
+    message.value = res.remembered
+      ? `已保存 ${res.provider} 的 key（内存 + 磁盘）`
+      : `已保存 ${res.provider} 的 key（仅本次运行，重启失效）`
+    key.value = ''
+    await load()
+  } catch (e) {
+    error.value = String(e)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function remove(p: string) {
+  error.value = null
+  message.value = null
+  try {
+    const res = await api.deleteSettingsKey(p)
+    message.value = res.removed ? `已删除 ${p} 的 key` : `${p} 没有已保存的 key`
+    await load()
+  } catch (e) {
+    error.value = String(e)
+  }
+}
+</script>
+
+<template>
+  <div class="h-full overflow-auto p-6">
+    <div class="mx-auto max-w-3xl space-y-6">
+      <div class="flex items-center gap-2">
+        <span class="text-sm font-semibold">Settings</span>
+        <Badge variant="secondary" class="font-mono text-[10px]">API keys</Badge>
+      </div>
+
+      <Alert v-if="!plaintextEntry" variant="warning">
+        服务绑定在非回环地址，网页内 key 管理已禁用。请在启动环境设置 <span class="font-mono">env:</span> 引用
+        （如 <span class="font-mono">api_key="env:OPENAI_API_KEY"</span>）或 provider 注册的默认环境变量。
+      </Alert>
+
+      <Card class="p-4">
+        <div class="space-y-4">
+          <div>
+            <Label>Provider</Label>
+            <Combobox
+              v-model="provider"
+              :options="store.providers"
+              class="mt-1"
+              placeholder="搜索 provider…"
+            />
+          </div>
+          <div>
+            <Label>API key（明文仅保存在服务端）</Label>
+            <Input
+              v-model="key"
+              type="password"
+              autocomplete="off"
+              class="mt-1 font-mono"
+              placeholder="sk-…"
+              :disabled="!plaintextEntry"
+            />
+            <div class="mt-1 text-[11px] text-muted-foreground">
+              保存后所有页面（Playground / Agent / Replay / Cache）调用该 provider 时自动使用；GET
+              列表只显示掩码，永不回传明文。
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <div>
+              <Label>记住（写入磁盘）</Label>
+              <div class="text-[11px] text-muted-foreground">
+                写入配置目录 keys.json（权限 0600），重启后自动加载；不勾选仅保存在内存。
+              </div>
+            </div>
+            <Switch v-model="remember" :disabled="!plaintextEntry" />
+          </div>
+          <div class="flex gap-2">
+            <Button :disabled="!plaintextEntry || !key || saving" @click="save">
+              {{ saving ? '保存中…' : '保存' }}
+            </Button>
+            <Button
+              variant="outline"
+              :disabled="!plaintextEntry || !provider"
+              @click="remove(provider.trim())"
+            >
+              删除该 provider 的 key
+            </Button>
+          </div>
+          <div v-if="message" class="text-xs text-success">{{ message }}</div>
+          <div v-if="error"><Badge variant="destructive">{{ error }}</Badge></div>
+        </div>
+      </Card>
+
+      <Separator />
+
+      <div>
+        <div class="mb-2 text-xs font-semibold text-muted-foreground">已保存的 key</div>
+        <Card class="p-0">
+          <table v-if="saved.length" class="w-full text-sm">
+            <thead class="text-left text-xs text-muted-foreground">
+              <tr>
+                <th class="px-4 py-2">Provider</th>
+                <th class="px-4 py-2">Key（掩码）</th>
+                <th class="px-4 py-2">持久化</th>
+                <th class="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="k in saved" :key="k.provider" class="border-t">
+                <td class="px-4 py-2 font-mono text-xs">{{ k.provider }}</td>
+                <td class="px-4 py-2 font-mono text-xs text-muted-foreground">{{ k.hint ?? '—' }}</td>
+                <td class="px-4 py-2 text-xs">
+                  <Badge :variant="k.remembered ? 'default' : 'secondary'">
+                    {{ k.remembered ? '磁盘' : '内存' }}
+                  </Badge>
+                </td>
+                <td class="px-4 py-2 text-right">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    :disabled="!plaintextEntry"
+                    @click="remove(k.provider)"
+                  >
+                    删除
+                  </Button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div v-else-if="loaded" class="px-4 py-6 text-center text-sm text-muted-foreground">
+            还没有保存任何 key。
+          </div>
+        </Card>
+        <div class="mt-2 text-[11px] text-muted-foreground">
+          调用优先级：请求内显式 env: 引用 &gt; 这里保存的 key &gt; provider 注册的默认环境变量。
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
> RFC-0029 设计修订（决策 D4）：网页内 provider key 设置替代"仅 env: 引用"。进 0.3.0（维护者裁决方案 B）。

## 动机

原设计要求用户先在 shell `export` 再启动控制台——对下载即用的本地工具是最/frustrating 的第一步。同类产品（OpenWebUI/LM Studio/各官方 Playground）均为网页内设置。

## 设计（安全模型）

- **Settings 页**：provider 选择 + key 输入（password 框，提交即清空）+ "记住（落盘）"开关 + 已存列表（仅掩码）
- **存储**：默认仅内存；显式 remember 才写 `~/.config/aimux-web/keys.json`（**0600**，temp+rename 原子写，同目录无 EXDEV）；启动加载，损坏文件静默忽略
- **回环门控**：绑定非环回（`--host 0.0.0.0`/LAN）时 PUT/DELETE 403、请求内明文维持拒绝、GET 返回 `plaintext_entry:false` 供前端禁用输入框——原决策担心的远程录入面被精确挡住
- **resolve 优先级**（calls/cache_probe/replay 三处统一）：请求显式 `env:VAR` > 请求明文（仅回环）> Settings 已存 key > provider 注册默认 env var
- **泄漏面控制**：GET 永不回明文（>8 字符 key 显示尾 4 位，≤8 只给长度）；明文不进日志/错误/Debug/Recording（录制脱敏在 HTTP 层）

## API

`GET /api/settings/keys`（掩码列表 + plaintext_entry）· `PUT /api/settings/keys {provider,key,remember?}` · `DELETE /api/settings/keys/{provider}`

## 文档

RFC-0029 决策表 D4 修订 + §5.5 Settings 与凭据（威胁模型）；README 快速开始改为双路径（网页内 or env）。

## 评审

两轮独立评审：R1 安全核心全过（无明文泄漏面/回环判定 fail-closed/三调用方一致），4 条低危（空串视同 unset、掩码阈值 8、原子写、DELETE trim）已修；R2 CLEAN 的 3 个小尾巴（空分支测试、过时注释、tmp 并发碰撞）亦已修。22 测试全过，clippy -D warnings 干净，前端 build+vue-tsc 过，curl 真机冒烟（掩码/403/重启加载/0600）通过。