### PR TITLE
fix(ci): console-build matrix entries must sit under 'settings:'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,7 +356,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        # NOTE: the entries MUST live under a `settings:` key — the job
+        # references matrix.settings.*. A bare `include:` list defines
+        # matrix.host/target/suffix instead, so runs-on resolves to an empty
+        # runner label and GitHub silently drops the job from the run (no
+        # error, not even a "skipped" entry — verified by bisect on
+        # 2026-08-17; this kept the console binaries out of the v0.3.0 tag run).
+        settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             suffix: -linux-x64


### PR DESCRIPTION
根因（7 次 dispatch 二分定位）：console-build 引用 ${{ matrix.settings.* }} 但矩阵是裸 include:（定义的是 matrix.host/target/suffix）→ runs-on 求值为空 runner 标签 → GitHub **静默丢弃该 job**（无报错、无 skipped 条目）。v0.3.0 tag run 因此完全没有 aimux-web/cli/replay 二进制。修复 = 条目包进 settings: 键（与 job 引用一致，go-build 同款风格）。修复合入后我会 dispatch artifacts-only 回填 v0.3.0 Release。