### PR TITLE
fix(clippy): allow chunks_exact_to_as_chunks (CI rust 1.98, MSRV 1.85)

### DIFF
--- a/aimux-core/src/trace/hash.rs
+++ b/aimux-core/src/trace/hash.rs
@@ -21,6 +21,9 @@ pub fn mix(mut x: u64) -> u64 {
 
 /// Keyed 64-bit hash: 8-byte word folding + rotation + finalization (length
 /// prefix included).
+// Rust 1.98 clippy suggests `as_chunks::<8>()`, which stabilized in 1.88;
+// the workspace MSRV is 1.85. Drop this allow when the MSRV moves past 1.88.
+#[allow(clippy::chunks_exact_to_as_chunks)]
 #[must_use]
 pub fn hash64(key: u64, data: &[u8]) -> u64 {
     let mut h = key ^ 0x9e37_79b9_7f4a_7c15;


### PR DESCRIPTION
CI's Rust 1.98 clippy added `chunks_exact_to_as_chunks`, which fails `-D warnings` on `aimux-core/src/trace/hash.rs` and currently breaks every PR's **Rust core** job. The suggested `as_chunks::<8>()` stabilized in Rust 1.88, above the workspace MSRV of 1.85, so this follows the existing precedent (the 1.97 `collapsible_if` allowance) and adds a scoped `#[allow]` with a note to drop it once the MSRV moves past 1.88.