### PR TITLE
fix(bench): make benchmark scripts portable across machines

### DIFF
--- a/aimux-core/src/trace/hash.rs
+++ b/aimux-core/src/trace/hash.rs
@@ -21,6 +21,9 @@ pub fn mix(mut x: u64) -> u64 {
 
 /// Keyed 64-bit hash: 8-byte word folding + rotation + finalization (length
 /// prefix included).
+// Rust 1.98 clippy suggests `as_chunks::<8>()`, which stabilized in 1.88;
+// the workspace MSRV is 1.85. Drop this allow when the MSRV moves past 1.88.
+#[allow(clippy::chunks_exact_to_as_chunks)]
 #[must_use]
 pub fn hash64(key: u64, data: &[u8]) -> u64 {
     let mut h = key ^ 0x9e37_79b9_7f4a_7c15;

--- a/aimux-provider-utils/src/ws.rs
+++ b/aimux-provider-utils/src/ws.rs
@@ -86,6 +86,10 @@ enum ConnectError {
     Tungstenite(tokio_tungstenite::tungstenite::Error),
 }
 
+// Rust 1.98 clippy: tungstenite::Error makes the Err variant ~136 bytes.
+// Private single-use helper on a cold path (one connect per stream); boxing
+// would only move bytes nobody pays for in a loop.
+#[allow(clippy::result_large_err)]
 async fn connect_with_timeout(
     request: tokio_tungstenite::tungstenite::http::Request<()>,
     timeout: Option<std::time::Duration>,

--- a/aimux-providers/src/openai/embedding.rs
+++ b/aimux-providers/src/openai/embedding.rs
@@ -214,6 +214,9 @@ fn parse_openai_provider_options(
 /// OpenAI's API returns embeddings as base64-encoded little-endian f32
 /// arrays when `encoding_format: "base64"` is requested. The raw bytes
 /// are decoded from base64, then reinterpreted as little-endian f32.
+// Rust 1.98 clippy suggests `as_chunks::<4>()`, stabilized in 1.88; the
+// workspace MSRV is 1.85. Drop when the MSRV moves past 1.88.
+#[allow(clippy::chunks_exact_to_as_chunks)]
 fn decode_base64_embedding(s: &str) -> Option<Vec<f32>> {
     use base64::Engine;
     let bytes = base64::engine::general_purpose::STANDARD.decode(s).ok()?;

--- a/bindings/node/bench/bench-constrained.ts
+++ b/bindings/node/bench/bench-constrained.ts
@@ -14,9 +14,10 @@
  */
 
 import { startMockServer } from './mock-server.ts'
+import { nativeBinaryPath } from './native.ts'
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
-const napi = require('../aimux.linux-x64-gnu.node') as {
+const napi = require(nativeBinaryPath()) as {
   openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{
     generateText: (prompt: string, opts?: string) => Promise<string>
   }>
@@ -62,8 +63,7 @@ function rssMB(): number {
 // ── bench ────────────────────────────────────────────────────────────────
 let aisdkModel: { doGenerate: (opts: unknown) => Promise<unknown> } | null = null
 async function initAisdk(uri: string) {
-  const openaiReq = createRequire('/media/eric8810/fast-deliver/code/aimux/reference/ai/packages/openai/package.json')
-  const { createOpenAI } = openaiReq('@ai-sdk/openai')
+    const { createOpenAI } = await import('@ai-sdk/openai')
   const openai = createOpenAI({ apiKey: 'test-key', baseURL: `${uri}/v1` })
   aisdkModel = openai.chat('gpt-4o') as never
 }

--- a/bindings/node/bench/bench-head-to-head.ts
+++ b/bindings/node/bench/bench-head-to-head.ts
@@ -6,9 +6,10 @@
  */
 
 import { startMockServer } from './mock-server.ts'
+import { nativeBinaryPath } from './native.ts'
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
-const napi = require('../aimux.linux-x64-gnu.node') as {
+const napi = require(nativeBinaryPath()) as {
   openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{
     generateText: (prompt: string, opts?: string) => Promise<string>
   }>
@@ -22,8 +23,7 @@ async function main() {
   const prompt = 'Explain Rust ownership in one sentence.'
 
   // ── AISDK init ──
-  const openaiReq = createRequire('/media/eric8810/fast-deliver/code/aimux/reference/ai/packages/openai/package.json')
-  const { createOpenAI } = openaiReq('@ai-sdk/openai')
+    const { createOpenAI } = await import('@ai-sdk/openai')
   const openai = createOpenAI({ apiKey: 'test-key', baseURL: `${uri}/v1` })
   const aisdkModel = openai.chat('gpt-4o') as { doGenerate: (opts: unknown) => Promise<unknown> }
 

--- a/bindings/node/bench/bench-mem-compare.ts
+++ b/bindings/node/bench/bench-mem-compare.ts
@@ -2,8 +2,7 @@ import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
 
 async function main() {
-  const openaiReq = createRequire('/media/eric8810/fast-deliver/code/aimux/reference/ai/packages/openai/package.json')
-  const { createOpenAI } = openaiReq('@ai-sdk/openai')
+    const { createOpenAI } = await import('@ai-sdk/openai')
 
   const uri = 'http://127.0.0.1:36131'
   const openai = createOpenAI({ apiKey: 'test-key', baseURL: uri + '/v1' })

--- a/bindings/node/bench/bench-node-vs-python.ts
+++ b/bindings/node/bench/bench-node-vs-python.ts
@@ -6,9 +6,10 @@
  */
 
 import { startMockServer } from './mock-server.ts'
+import { nativeBinaryPath } from './native.ts'
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
-const napi = require('../aimux.linux-x64-gnu.node') as {
+const napi = require(nativeBinaryPath()) as {
   openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{
     generateText: (prompt: string, opts?: string) => Promise<string>
   }>

--- a/bindings/node/bench/bench-nonstream.ts
+++ b/bindings/node/bench/bench-nonstream.ts
@@ -13,10 +13,11 @@
  */
 
 import { startMockServer } from './mock-server.ts'
+import { nativeBinaryPath } from './native.ts'
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
 // raw napi .node — 直接加载原生二进制，绕过 ts wrapper 的循环 re-export
-const napi = require('../aimux.linux-x64-gnu.node') as { openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{ generateText: (prompt: string, opts?: string) => Promise<string> }> }
+const napi = require(nativeBinaryPath()) as { openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{ generateText: (prompt: string, opts?: string) => Promise<string> }> }
 
 // ── B0: undici 直调 ──────────────────────────────────────────────────────
 async function benchB0(uri: string): Promise<number> {
@@ -56,9 +57,7 @@ async function benchAimux(uri: string): Promise<number> {
 let aisdkModel: { doGenerate: (opts: unknown) => Promise<unknown> } | null = null
 
 async function initAisdk(uri: string) {
-  const { createRequire: cR } = await import('node:module')
-  const openaiRequire = cR('/media/eric8810/fast-deliver/code/aimux/reference/ai/packages/openai/package.json')
-  const { createOpenAI } = openaiRequire('@ai-sdk/openai')
+  const { createOpenAI } = await import('@ai-sdk/openai')
   const openai = createOpenAI({ apiKey: 'test-key', baseURL: `${uri}/v1` })
   // 用 .chat() 走 chat completions 接口（默认 .responses() 走 Responses API）
   aisdkModel = openai.chat('gpt-4o') as never

--- a/bindings/node/bench/bench-openai-official.ts
+++ b/bindings/node/bench/bench-openai-official.ts
@@ -7,8 +7,9 @@
  */
 
 import { createRequire } from 'node:module'
+import { nativeBinaryPath } from './native.ts'
 const require = createRequire(import.meta.url)
-const napi = require('../aimux.linux-x64-gnu.node') as {
+const napi = require(nativeBinaryPath()) as {
   openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{
     generateText: (prompt: string, opts?: string) => Promise<string>
   }>
@@ -24,8 +25,8 @@ async function main() {
   const prompt = 'Explain Rust ownership in one sentence.'
 
   // OpenAI 官方 Node SDK
-  const openaiPath = '/media/eric8810/fast-deliver/code/aimux/reference/ai/node_modules/.pnpm/openai@6.38.0_ws@8.21.1_zod@3.25.76/node_modules/openai/index.js'
-  const OpenAI = require(openaiPath).default || require(openaiPath).OpenAI
+  const openaiModule = await import('openai')
+  const OpenAI = openaiModule.default ?? (openaiModule as { OpenAI?: unknown }).OpenAI
   const client = new OpenAI({ apiKey: 'test-key', baseURL: `${uri}/v1` })
 
   // aimux

--- a/bindings/node/bench/bench-real.ts
+++ b/bindings/node/bench/bench-real.ts
@@ -13,9 +13,10 @@
  */
 
 import { startMockServer } from './mock-server.ts'
+import { nativeBinaryPath } from './native.ts'
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
-const napi = require('../aimux.linux-x64-gnu.node') as {
+const napi = require(nativeBinaryPath()) as {
   openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{
     generateText: (prompt: string, opts?: string) => Promise<string>
   }>
@@ -87,8 +88,7 @@ async function benchAimux(uri: string, prompt: string): Promise<number> {
 
 let aisdkModel: { doGenerate: (opts: unknown) => Promise<unknown> } | null = null
 async function initAisdk(uri: string) {
-  const openaiReq = createRequire('/media/eric8810/fast-deliver/code/aimux/reference/ai/packages/openai/package.json')
-  const { createOpenAI } = openaiReq('@ai-sdk/openai')
+    const { createOpenAI } = await import('@ai-sdk/openai')
   const openai = createOpenAI({ apiKey: 'test-key', baseURL: `${uri}/v1` })
   aisdkModel = openai.chat('gpt-4o') as never
 }

--- a/bindings/node/bench/bench-serialize.ts
+++ b/bindings/node/bench/bench-serialize.ts
@@ -3,8 +3,9 @@
  */
 
 import { createRequire } from 'node:module'
+import { nativeBinaryPath } from './native.ts'
 const require = createRequire(import.meta.url)
-const napi = require('../aimux.linux-x64-gnu.node') as {
+const napi = require(nativeBinaryPath()) as {
   openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{
     generateText: (prompt: string, opts?: string) => Promise<string>
   }>

--- a/bindings/node/bench/bench-struct.ts
+++ b/bindings/node/bench/bench-struct.ts
@@ -14,12 +14,13 @@
  */
 
 import { startMockServer } from './mock-server.ts'
+import { nativeBinaryPath } from './native.ts'
 import { createRequire } from 'node:module'
 const require = cR()
 function cR() { return createRequire(import.meta.url) }
 
 // raw napi .node — 直接加载原生二进制
-const napi = require('../aimux.linux-x64-gnu.node') as {
+const napi = require(nativeBinaryPath()) as {
   openai: (apiKey: string, modelId: string, baseUrl?: string) => Promise<{
     generateText: (prompt: string, opts?: string) => Promise<string>
   }>
@@ -52,8 +53,7 @@ async function benchAimux(uri: string, prompt: string): Promise<number> {
 let aisdkModel: { doGenerate: (opts: unknown) => Promise<unknown> } | null = null
 
 async function initAisdk(uri: string) {
-  const openaiRequire = createRequire('/media/eric8810/fast-deliver/code/aimux/reference/ai/packages/openai/package.json')
-  const { createOpenAI } = openaiRequire('@ai-sdk/openai')
+    const { createOpenAI } = await import('@ai-sdk/openai')
   const openai = createOpenAI({ apiKey: 'test-key', baseURL: `${uri}/v1` })
   aisdkModel = openai.chat('gpt-4o') as never
 }

--- a/bindings/node/bench/native.ts
+++ b/bindings/node/bench/native.ts
@@ -1,0 +1,9 @@
+// Path of the napi binary for the current platform, relative to this bench
+// directory. Follows napi-rs artifact naming:
+// aimux.<platform>-<arch>[-<abi>].node (e.g. aimux.linux-x64-gnu.node,
+// aimux.darwin-arm64.node, aimux.win32-x64-msvc.node).
+export function nativeBinaryPath(): string {
+  const abi =
+    process.platform === 'linux' ? '-gnu' : process.platform === 'win32' ? '-msvc' : ''
+  return `../aimux.${process.platform}-${process.arch}${abi}.node`
+}

--- a/bindings/node/bench/package.json
+++ b/bindings/node/bench/package.json
@@ -6,8 +6,9 @@
     "bench": "tsx bench-nonstream.ts"
   },
   "dependencies": {
-    "@ai-sdk/openai": "file:../../reference/ai/packages/openai",
-    "ai": "file:../../reference/ai/packages/ai"
+    "@ai-sdk/openai": "^2",
+    "ai": "^5",
+    "openai": "^6"
   },
   "devDependencies": {
     "tsx": "^4.19.0"


### PR DESCRIPTION
## Problem

The Node benchmark suite (`bindings/node/bench/`) only ran on the machine it was originally written on:

1. **Machine-specific absolute paths** — six scripts loaded `@ai-sdk/openai` (and `bench-openai-official.ts` the official `openai` SDK) via `createRequire('/media/…')`, an absolute path into one developer machine's filesystem. On any other machine every AISDK comparison arm fails with `MODULE_NOT_FOUND`.
2. **Hardcoded platform artifact** — eight scripts required `../aimux.linux-x64-gnu.node` literally, so nothing ran on darwin/win32 even with a freshly built binding.
3. **Broken `file:` dependencies** — `package.json` linked `@ai-sdk/openai` and `ai` to `../../reference/ai/packages/…`, a source checkout of the AI SDK monorepo that is not part of this repository (gitignored, unbuilt, absent on a fresh clone).

## Fix

- New `bench/native.ts` resolves the napi artifact from `process.platform`/`process.arch` (napi-rs naming, `-gnu`/`-msvc` ABI suffixes); all scripts require through it.
- AISDK / official-SDK arms use normal imports.
- Comparison SDKs come from the npm registry: `@ai-sdk/openai@^2`, `ai@^5`, `openai@^6`.

## Also included: unbreak CI on rust 1.98

The first commit adds `#[allow(clippy::chunks_exact_to_as_chunks)]` in `aimux-core/src/trace/hash.rs`. GitHub runners rolled from rustc 1.97.1 (master green on Aug 18) to 1.98.0 (master red on Aug 22's merge run); the new lint fires on unchanged code under `-D warnings`, so every PR's **Rust core** job currently fails without this. The suggested `as_chunks::<8>()` stabilized in 1.88, above the workspace MSRV of 1.85 — hence an allowance, same precedent as the 1.97 `collapsible_if` one.

## Verified

`npm install && node bench-nonstream.ts` runs end-to-end against the local mock server on darwin-arm64 (previously impossible off the original machine): B0/aimux/AISDK all produce numbers.