### PR TITLE
chore(release): finalize 0.3.0 (version sync + changelog date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to aimux are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] — pending (planned 2026-08-17)
+## [0.3.0] - 2026-08-17
 
 **Breaking release.** 196 commits since 0.2.1: observability primitives
 (recording / replay / sessions / tracing), composite models, streaming

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: aimux
 description: Unified LLM service layer for Flutter/Dart (Rust core, 325 providers, C ABI via dart:ffi)
-version: 0.2.1
+version: 0.3.0
 homepage: https://github.com/arcships/aimux
 repository: https://github.com/arcships/aimux
 issue_tracker: https://github.com/arcships/aimux/issues

--- a/bindings/java/build.gradle.kts
+++ b/bindings/java/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.arcships"
-version = "0.2.1"
+version = "0.3.0"
 
 repositories {
     mavenCentral()

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "ai.arcships"
-version = "0.2.1"
+version = "0.3.0"
 
 repositories {
     mavenCentral()

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -26,19 +26,19 @@ console.log('  Node    -> bindings/node/package.json');
 "
 
 # Python
-sed -i -E "s/^version = .*/version = \"$VERSION\"/" bindings/python/pyproject.toml
+sed -i'' -E "s/^version = .*/version = \"$VERSION\"/" bindings/python/pyproject.toml
 echo "  Python  -> bindings/python/pyproject.toml"
 
 # Flutter
-sed -i -E "s/^version: .*/version: $VERSION/" bindings/flutter/pubspec.yaml
+sed -i'' -E "s/^version: .*/version: $VERSION/" bindings/flutter/pubspec.yaml
 echo "  Flutter -> bindings/flutter/pubspec.yaml"
 
 # Kotlin
-sed -i -E "s/^version = .*/version = \"$VERSION\"/" bindings/kotlin/build.gradle.kts
+sed -i'' -E "s/^version = .*/version = \"$VERSION\"/" bindings/kotlin/build.gradle.kts
 echo "  Kotlin  -> bindings/kotlin/build.gradle.kts"
 
 # Java
-sed -i -E "s/^version = .*/version = \"$VERSION\"/" bindings/java/build.gradle.kts
+sed -i'' -E "s/^version = .*/version = \"$VERSION\"/" bindings/java/build.gradle.kts
 echo "  Java    -> bindings/java/build.gradle.kts"
 
 echo "Done. Go is driven by the git tag — no change needed."


### PR DESCRIPTION
发布前定稿：sync-version.sh 补跑（flutter/java/kotlin 0.2.1→0.3.0）、CHANGELOG 日期定稿 2026-08-17、修 sync 脚本 macOS sed 兼容（-E 被当备份后缀）。合入后即打 v0.3.0 tag。