### PR TITLE
fix(ci): stage aimux-cli under its release name (bin is named 'aimux')

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,7 +396,13 @@ jobs:
           mkdir -p staging
           EXT=""; [ "$RUNNER_OS" = "Windows" ] && EXT=".exe"
           cp "target/${{ matrix.settings.target }}/release/aimux-web$EXT" "staging/aimux-web${{ matrix.settings.suffix }}"
-          for tool in aimux-cli aimux-replay; do
+          # aimux-cli's [[bin]] is named "aimux" — rename on the way out so
+          # the release asset stays aimux-cli-<platform> (the -f guard keeps
+          # the replay step honest on platforms where a tool is absent).
+          if [ -f "target/${{ matrix.settings.target }}/release/aimux$EXT" ]; then
+            cp "target/${{ matrix.settings.target }}/release/aimux$EXT" "staging/aimux-cli${{ matrix.settings.suffix }}"
+          fi
+          for tool in aimux-replay; do
             if [ -f "target/${{ matrix.settings.target }}/release/$tool$EXT" ]; then
               cp "target/${{ matrix.settings.target }}/release/$tool$EXT" "staging/$tool${{ matrix.settings.suffix }}"
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ dist/
 /tools/aimux-web/web/node_modules/
 /tools/aimux-web/web/dist/
 tsconfig.tsbuildinfo
+
+# 竞品 bad-case 挖矿副产物（数据 + 临时脚本），不进产品仓库
+quirks-corpus/


### PR DESCRIPTION
aimux-cli 的 [[bin]] 名是 `aimux`，staging 找 `aimux-cli` 被 -f 守卫静默跳过——v0.3.0 产物里有 aimux-replay 却没有 aimux-cli。修复后我会再 dispatch 一次 artifacts-only 补齐。